### PR TITLE
Require Ruby 2.2+ and update boilerplate

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -2,7 +2,7 @@
 ---
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:
-  notify_channel: sustaining-notify
+  notify_channel: chef-notify
 
 # This publish is triggered by the `built_in:publish_rubygems` artifact_action.
 rubygems:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+# Version:
+
+[Version of the project installed]
+
+# Environment: [Details about the environment such as the Operating System, cookbook details, etc...]
+
+# Scenario:
+
+[What you are trying to achieve and you can't?]
+
+# Steps to Reproduce:
+
+[If you are filing an issue what are the things we need to do in order to repro your problem?]
+
+# Expected Result:
+
+[What are you expecting to happen as the consequence of above reproduction steps?]
+
+# Actual Result:
+
+[What actually happens after the reproduction steps?]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+### Description
+
+[Please describe what this change achieves]
+
+### Issues Resolved
+
+[List any existing issues this PR resolves, or any Discourse or
+StackOverflow discussion that's relevant]
+
+### Check List
+
+- [ ] New functionality includes tests
+- [ ] All tests pass
+- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,1 @@
+daysUntilLock: 60

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
   - gem update --system
 
 rvm:
+  - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please refer to https://github.com/chef/chef/blob/master/CONTRIBUTING.md

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,21 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in cookstyle.gemspec
 gemspec
+
+group :debug do
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-stack_explorer"
+end
+
+group :docs do
+  gem "github-markup"
+  gem "redcarpet"
+  gem "yard"
+end
+
+instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
+
+# If you want to load debugging tools into the bundle exec sandbox,
+# add these additional dependencies into Gemfile.local
+eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")

--- a/cookstyle.gemspec
+++ b/cookstyle.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'RuboCop configuration for Chef cookbooks'
   spec.homepage      = 'https://github.com/chef/cookstyle'
   spec.license       = 'Apache-2.0'
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.2'
 
   # the gemspec and Gemfile are necessary for appbundling of the gem
   spec.files = %w{LICENSE cookstyle.gemspec Gemfile} + Dir.glob("{lib,bin,config}/**/*")


### PR DESCRIPTION
Add github templates
Require Ruby 2.2+ since Ruby 2.1 is EOL
Add additional rake tasks
Add contributing doc
Add Ruby 2.2/2.6 testing

Signed-off-by: Tim Smith <tsmith@chef.io>