### PR TITLE
set TrailingCommaInLiteral correctly

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -31,3 +31,6 @@ PerceivedComplexity:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false
+Style/TrailingCommaInLiteral:
+  Enabled: true
+    EnforcedStyleForMultiline: comma


### PR DESCRIPTION
this was the setting that even made vargo admit that rubocop was jumping the shark in favor of trying to construct their own flavor of the ruby language with their own finely honed ground down axes that nobody in their right mind really wanted.

this favors cut+paste over the bizzare 'its like the english language' argument that rubocop's authors use to defend the default behavior.

everyone hates editing raw JSON files because it enforces semicolon usage the way rubocop's default does.

rubocop is currently enforcing this:

```ruby
[
  "foo",
  "bar"
]
```

this change will start to enforce this:

```ruby
[
  "foo",
  "bar",
]
```

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>