### PR TITLE
Force the fail level to :convention and set rules to :refactor level

### DIFF
--- a/bin/cookstyle
+++ b/bin/cookstyle
@@ -5,6 +5,13 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), %w(.. lib))
 
 require 'cookstyle'
 
+# force the fail level to :convention so that we can set all our new rules to
+# the lowest level of :refactor without failing everyone's CI jobs
+unless ARGV.include?('--fail-level')
+  ARGV << '--fail-level'
+  ARGV << 'C'
+end
+
 if ARGV.size == 1 && %w(-v --version).include?(ARGV.first)
   puts "Cookstyle #{Cookstyle::VERSION}"
   print '  * RuboCop '

--- a/lib/rubocop/cop/chef/attribute_keys.rb
+++ b/lib/rubocop/cop/chef/attribute_keys.rb
@@ -68,10 +68,10 @@ module RuboCop
         def on_node_attribute_access(node)
           if node.type == :str
             style_detected(:strings)
-            add_offense(node, location: :expression, message: MSG % style, severity: :warning) if style == :symbols
+            add_offense(node, location: :expression, message: MSG % style, severity: :refactor) if style == :symbols
           elsif node.type == :sym
             style_detected(:symbols)
-            add_offense(node, location: :expression, message: MSG % style, severity: :warning) if style == :strings
+            add_offense(node, location: :expression, message: MSG % style, severity: :refactor) if style == :strings
           end
         end
 

--- a/lib/rubocop/cop/chef/berksfile_source.rb
+++ b/lib/rubocop/cop/chef/berksfile_source.rb
@@ -43,7 +43,7 @@ module RuboCop
 
         def on_send(node)
           berksfile_source?(node) do
-            add_offense(node, location: :expression, message: MSG, severity: :warning)
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
           end
         end
 

--- a/lib/rubocop/cop/chef/comment_sentence_spacing.rb
+++ b/lib/rubocop/cop/chef/comment_sentence_spacing.rb
@@ -27,7 +27,7 @@ module RuboCop
           return unless processed_source.ast
           processed_source.comments.each do |comment|
             if comment.text.match?(/(.|\?)\s{2}/) # https://rubular.com/r/8o3SiDrQMJSzuU
-              add_offense(comment, location: comment.loc.expression, message: MSG, severity: :warning)
+              add_offense(comment, location: comment.loc.expression, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/comments_copyright_format.rb
+++ b/lib/rubocop/cop/chef/comments_copyright_format.rb
@@ -46,7 +46,7 @@ module RuboCop
             next unless comment.inline? # headers aren't in blocks
 
             if invalid_copyright_comment?(comment)
-              add_offense(comment, location: comment.loc.expression, message: MSG, severity: :warning)
+              add_offense(comment, location: comment.loc.expression, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/comments_format.rb
+++ b/lib/rubocop/cop/chef/comments_format.rb
@@ -46,7 +46,7 @@ module RuboCop
             next unless comment.inline? # headers aren't in blocks
 
             if invalid_comment?(comment)
-              add_offense(comment, location: comment.loc.expression, message: MSG, severity: :warning)
+              add_offense(comment, location: comment.loc.expression, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/file_mode.rb
+++ b/lib/rubocop/cop/chef/file_mode.rb
@@ -37,9 +37,7 @@ module RuboCop
 
         def on_send(node)
           resource_mode?(node) do |mode_int|
-            # for post April 2020
-            # add_offense(mode_int, location: :expression, message: MSG, severity: octal?(mode_int) ? :warning : :error)
-            add_offense(mode_int, location: :expression, message: MSG, severity: :warning)
+            add_offense(mode_int, location: :expression, message: MSG, severity: :refactor)
           end
         end
 

--- a/lib/rubocop/cop/chef/insecure_cookbook_url.rb
+++ b/lib/rubocop/cop/chef/insecure_cookbook_url.rb
@@ -44,7 +44,7 @@ module RuboCop
 
         def on_send(node)
           insecure_cb_url?(node) do
-            add_offense(node, location: :expression, message: MSG, severity: :warning)
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
           end
         end
 

--- a/lib/rubocop/cop/chef/node_normal.rb
+++ b/lib/rubocop/cop/chef/node_normal.rb
@@ -44,7 +44,7 @@ module RuboCop
 
         def on_send(node)
           node_normal?(node) do
-            add_offense(node, location: :expression, message: MSG, severity: :warning)
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
           end
         end
       end

--- a/lib/rubocop/cop/chef/node_normal_unless.rb
+++ b/lib/rubocop/cop/chef/node_normal_unless.rb
@@ -44,7 +44,7 @@ module RuboCop
 
         def on_send(node)
           node_normal_unless?(node) do
-            add_offense(node, location: :expression, message: MSG, severity: :warning)
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
           end
         end
       end

--- a/lib/rubocop/cop/chef/node_set.rb
+++ b/lib/rubocop/cop/chef/node_set.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         def on_send(node)
           node_set?(node) do
-            add_offense(node, location: :expression, message: MSG, severity: :warning)
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
           end
         end
 

--- a/lib/rubocop/cop/chef/node_set_unless.rb
+++ b/lib/rubocop/cop/chef/node_set_unless.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         def on_send(node)
           node_set_unless?(node) do
-            add_offense(node, location: :expression, message: MSG, severity: :warning)
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
           end
         end
 

--- a/lib/rubocop/cop/chef/service_resource.rb
+++ b/lib/rubocop/cop/chef/service_resource.rb
@@ -35,7 +35,7 @@ module RuboCop
         def on_send(node)
           execute_command?(node) do |command|
             if starts_service?(command)
-              add_offense(command, location: :expression, message: MSG, severity: :warning)
+              add_offense(command, location: :expression, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/tmp_path.rb
+++ b/lib/rubocop/cop/chef/tmp_path.rb
@@ -38,7 +38,7 @@ module RuboCop
         def on_send(node)
           remote_file?(node) do |command|
             if hardcoded_tmp?(command) && !file_cache_path?(command)
-              add_offense(command, location: :expression, message: MSG, severity: :warning)
+              add_offense(command, location: :expression, message: MSG, severity: :refactor)
             end
           end
         end


### PR DESCRIPTION
This way we can introduce new rules without failing builds. They'll warn to the console and auto correct, but they won't fail CI

Signed-off-by: Tim Smith <tsmith@chef.io>