### PR TITLE
Add the ability to specify the target chef version

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1,7 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.4
+  TargetChefVersion:: 14
   Exclude:
-    - vendor/**/*
     - Guardfile
   ChefAttributes:
     Patterns:

--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -32,6 +32,7 @@ end
 
 require 'rubocop/chef'
 require 'rubocop/chef/cookbook_only'
+require 'rubocop/mixin/target_chef_version'
 
 # Chef specific cops
 Dir.glob(File.dirname(__FILE__) + '/rubocop/cop/chef/**/*.rb') do |file|

--- a/lib/rubocop/cop/chef/why_run_supported_true.rb
+++ b/lib/rubocop/cop/chef/why_run_supported_true.rb
@@ -26,6 +26,10 @@ module RuboCop
       #   end
       #
       class WhyRunSupportedTrue < Cop
+        extend TargetChefVersion
+
+        minimum_target_chef_version 13
+
         MSG = 'why_run_supported? no longer needs to be set to true as it is the default in Chef 13++'.freeze
 
         def on_def(node)

--- a/lib/rubocop/mixin/target_chef_version.rb
+++ b/lib/rubocop/mixin/target_chef_version.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    module TargetChefVersion
+      def minimum_target_chef_version(version)
+        @minimum_target_chef_version = version
+      end
+
+      def support_target_chef_version?(version)
+        @minimum_target_chef_version <= version
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows you to set your cookstyle to enforce an older version of Chef. We'll default to Chef 14. This is entirely stolen from the rubocop-rails project.

Signed-off-by: Tim Smith <tsmith@chef.io>