### PR TITLE
bump rubocop engine to 0.41.1

### DIFF
--- a/config/disable_all.yml
+++ b/config/disable_all.yml
@@ -45,6 +45,8 @@ Lint/HandleExceptions:
   Enabled: false
 Lint/ImplicitStringConcatenation:
   Enabled: false
+Lint/InheritException:
+  Enabled: false
 Lint/IneffectiveAccessModifier:
   Enabled: false
 Lint/InvalidCharacterLiteral:
@@ -63,11 +65,17 @@ Lint/NonLocalExitFromIterator:
   Enabled: false
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false
+Lint/PercentStringArray:
+  Enabled: false
+Lint/PercentSymbolArray:
+  Enabled: false
 Lint/RandOne:
   Enabled: false
 Lint/RequireParentheses:
   Enabled: false
 Lint/RescueException:
+  Enabled: false
+Lint/ShadowedException:
   Enabled: false
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
@@ -84,6 +92,8 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Enabled: false
 Lint/UselessAccessModifier:
+  Enabled: false
+Lint/UselessArraySplat:
   Enabled: false
 Lint/UselessAssignment:
   Enabled: false
@@ -132,6 +142,8 @@ Performance/FlatMap:
 Performance/HashEachMethods:
   Enabled: false
 Performance/LstripRstrip:
+  Enabled: false
+Performance/PushSplat:
   Enabled: false
 Performance/RangeInclude:
   Enabled: false
@@ -227,7 +239,7 @@ Style/Copyright:
   Enabled: false
 Style/DefWithParentheses:
   Enabled: false
-Style/DeprecatedHashMethods:
+Style/PreferredHashMethods:
   Enabled: false
 Style/Documentation:
   Enabled: false
@@ -235,9 +247,13 @@ Style/DotPosition:
   Enabled: false
 Style/DoubleNegation:
   Enabled: false
+Style/EachForSimpleLoop:
+  Enabled: false
 Style/EachWithObject:
   Enabled: false
 Style/ElseAlignment:
+  Enabled: false
+Style/EmptyCaseCondition:
   Enabled: false
 Style/EmptyElse:
   Enabled: false
@@ -302,6 +318,8 @@ Style/IfUnlessModifier:
 Style/IfUnlessModifierOfIfUnless:
   Enabled: false
 Style/IfWithSemicolon:
+  Enabled: false
+Style/ImplicitRuntimeError:
   Enabled: false
 Style/IndentArray:
   Enabled: false
@@ -382,6 +400,8 @@ Style/NonNilCheck:
 Style/Not:
   Enabled: false
 Style/NumericLiterals:
+  Enabled: false
+Style/NumericLiteralPrefix:
   Enabled: false
 Style/OneLineConditional:
   Enabled: false
@@ -465,6 +485,8 @@ Style/SpaceBeforeFirstArg:
   Enabled: false
 Style/SpaceBeforeSemicolon:
   Enabled: false
+Style/SpaceInsideArrayPercentLiteral:
+  Enabled: false
 Style/SpaceInsideBlockBraces:
   Enabled: false
 Style/SpaceInsideBrackets:
@@ -472,6 +494,8 @@ Style/SpaceInsideBrackets:
 Style/SpaceInsideHashLiteralBraces:
   Enabled: false
 Style/SpaceInsideParens:
+  Enabled: false
+Style/SpaceInsidePercentLiteralDelimiters:
   Enabled: false
 Style/SpaceInsideRangeLiteral:
   Enabled: false
@@ -537,11 +561,15 @@ Rails/Date:
   Enabled: false
 Rails/Delegate:
   Enabled: false
+Rails/Exit:
+  Enabled: false
 Rails/FindBy:
   Enabled: false
 Rails/FindEach:
   Enabled: false
 Rails/HasAndBelongsToMany:
+  Enabled: false
+Rails/OutputSafety:
   Enabled: false
 Rails/Output:
   Enabled: false
@@ -549,9 +577,13 @@ Rails/PluralizationGrammar:
   Enabled: false
 Rails/ReadWriteAttribute:
   Enabled: false
