### PR TITLE
Change Ruby Target to 2.3

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -118,6 +118,10 @@ Bundler/DuplicatedGem:
 Performance/Casecmp:
   Enabled: false
 
+# This comes with changing the ruby target to 2.3+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 # maintain the previous array behavior in previous cookstyle releases
 Style/PercentLiteralDelimiters:
    PreferredDelimiters:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.3
   Exclude:
     - vendor/**/*
     - Guardfile


### PR DESCRIPTION
This is what ships in ChefDK 1.x, Chef Client 12.x, and 13.0

It can be moved up again to 2.4 once all stable chef products move up to 2.4

Part of the motivation here is to use some new Ruby style features, specifically a new heredoc syntax in 2.3 which uses a tilde to denote automatic whitespace trimming.

One of the cops that becomes enabled by this target change is `Style/FrozenStringLiteralComment` which can be disabled for the time being I think.