### PR TITLE
disable CyclomaticComplexity

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -23,6 +23,8 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/ModuleLength:
   Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
 PerceivedComplexity:
   Enabled: false
 Style/ClassAndModuleChildren:


### PR DESCRIPTION
fires for too many trivial cases.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>