### PR TITLE
Improve detection of double spaces after sentences

### DIFF
--- a/lib/rubocop/cop/chef/comment_sentence_spacing.rb
+++ b/lib/rubocop/cop/chef/comment_sentence_spacing.rb
@@ -26,14 +26,14 @@ module RuboCop
         def investigate(processed_source)
           return unless processed_source.ast
           processed_source.comments.each do |comment|
-            if comment.text.match?(/\.  /)
+            if comment.text.match?(/(.|\?)\s{2}/) # https://rubular.com/r/8o3SiDrQMJSzuU
               add_offense(comment, location: comment.loc.expression, message: MSG, severity: :warning)
             end
           end
         end
 
         def autocorrect(comment)
-          ->(corrector) { corrector.replace(comment.loc.expression, comment.text.gsub('.  ', '. ')) }
+          ->(corrector) { corrector.replace(comment.loc.expression, comment.text.gsub('.  ', '. ').gsub('?  ', '? ')) }
         end
       end
     end


### PR DESCRIPTION
Support sentences that end in a question mark
Don't match on more than 2 spaces because there may be a reason for that (who knows :shrug:)

Signed-off-by: Tim Smith <tsmith@chef.io>