### PR TITLE
Disable Performance/Casecmp and release 1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
-
+dist: trusty
 sudo: false
 
 branches:
@@ -12,6 +12,5 @@ before_install:
   - gem update --system
 
 rvm:
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.3.4
+  - 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Cookstyle Changelog
 
+## 1.4.0 (2017-05-30)
+
+- Our configuration of Lint/AmbiguousRegexpLiteral now ignores files in the test dir even if you run cookstyle against a chef-repo instead of each individual cookbook directory
+- We now explicitly set TargetRubyVersion to 2.0, as Ruby 2.0 shipped in older Chef 12 releases.
+
+### Newly Disabled Cops:
+
+- BlockLength which completes Cookstyle ignoring length in cookbooks
+
 ## 1.3.1 (2017-04-17)
 
 ### Newly Disabled Cops:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## 1.4.0 (2017-05-30)
 
-- Our configuration of Lint/AmbiguousRegexpLiteral now ignores files in the test dir even if you run cookstyle against a chef-repo instead of each individual cookbook directory
+- Our configuration of Lint/AmbiguousRegexpLiteral now ignores files in the test dir even if you run Cookstyle against a chef-repo directory instead of individual cookbook directories.
 - We now explicitly set TargetRubyVersion to 2.0, as Ruby 2.0 shipped in older Chef 12 releases.
 
 ### Newly Disabled Cops:
 
-- BlockLength which completes Cookstyle ignoring length in cookbooks
+- BlockLength which completes Cookstyle ignoring length in cookbooks.
+- Performance/Casecmp which resulted in confusing code.
 
 ## 1.3.1 (2017-04-17)
 

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -113,3 +113,7 @@ Bundler/OrderedGems:
 # There's no reason to have a gem listed twice
 Bundler/DuplicatedGem:
   Enabled: true
+
+# This results in very confusing code to read with little perf benefit
+Performance/Casecmp:
+  Enabled: false

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,4 +1,4 @@
 module Cookstyle
-  VERSION = "1.3.1".freeze
+  VERSION = "1.4.0".freeze
   RUBOCOP_VERSION = "0.47.1".freeze
 end


### PR DESCRIPTION
Slip 1 more change in and release 1.4.0. After this I'll bump Rubocop and release 2.0