+Rails/RequestReferer:
+  Enabled: false
 Rails/ScopeArgs:
   Enabled: false
 Rails/TimeZone:
+  Enabled: false
+Rails/UniqBeforePluck:
   Enabled: false
 Rails/Validation:
   Enabled: false

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -47,6 +47,12 @@ Style/FirstMethodParameterLineBreak:
                  multi-line method parameter definition.
   Enabled: false
 
+Style/ImplicitRuntimeError:
+  Description: >-
+                 Use `raise` or `fail` with an explicit exception class and
+                 message, rather than just a message.
+  Enabled: false
+
 Style/InlineComment:
   Description: 'Avoid inline comments.'
   Enabled: false
@@ -73,37 +79,9 @@ Style/MissingElse:
     - case
     - both
 
-Style/MultilineArrayBraceLayout:
-  Description: >-
-                 Checks that the closing brace in an array literal is
-                 symmetrical with respect to the opening brace and the
-                 array elements.
-  Enabled: false
-
 Style/MultilineAssignmentLayout:
   Description: 'Check for a newline after the assignment operator in multi-line assignments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-conditional-assignment'
-  Enabled: false
-
-Style/MultilineHashBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a hash literal is
-                 symmetrical with respect to the opening brace and the
-                 hash elements.
-  Enabled: false
-
-Style/MultilineMethodCallBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method call is
-                 symmetrical with respect to the opening brace and the
-                 method arguments.
-  Enabled: false
-
-Style/MultilineMethodDefinitionBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method definition is
-                 symmetrical with respect to the opening brace and the
-                 method parameters.
   Enabled: false
 
 Style/OptionHash:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -7,6 +7,7 @@ Style/AccessModifierIndentation:
 
 Style/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#accessor_mutator_method_names'
   Enabled: true
 
 Style/Alias:
@@ -170,8 +171,8 @@ Style/DefWithParentheses:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
   Enabled: true
 
-Style/DeprecatedHashMethods:
-  Description: 'Checks for use of deprecated Hash methods.'
+Style/PreferredHashMethods:
+  Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
   Enabled: true
 
@@ -192,6 +193,12 @@ Style/DoubleNegation:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
   Enabled: true
 
+Style/EachForSimpleLoop:
+  Description: >-
+                 Use `Integer#times` for a simple loop which iterates a fixed
+                 number of times.
+  Enabled: true
+
 Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: true
@@ -202,6 +209,10 @@ Style/ElseAlignment:
 
 Style/EmptyElse:
   Description: 'Avoid empty else-clauses.'
+  Enabled: true
+
+Style/EmptyCaseCondition:
+  Description: 'Avoid empty condition in case statements.'
   Enabled: true
 
 Style/EmptyLineBetweenDefs:
@@ -411,6 +422,13 @@ Style/ModuleFunction:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
   Enabled: true
 
+Style/MultilineArrayBraceLayout:
+  Description: >-
+                 Checks that the closing brace in an array literal is
+                 either on the same line as the last array element, or
+                 a new line.
+  Enabled: true
+
 Style/MultilineBlockChain:
   Description: 'Avoid multi-line chains of blocks.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
@@ -420,15 +438,36 @@ Style/MultilineBlockLayout:
   Description: 'Ensures newlines after multiline block do statements.'
   Enabled: true
 
+Style/MultilineHashBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a hash literal is
+                 either on the same line as the last hash element, or
+                 a new line.
+  Enabled: true
+
 Style/MultilineIfThen:
   Description: 'Do not use then for multi-line if/unless.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-then'
+  Enabled: true
+
+Style/MultilineMethodCallBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a method call is
+                 either on the same line as the last method argument, or
+                 a new line.
   Enabled: true
 
 Style/MultilineMethodCallIndentation:
   Description: >-
                  Checks indentation of method calls with the dot operator
                  that span more than one line.
+  Enabled: true
+
+Style/MultilineMethodDefinitionBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a method definition is
+                 either on the same line as the last method parameter, or
+                 a new line.
   Enabled: true
 
 Style/MultilineOperationIndentation:
@@ -501,6 +540,11 @@ Style/NumericLiterals:
                  Add underscores to large numeric literals to improve their
                  readability.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
