### PR TITLE
Add rules for Effortless Infra pattern

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -131,6 +131,18 @@ Chef/UseBuildEssentialResource:
   Description: Use the build_essential resource instead of the legacy build-essential recipe
   Enabled: true
 
+###############################
+# Migrating to new patterns
+###############################
+
+Chef/CookbookUsesSearch:
+  Description: Cookbook uses search, which cannot be used in the Effortless Infra pattern
+  Enabled: false
+
+Chef/CookbookUsesDatabags:
+  Description: Cookbook uses data bags, which cannot be used in the Effortless Infra pattern
+  Enabled: false
+
 #### The base rubocop 0.37 enabled.yml file we started with ####
 
 Layout/AccessModifierIndentation:

--- a/lib/rubocop/cop/chef/data_bags.rb
+++ b/lib/rubocop/cop/chef/data_bags.rb
@@ -1,0 +1,36 @@
+#
+# Copyright:: Copyright 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      # Data bags cannot be used with the Effortless Infra pattern
+      #
+      # @example
+      #
+      #   # bad
+      #   data_bag_item('admins', login)
+      #   data_bag(data_bag_name)
+      class CookbookUsesDatabags < Cop
+        MSG = 'Cookbook uses data bags, which cannot be used in the Effortless Infra pattern'.freeze
+
+        def on_send(node)
+          add_offense(node, location: :expression, message: MSG, severity: :refactor) if %i(data_bag data_bag_item).include?(node.method_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/search.rb
+++ b/lib/rubocop/cop/chef/search.rb
@@ -1,0 +1,36 @@
+#
+# Copyright:: Copyright 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      # Search is not compatible with the Effortless Infra pattern
+      #
+      # @example
+      #
+      #   # bad
+      #   search(:node, 'run_list:recipe\[bacula\:\:server\]')
+      #
+      class CookbookUsesSearch < Cop
+        MSG = 'Cookbook uses search, which cannot be used in the Effortless Infra pattern'.freeze
+
+        def on_send(node)
+          add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :search
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Detect if a cookbook uses data bags or search. Disabled by default.

Signed-off-by: Tim Smith <tsmith@chef.io>