### PR TITLE
Disable Bundler/OrderedGems until there’s an autocorrect

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -98,6 +98,10 @@ Style/SpaceInsideArrayPercentLiteral:
 Style/TernaryParentheses:
   Enabled: true
 
+# disable this until there's an autocorrect
+Bundler/OrderedGems:
+  Enabled: false
+
 # There's no reason to have a gem listed twice
 Bundler/DuplicatedGem:
    Enabled: true


### PR DESCRIPTION
This is a handy cop, but it doesn’t autocorrect yet

Signed-off-by: Tim Smith <tsmith@chef.io>