### PR TITLE
Add Chef/CommentSentenceSpacing cop (disabled by default)

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -45,6 +45,10 @@ Chef/CopyrightCommentFormat:
   Description: Properly format copyright dates in comment blocks and ensure dates are up to date
   Enabled: false
 
+Chef/CommentSentenceSpacing:
+  Description: Use a single space after sentences in comments
+  Enabled: false
+
 Chef/CommentFormat:
   Description: Use Chef's unique format for comment headers
   Enabled: true

--- a/lib/rubocop/cop/chef/comment_sentence_spacing.rb
+++ b/lib/rubocop/cop/chef/comment_sentence_spacing.rb
@@ -1,0 +1,41 @@
+#
+# Author: Tim Smith (<tsmith@chef.io>)
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      # Replaces double spaces between sentences with a single space.
+      # Note: This is DISABLED by default.
+      class CommentSentenceSpacing < Cop
+        MSG = 'Use a single space after sentences in comments'.freeze
+
+        def investigate(processed_source)
+          return unless processed_source.ast
+          processed_source.comments.each do |comment|
+            if comment.text.match?(/\.  /)
+              add_offense(comment, location: comment.loc.expression, message: MSG, severity: :warning)
+            end
+          end
+        end
+
+        def autocorrect(comment)
+          ->(corrector) { corrector.replace(comment.loc.expression, comment.text.gsub('.  ', '. ')) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a new cop that correct sentences in comment blocks to only have a single space after the period.

Signed-off-by: Tim Smith <tsmith@chef.io>