### PR TITLE
Avoid false positives in header cleanup

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -27,7 +27,7 @@ steps:
       docker:
         image: ruby:2.6-stretch
 
-- label: run-specs-windows
+- label: run-cookstyle-windows
   command:
     - bundle install --jobs=7 --retry=3 --without docs debug
     - bundle exec rake style

--- a/lib/rubocop/cop/chef/comments_format.rb
+++ b/lib/rubocop/cop/chef/comments_format.rb
@@ -44,6 +44,7 @@ module RuboCop
           return unless processed_source.ast
 
           processed_source.comments.each do |comment|
+            next if comment.loc.first_line > 10 # avoid false positives when we were checking further down the file
             next unless comment.inline? # headers aren't in blocks
 
             if invalid_comment?(comment)


### PR DESCRIPTION
Don't process past line 10 because we're not in a header anymore and a sentence might start with one of our keywords.

Signed-off-by: Tim Smith <tsmith@chef.io>