### PR TITLE
Underscores in numbers are unnecessary

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -34,3 +34,5 @@ Style/ClassAndModuleChildren:
 Style/TrailingCommaInLiteral:
   Enabled: true
     EnforcedStyleForMultiline: comma
+Style/NumericLiterals:
+  Enabled: false


### PR DESCRIPTION
Underscores in numbers are unnecessary, especially for port numbers in attributes where they are unexpected (ie. 1_234)

Signed-off-by: Matt Ray <matthewhray@gmail.com>