### PR TITLE
disable `Lint/ParenthesesAsGroupedExpression` as it is not DSL friendly

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -230,3 +230,15 @@ Style/UnpackFirst:
 # simplify how you get the min or max of an array
 Performance/UnneededSort:
   Enable: true
+
+# disable group expressions as it does not make much sense with a DSL
+# take the following example:
+# sensu_client node['sensu']['client_name'] do
+#   subscriptions (['base'] + node['sensu']['subscriptions'] + node['subscriptions']).uniq.sort
+# end
+# will result in:
+# recipes/client.rb:23:16: W: Lint/ParenthesesAsGroupedExpression: (...) interpreted as grouped expression. (https://github.com/bbatsov/ruby-style-guide#parens-no-spaces)
+#   subscriptions (['base'] + node['sensu']['subscriptions'] + node['subscriptions']).uniq.sort
+#                ^
+Lint/ParenthesesAsGroupedExpression:
+  Enable: false


### PR DESCRIPTION
I have never seen this cop make sense in the context of `chef` or any other DSL and leads to lots of false positives.

Take the following example:
```ruby
sensu_client node['sensu']['client_name'] do
	# lots of stuff
	subscriptions (['base'] + node['sensu']['subscriptions'] + node['subscriptions']).uniq.sort
end
```

Would result in:
```
recipes/client.rb:23:16: W: Lint/ParenthesesAsGroupedExpression: (...) interpreted as grouped expression. (https://github.com/bbatsov/ruby-style-guide#parens-no-spaces)
  subscriptions (['base'] + node['sensu']['subscriptions'] + node['subscriptions']).uniq.sort
               ^
```

The cop would have you believe that either its safe to:
- remove the parentesis (not safe, see below)
- remove the space between `subscriptions` and the array of subscriptions, this leads to ambigous code as its now no longer clear that you are using the DSL and looks more like they are arguments passed to a method. (i think technically safe but makes the code less clear)

The grouped expression makes a real difference and is intentionally grouped:
```
$ irb
irb(main):001:0> (['base'] + ['a'] + ['kitchen']).sort
=> ["a", "base", "kitchen"]
irb(main):002:0> ['base'] + ['a'] + ['kitchen'].sort
=> ["base", "a", "kitchen"]
```

I discussed this with @tas50 

Signed-off-by: Ben Abrams <me@benabrams.it>