### PR TITLE
Add an autocorrect for insecure gitlab/github source/issue url metadata

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -61,6 +61,10 @@ Chef/LegacyBerksfileSource:
   Description: Do not use legacy Berkfile community sources. Use Chef Supermarket instead.
   Enabled: true
 
+Chef/InsecureCookbookURL:
+  Description: Insecure http Github or Gitlab URLs for metadata source_url/issues_url fields
+  Enabled: true
+
 #### The base rubocop 0.37 enabled.yml file we started with ####
 
 Layout/AccessModifierIndentation:

--- a/lib/rubocop/cop/chef/insecure_cookbook_url.rb
+++ b/lib/rubocop/cop/chef/insecure_cookbook_url.rb
@@ -27,8 +27,8 @@ module RuboCop
       #   source_url 'http://gitlab.com/something/something'
       #
       #   # good
-
-      #   source 'https://supermarket.chef.io'
+      #   source_url 'http://github.com/something/something'
+      #   source_url 'http://gitlab.com/something/something'
       #
       class InsecureCookbookURL < Cop
         MSG = 'Insecure http Github or Gitlab URLs for metadata source_url/issues_url fields'.freeze

--- a/lib/rubocop/cop/chef/insecure_cookbook_url.rb
+++ b/lib/rubocop/cop/chef/insecure_cookbook_url.rb
@@ -28,7 +28,6 @@ module RuboCop
       #
       #   # good
 
-
       #   source 'https://supermarket.chef.io'
       #
       class InsecureCookbookURL < Cop
@@ -40,7 +39,7 @@ module RuboCop
 
         def insecure_url?(url)
           # https://rubular.com/r/dS6L6bQZvwWxWq
-          url.match?(/http:\/\/(www.)*git(hub|lab)/)
+          url.match?(%r{http://(www.)*git(hub|lab)})
         end
 
         def on_send(node)
@@ -51,7 +50,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.loc.expression, node.source.gsub(/http:\/\/(www.)*/,'https://'))
+            corrector.replace(node.loc.expression, node.source.gsub(%r{http://(www.)*}, 'https://'))
           end
         end
       end

--- a/lib/rubocop/cop/chef/insecure_cookbook_url.rb
+++ b/lib/rubocop/cop/chef/insecure_cookbook_url.rb
@@ -1,0 +1,60 @@
+#
+# Copyright:: Copyright 2019, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      # Use secure Github and Gitlab URLs for source_url and issues_url
+      #
+      # @example
+      #
+      #   # bad
+      #   source_url 'http://github.com/something/something'
+      #   source_url 'http://www.github.com/something/something'
+      #   source_url 'http://www.gitlab.com/something/something'
+      #   source_url 'http://gitlab.com/something/something'
+      #
+      #   # good
+
+
+      #   source 'https://supermarket.chef.io'
+      #
+      class InsecureCookbookURL < Cop
+        MSG = 'Insecure http Github or Gitlab URLs for metadata source_url/issues_url fields'.freeze
+
+        def_node_matcher :insecure_cb_url?, <<-PATTERN
+          (send nil? {:source_url :issues_url} (str #insecure_url?))
+        PATTERN
+
+        def insecure_url?(url)
+          # https://rubular.com/r/dS6L6bQZvwWxWq
+          url.match?(/http:\/\/(www.)*git(hub|lab)/)
+        end
+
+        def on_send(node)
+          insecure_cb_url?(node) do
+            add_offense(node, location: :expression, message: MSG, severity: :warning)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.loc.expression, node.source.gsub(/http:\/\/(www.)*/,'https://'))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
These represent almost all of the community cookbook and this makes sure folks are using secure URLs

Signed-off-by: Tim Smith <tsmith@chef.io>