### PR TITLE
Unpin the bundler dev dep

### DIFF
--- a/cookstyle.gemspec
+++ b/cookstyle.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables = %w(cookstyle)
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_dependency('rubocop', Cookstyle::RUBOCOP_VERSION)


### PR DESCRIPTION
This breaks installs on systems with bundler 2.x

Signed-off-by: Tim Smith <tsmith@chef.io>