+  Enabled: true
+
+Style/NumericLiteralPrefix:
+  Description: 'Use smallcase prefixes for numeric literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#numeric-literal-prefixes'
   Enabled: true
 
 Style/OneLineConditional:
@@ -716,6 +760,14 @@ Style/SpaceAroundOperators:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: true
 
+Style/SpaceInsideArrayPercentLiteral:
+  Description: 'No unnecessary additional spaces between elements in %i/%w literals.'
+  Enabled: true
+
+Style/SpaceInsidePercentLiteralDelimiters:
+  Description: 'No unnecessary spaces inside delimiters of %i/%w/%x literals.'
+  Enabled: true
+
 Style/SpaceInsideBrackets:
   Description: 'No spaces after [ or before ].'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
@@ -787,7 +839,7 @@ Style/TrailingBlankLines:
 
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in argument lists.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
   Enabled: true
 
 Style/TrailingCommaInLiteral:
@@ -1035,6 +1087,10 @@ Lint/IneffectiveAccessModifier:
                  the visibility of a class method, which does not work.
   Enabled: true
 
+Lint/InheritException:
+  Description: 'Avoid inheriting from the `Exception` class.'
+  Enabled: true
+
 Lint/InvalidCharacterLiteral:
   Description: >-
                  Checks for invalid character literals with a non-escaped
@@ -1078,6 +1134,16 @@ Lint/ParenthesesAsGroupedExpression:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
   Enabled: true
 
+Lint/PercentStringArray:
+  Description: >-
+                 Checks for unwanted commas and quotes in %w/%W literals.
+  Enabled: true
+
+Lint/PercentSymbolArray:
+  Description: >-
+                 Checks for unwanted commas and colons in %i/%I literals.
+  Enabled: true
+
 Lint/RandOne:
   Description: >-
                  Checks for `rand(1)` calls. Such calls always return `0`
@@ -1093,6 +1159,12 @@ Lint/RequireParentheses:
 Lint/RescueException:
   Description: 'Avoid rescuing the Exception class.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-blind-rescues'
+  Enabled: true
+
+Lint/ShadowedException:
+  Description: >-
+                  Avoid rescuing a higher level exception
+                  before a lower level exception.
   Enabled: true
 
 Lint/ShadowingOuterLocalVariable:
@@ -1133,6 +1205,10 @@ Lint/UnreachableCode:
 
 Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
+  Enabled: true
+
+Lint/UselessArraySplat:
+  Description: 'Checks for useless array splats.'
   Enabled: true
 
 Lint/UselessAssignment:
@@ -1234,6 +1310,10 @@ Performance/LstripRstrip:
   Description: 'Use `strip` instead of `lstrip.rstrip`.'
   Enabled: true
 
+Performance/PushSplat:
+  Description: 'Use `concat` instead of `push(*)`.'
+  Enabled: true
+
 Performance/RangeInclude:
   Description: 'Use `Range#cover?` instead of `Range#include?`.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code'
@@ -1311,6 +1391,13 @@ Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: true
 
+Rails/Exit:
+  Description: >-
+                  Favor `fail`, `break`, `return`, etc. over `exit` in
+                  application or library code outside of Rake files to avoid
+                  exits during unit testing or running in production.
+  Enabled: true
+
 Rails/FindBy:
   Description: 'Prefer find_by over where.first.'
   Enabled: true
@@ -1327,6 +1414,10 @@ Rails/Output:
   Description: 'Checks for calls to puts, print, etc.'
   Enabled: true
 
+Rails/OutputSafety:
+  Description: 'The use of `html_safe` or `raw` may be a security risk.'
+  Enabled: true
+
 Rails/PluralizationGrammar:
   Description: 'Checks for incorrect grammar when using methods like `3.day.ago`.'
   Enabled: true
@@ -1337,6 +1428,10 @@ Rails/ReadWriteAttribute:
                  write_attribute(:attr, val).
   Enabled: true
 
+Rails/RequestReferer:
+  Description: 'Use consistent syntax for request.referer.'
+  Enabled: true
+
 Rails/ScopeArgs:
   Description: 'Checks the arguments of ActiveRecord scopes.'
   Enabled: true
