### PR TITLE
Change target Ruby to at least 2.3

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.3
   Exclude:
     - vendor/**/*
     - Guardfile
@@ -116,6 +116,10 @@ Bundler/DuplicatedGem:
 
 # This results in very confusing code to read with little perf benefit
 Performance/Casecmp:
+  Enabled: false
+
+# This comes with changing the ruby target to 2.3+
+Style/FrozenStringLiteralComment:
   Enabled: false
 
 # maintain the previous array behavior in previous cookstyle releases


### PR DESCRIPTION
Giving this another shot since #37 was a bit too early and with ChefDK 3.0 on the horizon it seems fitting to target a newer Ruby.