### PR TITLE
Fixup two mistakes in the 1.0 config

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -70,7 +70,7 @@ Lint/PercentSymbolArray:
 
 # if you rescue Exception, then rescue say StandardError you're gonna have a bad time
 Lint/ShadowedException:
-  Enabled: false
+  Enabled: true
 
 # We're on modern ruby so let's assume Integer everywhere
 Lint/UnifiedInteger:
@@ -94,10 +94,6 @@ Style/NumericPredicate:
 
 # this is bad %w(something     another_thing   one_more)
 Style/SpaceInsideArrayPercentLiteral:
-  Enabled: true
-
-# ( true ) ? 'bob' : 'bill' is unnecessary
-Style/TernaryParentheses:
   Enabled: true
 
 # disable this until there's an autocorrect


### PR DESCRIPTION
I mean to disable Style/TernaryParentheses per Lamont's feedback

Lint/ShadowedException was meant to be enabled

Signed-off-by: Tim Smith <tsmith@chef.io>