### PR TITLE
Fix the update version script for expeditor

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -6,7 +6,7 @@
 
 set -evx
 
-sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" lib/cookstyle/version.rb
+sed -i -r "s/^(\s*)VERSION = \'.+\'/\1VERSION = \'$(cat VERSION)\'/" lib/cookstyle/version.rb
 
 # Once Expeditor finshes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.


### PR DESCRIPTION
Other projects have double quotes, but cookstyle is linted with
cookstyle (which is kinda odd btw).

Signed-off-by: Tim Smith <tsmith@chef.io>