@@ -1345,6 +1440,10 @@ Rails/TimeZone:
   Description: 'Checks the correct usage of time zone aware methods.'
   StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
+  Enabled: true
+
+Rails/UniqBeforePluck:
+  Description: 'Prefer the use of uniq or distinct before pluck.'
   Enabled: true
 
 Rails/Validation:

--- a/config/upstream.yml
+++ b/config/upstream.yml
@@ -25,6 +25,8 @@ AllCops:
     - '**/Berksfile'
     - '**/Cheffile'
     - '**/Vagabondfile'
+    - '**/Fastfile'
+    - '**/*Fastfile'
   Exclude:
     - 'vendor/**/*'
   # Default formatter will be used if no -f/--format option is given.
@@ -63,6 +65,14 @@ AllCops:
   # which is "/tmp" on Unix-like systems, but could be something else on other
   # systems.
   CacheRootDirectory: /tmp
+  # The default cache root directory is /tmp, which on most systems is
+  # writable by any system user. This means that it is possible for a
+  # malicious user to anticipate the location of Rubocop's cache directory,
+  # and create a symlink in its place that could cause Rubocop to overwrite
+  # unintended files, or read malicious input. If you are certain that your
+  # cache location is secure from this kind of attack, and wish to use a
+  # symlinked cache location, set this value to "true".
+  AllowSymlinksInCacheRootDirectory: false
   # What version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)
   TargetRubyVersion: 2.0
@@ -165,6 +175,9 @@ Style/AlignParameters:
   SupportedStyles:
     - with_first_parameter
     - with_fixed_indentation
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Style/AndOr:
   # Whether `and` and `or` are banned only in conditionals (conditionals)
@@ -425,10 +438,11 @@ Style/EmptyLinesAroundModuleBody:
 # AutoCorrectEncodingComment must match the regex
 # /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
 Style/Encoding:
-  EnforcedStyle: always
+  EnforcedStyle: never
   SupportedStyles:
     - when_needed
     - always
+    - never
   AutoCorrectEncodingComment: '# encoding: utf-8'
 
 Style/ExtraSpacing:
@@ -518,8 +532,10 @@ Style/HashSyntax:
     - ruby19
     - ruby19_no_mixed_keys
     - hash_rockets
-# Force hashes that have a symbol value to use hash rockets
+  # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
+  # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
+  PreferHashRocketsForNonAlnumEndingSymbols: false
 
 Style/IfUnlessModifier:
   MaxLineLength: 80
@@ -590,6 +606,13 @@ Style/IndentHash:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Style/Lambda:
+  EnforcedStyle: line_count_dependent
+  SupportedStyles:
+    - line_count_dependent
+    - lambda
+    - literal
+
 Style/LambdaCall:
   EnforcedStyle: call
   SupportedStyles:
@@ -630,6 +653,22 @@ Style/MethodName:
     - snake_case
     - camelCase
 
+Style/ModuleFunction:
+  EnforcedStyle: module_function
+  SupportedStyles:
+    - module_function
+    - extend_self
+
+Style/MultilineArrayBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
 Style/MultilineAssignmentLayout:
   # The types of assignments which are subject to this rule.
   SupportedTypes:
@@ -648,14 +687,45 @@ Style/MultilineAssignmentLayout:
     # for the set of supported types.
     - new_line
 
+Style/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
+Style/MultilineMethodCallBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last argument
+    - symmetrical
+    - new_line
+    - same_line
+
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: aligned
   SupportedStyles:
     - aligned
     - indented
+    - indented_relative_to_receiver
   # By default, the indentation width from Style/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
+
+Style/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last parameter
+    - symmetrical
+    - new_line
+    - same_line
 
 Style/MultilineOperationIndentation:
   EnforcedStyle: aligned
@@ -668,6 +738,12 @@ Style/MultilineOperationIndentation:
 
 Style/NumericLiterals:
   MinDigits: 5
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_with_o
+  SupportedOctalStyles:
+    - zero_with_o
+    - zero_only
 
 Style/OptionHash:
   # A list of parameter names that will be flagged by this cop.
