### PR TITLE
Disable Metrics/ClassLength and cleanup cookstyle_base

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -23,6 +23,8 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/ModuleLength:
   Enabled: false
+Metrics/ClassLength:
+  Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: false
 PerceivedComplexity:

--- a/config/cookstyle_base.yml
+++ b/config/cookstyle_base.yml
@@ -332,23 +332,13 @@ Style/WordArray:
   Enabled: true
 Style/ZeroLengthPredicate:
   Enabled: true
-Metrics/AbcSize:
-  Enabled: true
 Metrics/BlockNesting:
-  Enabled: true
-Metrics/ClassLength:
-  Enabled: true
-Metrics/ModuleLength:
-  Enabled: true
-Metrics/CyclomaticComplexity:
   Enabled: true
 Metrics/LineLength:
   Enabled: true
 Metrics/MethodLength:
   Enabled: true
 Metrics/ParameterLists:
-  Enabled: true
-Metrics/PerceivedComplexity:
   Enabled: true
 Lint/AmbiguousOperator:
   Enabled: true

--- a/config/cookstyle_base.yml
+++ b/config/cookstyle_base.yml
@@ -479,27 +479,3 @@ Performance/StringReplacement:
   Enabled: true
 Performance/TimesMap:
   Enabled: true
-Rails/ActionFilter:
-  Enabled: true
-Rails/Date:
-  Enabled: true
-Rails/Delegate:
-  Enabled: true
-Rails/FindBy:
-  Enabled: true
-Rails/FindEach:
-  Enabled: true
-Rails/HasAndBelongsToMany:
-  Enabled: true
-Rails/Output:
-  Enabled: true
-Rails/PluralizationGrammar:
-  Enabled: true
-Rails/ReadWriteAttribute:
-  Enabled: true
-Rails/ScopeArgs:
-  Enabled: true
-Rails/TimeZone:
-  Enabled: true
-Rails/Validation:
-  Enabled: true


### PR DESCRIPTION
We should disable Metrics/ClassLength as well. Also avoid turning off things we just turned on in the base rubocop.yml

Signed-off-by: Tim Smith <tsmith@chef.io>