### PR TITLE
Ignore lazy { } for symbol proc check

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -230,3 +230,9 @@ Style/UnpackFirst:
 # simplify how you get the min or max of an array
 Performance/UnneededSort:
   Enable: true
+
+Style/SymbolProc:
+  # A list of method names to be ignored by the check.
+  # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
+  IgnoredMethods:
+    - lazy


### PR DESCRIPTION
Since lazy is a decorator method a yield of the block isn't always implicit and thus can break more often than work. Closes #52 