@@ -715,6 +791,10 @@ Style/PredicateName:
   # should still be accepted
   NameWhitelist:
     - is_a?
+  # Exclude Rspec specs because there is a strong convetion to write spec
+  # helpers in the form of `have_something` or `be_something`.
+  Exclude:
+    - 'spec/**/*'
 
 Style/RaiseArgs:
   EnforcedStyle: exploded
@@ -846,6 +926,9 @@ Style/SpaceInsideHashLiteralBraces:
   SupportedStyles:
     - space
     - no_space
+    # 'compact' normally requires a space inside hash braces, with the exception
+    # that successive left braces or right braces are collapsed together
+    - compact
 
 Style/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space
@@ -864,6 +947,7 @@ Style/SymbolProc:
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:
     - respond_to
+    - define_method
 
 Style/TrailingBlankLines:
   EnforcedStyle: final_newline
@@ -944,11 +1028,17 @@ Style/VariableName:
 Style/WhileUntilModifier:
   MaxLineLength: 80
 
+# WordArray enforces how array literals of word-like strings should be expressed.
 Style/WordArray:
   EnforcedStyle: percent
   SupportedStyles:
+    # percent style: %w(word1 word2)
     - percent
+    # bracket style: ['word1', 'word2']
     - brackets
+  # The MinSize option causes the WordArray rule to be ignored for arrays
+  # smaller than a certain size.  The rule is only applied to arrays
+  # whose element count is greater than or equal to MinSize.
   MinSize: 0
   # The regular expression WordRegex decides what is considered a word.
   WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
@@ -1006,7 +1096,7 @@ Lint/AssignmentInCondition:
 Lint/BlockAlignment:
   # The value `start_of_block` means that the `end` should be aligned with line
   # where the `do` keyword appears.
-  # The value `start_of_line` means it should be aligned with the whole 
+  # The value `start_of_line` means it should be aligned with the whole
   # expression's starting line.
   # The value `either` means both are allowed.
   AlignWith: either
@@ -1042,9 +1132,17 @@ Lint/DefEndAlignment:
     - def
   AutoCorrect: false
 
+Lint/InheritException:
+  # The default base class in favour of `Exception`.
+  EnforcedStyle: runtime_error
+  SupportedStyles:
+    - runtime_error
+    - standard_error
+
 # Checks for unused block arguments
 Lint/UnusedBlockArgument:
   IgnoreEmptyBlocks: true
+  AllowUnusedKeywordArguments: false
 
 # Checks for unused method arguments.
 Lint/UnusedMethodArgument:
@@ -1078,6 +1176,14 @@ Rails/Date:
     - strict
     - flexible
 
+Rails/Exit:
+  Include:
+    - app/**/*.rb
+    - config/**/*.rb
+    - lib/**/*.rb
+  Exclude:
+    - lib/**/*.rake
+
 Rails/FindBy:
   Include:
     - app/models/**/*.rb
@@ -1101,6 +1207,12 @@ Rails/ReadWriteAttribute:
   Include:
     - app/models/**/*.rb
 
+Rails/RequestReferer:
+  EnforcedStyle: referer
+  SupportedStyles:
+    - referer
+    - referrer
+
 Rails/ScopeArgs:
   Include:
     - app/models/**/*.rb
@@ -1112,6 +1224,13 @@ Rails/TimeZone:
   SupportedStyles:
     - strict
     - flexible
+
+Rails/UniqBeforePluck:
+  EnforcedMode: conservative
+  SupportedModes:
+    - conservative
+    - aggressive
+  AutoCorrect: false
 
 Rails/Validation:
   Include:

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,4 +1,4 @@
 module Cookstyle
-  VERSION = "0.0.1".freeze
-  RUBOCOP_VERSION = "0.39.0".freeze
+  VERSION = "1.0.0".freeze
+  RUBOCOP_VERSION = "0.41.1".freeze
 end


### PR DESCRIPTION
does not change cookstyle definitions.   all new cops disabled.  validated on activemq, aws, build-essential, docker, nscd, and the results match with prior release of cookstyle.