### PR TITLE
Disable Style/GuardClause and release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Cookstyle Changelog
 
+## 1.2.0 (2016-12-16)
+
+- Disable Style/GuardClause
+
 ## 1.1.0 (2016-12-13)
 
 ### Newly Disabled Cops:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -105,3 +105,7 @@ Bundler/OrderedGems:
 # There's no reason to have a gem listed twice
 Bundler/DuplicatedGem:
    Enabled: true
+
+# guard clause refactoring makes some cookbook logic harder to comprehend
+Style/GuardClause:
+  Enabled: false

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,4 +1,4 @@
 module Cookstyle
-  VERSION = "1.1.0".freeze
+  VERSION = "1.2.0".freeze
   RUBOCOP_VERSION = "0.46.0".freeze
 end


### PR DESCRIPTION
GuardClause results in some awful code to read for new users. Instead of having simple if/else logic you end up with returns that break simple logic flows. It's not an improvement.

Signed-off-by: Tim Smith <tsmith@chef.io>