### PR TITLE
Enforce LF for line endings to prevent failures on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Cookstyle Changelog
 
+## 2.1.0 (2017-08-24)
+
+- The Layout/EndOfLine cop now enforces a LF for line endings. This prevents users on Windows from seeing the "Carriage return character missing" error message.
+
 ## 2.0.0 (2017-05-31)
 
 ### Security Update

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -138,3 +138,8 @@ Style/YodaCondition:
 
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Enabled: true
+
+# enforce lf to avoid failures on Windows systems
+Layout/EndOfLine:
+  Enabled: true
+  EnforcedStyle: lf

--- a/config/cookstyle_base.yml
+++ b/config/cookstyle_base.yml
@@ -94,8 +94,6 @@ Style/EmptyLiteral:
   Enabled: true
 Style/EndBlock:
   Enabled: true
-Layout/EndOfLine:
-  Enabled: true
 Style/EvenOdd:
   Enabled: true
 Layout/ExtraSpacing:

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,4 +1,4 @@
 module Cookstyle
-  VERSION = "2.0.0".freeze
+  VERSION = "2.1.0".freeze
   RUBOCOP_VERSION = "0.49.1".freeze
 end


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>