### PR TITLE
Fix version bumps and codeowners

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,5 +1,6 @@
 # Documentation available at https://expeditor.chef.io/docs/getting-started/
 ---
+
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:
   notify_channel: chef-ws-notify

--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -6,7 +6,7 @@
 
 set -evx
 
-sed -i -r "s/^(\s*)VERSION = \'.+\'/\1VERSION = \'$(cat VERSION)\'/" lib/cookstyle/version.rb
+sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" lib/cookstyle/version.rb
 
 # Once Expeditor finshes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*                 @chef/client-maintainers
-.expeditor/**     @chef/jex-team
-*.md              @chef/docs-team
+*             @chef/chef-workstation-owners @chef/chef-workstation-approvers @chef/chef-workstation-reviewers
+.expeditor/   @chef/jex-team
+*.md          @chef/docs-team

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,4 +1,4 @@
 module Cookstyle
-  VERSION = '5.0.0'.freeze
+  VERSION = "5.0.1".freeze # rubocop: disable Style/StringLiterals
   RUBOCOP_VERSION = '0.72.0'.freeze
 end


### PR DESCRIPTION
Fix quoting in our version bump script by just using our standard sed command and double quotes in the cookstyle version file.

Signed-off-by: Tim Smith <tsmith@chef.io>