### PR TITLE
Add the majority of specs from rubocop-chef

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,36 +1,36 @@
 steps:
 
-- label: run-cookstyle-ruby-2.4
+- label: run-cookstyle-and-specs-ruby-2.4
   command:
     - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake style
+    - bundle exec rake
   expeditor:
     executor:
       docker:
         image: ruby:2.4-stretch
 
-- label: run-cookstyle-ruby-2.5
+- label: run-cookstyle-and-specs-ruby-2.5
   command:
     - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake style
+    - bundle exec rake
   expeditor:
     executor:
       docker:
         image: ruby:2.5-stretch
 
-- label: run-cookstyle-ruby-2.6
+- label: run-cookstyle-and-specs-ruby-2.6
   command:
     - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake style
+    - bundle exec rake
   expeditor:
     executor:
       docker:
         image: ruby:2.6-stretch
 
-- label: run-cookstyle-windows
+- label: run-cookstyle-and-specs-windows
   command:
     - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake style
+    - bundle exec rake
   expeditor:
     executor:
       docker:

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,15 @@ group :docs do
   gem 'yard'
 end
 
+group :development do
+  gem 'adamantium'
+  gem 'anima'
+  gem 'concord'
+  gem 'rake'
+  gem 'rspec', '>= 3.4'
+  gem 'simplecov'
+end
+
 instance_eval(ENV['GEMFILE_MOD']) if ENV['GEMFILE_MOD']
 
 # If you want to load debugging tools into the bundle exec sandbox,

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,22 @@ RuboCop::RakeTask.new(:style) do |task|
   task.options << '--display-cop-names'
 end
 
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = FileList['spec/**/*_spec.rb']
+end
+
+desc 'Run RSpec with code coverage'
+task :coverage do
+  ENV['COVERAGE'] = 'true'
+  Rake::Task['spec'].execute
+end
+
+desc 'Run RuboCop over this gem'
+task :internal_investigation do
+  sh('bundle exec rubocop --require rubocop-rspec')
+end
+
 begin
   require 'yard'
   YARD::Rake::YardocTask.new(:docs)
@@ -38,4 +54,4 @@ task :console do
   ARGV.clear
   IRB.start
 end
-task default: [:build, :install]
+task default: [:style, :spec]

--- a/spec/expect_violation/expectation_spec.rb
+++ b/spec/expect_violation/expectation_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ExpectViolation::Expectation do
+  subject(:expectation) { described_class.new(string) }
+
+  context 'when given a single assertion on class end' do
+    let(:string) do
+      <<-SRC
+      class Foo
+      end
+      ^^^ The end of `Foo` should be annotated.
+      SRC
+    end
+
+    let(:assertion) { expectation.assertions.first }
+
+    it 'has one assertion' do
+      expect(expectation.assertions.size).to be(1)
+    end
+
+    it 'has an assertion on line 2' do
+      expect(assertion.line_number).to be(2)
+    end
+
+    it 'has an assertion on column range 1-3' do
+      expect(assertion.column_range).to eql(6...9)
+    end
+
+    it 'has an assertion with correct violation message' do
+      expect(assertion.message).to eql('The end of `Foo` should be annotated.')
+    end
+
+    it 'recreates source' do
+      expect(expectation.source).to eql(<<-RUBY)
+      class Foo
+      end
+      RUBY
+    end
+  end
+
+  context 'when given many assertions on two lines' do
+    let(:string) do
+      <<-SRC
+      foo bar
+          ^ Charlie
+         ^^ Charlie
+          ^^ Bronco
+          ^^ Alpha
+      baz
+      ^ Delta
+      SRC
+    end
+
+    let(:assertions) { expectation.assertions.sort }
+
+    it 'has two assertions' do
+      expect(expectation.assertions.size).to be(5)
+    end
+
+    it 'has assertions on lines 1 and 2' do
+      expect(assertions.map(&:line_number)).to eql(
+        [1, 1, 1, 1, 2]
+      )
+    end
+
+    it 'has assertions on column range 1-3' do
+      expect(assertions.map(&:column_range)).to eql(
+        [9...11, 10...11, 10...12, 10...12, 6...7]
+      )
+    end
+
+    it 'has an assertion with correct violation message' do
+      expect(assertions.map(&:message)).to eql(
+        %w(Charlie Charlie Alpha Bronco Delta)
+      )
+    end
+
+    it 'recreates source' do
+      expect(expectation.source).to eql(<<-RUBY)
+      foo bar
+      baz
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/attribute_keys_spec.rb
+++ b/spec/rubocop/cop/chef/attribute_keys_spec.rb
@@ -1,0 +1,117 @@
+#
+# Copyright:: 2016, Noah Kantrowitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::AttributeKeys, :config do
+  subject(:cop) { described_class.new(config) }
+
+  context 'when EnforcedStyle is `symbols`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'symbols' } }
+
+    it 'does not register an offense when accessing a single node attribute with a symbol' do
+      expect_no_violations(<<-RUBY)
+        node[:foo]
+      RUBY
+    end
+
+    it 'registers an offense when accessing a single node attribute with a single quoted string' do
+      expect_violation(<<-RUBY)
+        node['foo']
+             ^^^^^ Use symbols to access node attributes
+      RUBY
+    end
+
+    it 'registers an offense when accessing a single node attribute with a double quoted string' do
+      expect_violation(<<-RUBY)
+        node["foo"]
+             ^^^^^ Use symbols to access node attributes
+      RUBY
+    end
+
+    it 'registers an offense when accessing a nested node attributes with strings' do
+      expect_violation(<<-RUBY)
+        node['foo']["bar"][%q{baz}]
+             ^^^^^ Use symbols to access node attributes
+                    ^^^^^ Use symbols to access node attributes
+                           ^^^^^^^ Use symbols to access node attributes
+      RUBY
+    end
+
+    it 'registers an offense when accessing a nested node attributes with mixed values' do
+      expect_violation(<<-RUBY)
+        node["foo"][:bar][0]['other']
+             ^^^^^ Use symbols to access node attributes
+                             ^^^^^^^ Use symbols to access node attributes
+      RUBY
+    end
+
+    include_examples 'autocorrect',
+                     'node[:foo]["bar"]',
+                     'node[:foo][:bar]'
+
+    include_examples 'autocorrect',
+                     'node[:foo][\'bar\']',
+                     'node[:foo][:bar]'
+  end # /context when EnforcedStyle is `symbols`
+
+  context 'when EnforcedStyle is `strings`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'strings' } }
+
+    it 'registers an offense when accessing a single node attribute with a symbol' do
+      expect_violation(<<-RUBY)
+        node[:foo]
+             ^^^^ Use strings to access node attributes
+      RUBY
+    end
+
+    it 'does not register an offense when accessing a single node attribute with a single quoted string' do
+      expect_no_violations(<<-RUBY)
+        node['foo']
+      RUBY
+    end
+
+    it 'does not register an offense when accessing a single node attribute with a double quoted string' do
+      expect_no_violations(<<-RUBY)
+        node["foo"]
+      RUBY
+    end
+
+    it 'registers an offense when accessing a nested node attributes with symbols' do
+      expect_violation(<<-RUBY)
+        node[:foo][:bar][:baz]
+             ^^^^ Use strings to access node attributes
+                   ^^^^ Use strings to access node attributes
+                         ^^^^ Use strings to access node attributes
+      RUBY
+    end
+
+    it 'registers an offense when accessing a nested node attributes with mixed values' do
+      expect_violation(<<-RUBY)
+        node["foo"][:bar][0]['other']
+                    ^^^^ Use strings to access node attributes
+      RUBY
+    end
+
+    include_examples 'autocorrect',
+                     'node[:foo]["bar"]',
+                     'node["foo"]["bar"]'
+
+    include_examples 'autocorrect',
+                     'node[:foo][\'bar\']',
+                     'node["foo"][\'bar\']'
+  end # /context when EnforcedStyle is `strings`
+end

--- a/spec/rubocop/cop/chef/file_mode_spec.rb
+++ b/spec/rubocop/cop/chef/file_mode_spec.rb
@@ -1,0 +1,91 @@
+#
+# Copyright:: 2016, Noah Kantrowitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::FileMode do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when setting a mode using a decimal integer' do
+    expect_violation(<<-RUBY)
+      file '/foo' do
+        owner 'root'
+        mode 644
+             ^^^ Use strings for file modes
+      end
+    RUBY
+  end
+
+  it 'registers an offense when setting a mode using a octal integer' do
+    expect_violation(<<-RUBY)
+      file '/foo' do
+        owner 'root'
+        mode 0644
+             ^^^^ Use strings for file modes
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when setting a mode using a single quoted string' do
+    expect_no_violations(<<-RUBY)
+      file '/foo' do
+        owner 'root'
+        mode '644'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when setting a mode using a double quoted string' do
+    expect_no_violations(<<-RUBY)
+      file '/foo' do
+        owner 'root'
+        mode "644"
+      end
+    RUBY
+  end
+
+  include_examples 'autocorrect',
+                   'mode 644',
+                   'mode "644"'
+
+  include_examples 'autocorrect',
+                   'mode 0644',
+                   'mode "644"'
+
+  include_examples 'autocorrect',
+                   'mode 00644',
+                   'mode "644"'
+
+  include_examples 'autocorrect',
+                   'mode 1644',
+                   'mode "1644"'
+
+  include_examples 'autocorrect',
+                   'mode 01644',
+                   'mode "1644"'
+
+  include_examples 'autocorrect',
+                   'mode 0o644',
+                   'mode "644"'
+
+  include_examples 'autocorrect',
+                   'mode 0O644',
+                   'mode "644"'
+
+  include_examples 'autocorrect',
+                   'mode 0x284',
+                   'mode "644"'
+end

--- a/spec/rubocop/cop/chef/service_resource_spec.rb
+++ b/spec/rubocop/cop/chef/service_resource_spec.rb
@@ -1,0 +1,38 @@
+#
+# Copyright:: 2016, Chris Henry
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ServiceResource, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when starting a service in execute resource' do
+    expect_violation(<<-RUBY)
+      execute 'apache_start' do
+        command '/etc/init.d/httpd start'
+                ^^^^^^^^^^^^^^^^^^^^^^^^^ Use a service resource to start and stop services
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when running a normal command' do
+    expect_no_violations(<<-RUBY)
+      execute 'apache_start' do
+        command 'echo "not starting a service"'
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/tmp_path_spec.rb
+++ b/spec/rubocop/cop/chef/tmp_path_spec.rb
@@ -1,0 +1,38 @@
+#
+# Copyright:: 2016, Chris Henry
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::TmpPath, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when hardcoding a path in /tmp' do
+    expect_violation(<<-RUBY)
+      remote_file '/tmp/large-file.tar.gz' do
+                  ^^^^^^^^^^^^^^^^^^^^^^^^ Use file_cache_path rather than hard-coding tmp paths
+        source 'http://www.example.org/large-file.tar.gz'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when using file_cache_path" do
+    expect_no_violations(<<-RUBY)
+      remote_file "\#\{Chef::Config[:file_cache_path]\}/large-file.tar.gz" do
+        source 'http://www.example.org/large-file.tar.gz'
+      end
+    RUBY
+  end
+end

--- a/spec/shared/autocorrect_behavior.rb
+++ b/spec/shared/autocorrect_behavior.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples 'autocorrect' do |original, corrected|
+  it "autocorrects `#{original}` to `#{corrected}`" do
+    autocorrected = autocorrect_source(original, 'spec/foo_spec.rb')
+
+    expect(autocorrected).to eql(corrected)
+  end
+end

--- a/spec/shared/detects_style_behavior.rb
+++ b/spec/shared/detects_style_behavior.rb
@@ -1,0 +1,8 @@
+RSpec.shared_examples 'detects style' do |source, detected_style|
+  it 'generates a todo based on the detected style' do
+    inspect_source(cop, source, 'foo_spec.rb')
+
+    expect(cop.config_to_allow_offenses)
+      .to eq('EnforcedStyle' => detected_style)
+  end
+end

--- a/spec/shared/rspec_only_cop_behavior.rb
+++ b/spec/shared/rspec_only_cop_behavior.rb
@@ -1,0 +1,68 @@
+module SpecHelper
+  # Provides a helper method for checking that `cop` works
+  #
+  # @note this is defined in a module so that the failure message can be
+  #   a constant without creating a bunch of warnings when the shared
+  #   context is included
+  #
+  module CheckCop
+    CURRENT_FILE = Pathname.new(__FILE__).relative_path_from(ROOT).freeze
+
+    FAILURE = <<-MSG.freeze
+      Attempting to access `cop` produced the following error:
+
+        %<exception>s
+
+      The shared context under #{CURRENT_FILE} is included for all RSpec
+      cops. This context expects you to define a subject named `cop` like so:
+
+        describe RuboCop::Cop::RSpec::SomeCheck do
+          subject(:cop) { described_class.new }
+
+          ...
+        end
+
+      or if your cop is configurable you should have something like:
+
+        describe RuboCop::Cop::RSpec::SomeConfigurableCheck, :config do
+          subject(:cop) { described_class.new(config) }
+
+          let(:cop_config) do
+            { 'EnforcedStyle' => 'fancy', 'WhateverElse' => 'YouNeed' }
+          end
+
+          ...
+        end
+
+      This error likely means that you either don't define `cop` at the top
+      level or you have dependent definitions (like `cop_config`) that are not
+      defined at the top level.
+    MSG
+
+    # This method exists to reduce confusion for contributors. It is important
+    # that these shared examples are automatically included for all cops but
+    # it is easy for these to fail if you don't realize that your top level
+    # describe needs to define a useable `cop` subject.
+    def check_cop_definition
+      cop
+    rescue => exception
+      raise format(FAILURE, exception: exception)
+    end
+  end
+end
+
+RSpec.shared_examples 'an rspec only cop', rspec_cop: true do
+  include SpecHelper::CheckCop
+
+  before do
+    check_cop_definition
+  end
+
+  it 'does not deem lib/feature/thing.rb to be a relevant file' do
+    expect(cop.relevant_file?('lib/feature/thing.rb')).to be_falsey
+  end
+
+  it 'deems spec/feature/thing_spec.rb to be a relevant file' do
+    expect(cop.relevant_file?('spec/feature/thing_spec.rb')).to be(true)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,38 @@
+require 'rubocop'
+require 'rubocop/rspec/support'
+
+module SpecHelper
+  ROOT = Pathname.new(__dir__).parent.freeze
+end
+
+spec_helper_glob = File.expand_path('{support,shared}/*.rb', __dir__)
+Dir.glob(spec_helper_glob).map(&method(:require))
+
+RSpec.configure do |config|
+  # Basic configuraiton
+  config.run_all_when_everything_filtered = true
+  config.filter_run(:focus)
+  config.order = :random
+
+  # Define spec metadata for all rspec cop spec files
+  cop_specs = 'spec/rubocop/cop/chef/'
+  config.define_derived_metadata(file_path: /\b#{cop_specs}/) do |metadata|
+    # Attach metadata that signals the specified code is for an RSpec only cop
+    metadata[:chef_cop] = true
+  end
+
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect # Disable `should`
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect # Disable `should_receive` and `stub`
+  end
+
+  config.include(ExpectViolation)
+end
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+
+require 'cookstyle'

--- a/spec/support/expect_violation.rb
+++ b/spec/support/expect_violation.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'adamantium'
+require 'concord'
+require 'anima'
+
+module ExpectViolation
+  DEFAULT_FILENAME = 'example_spec.rb'
+  def expect_violation(source, filename: DEFAULT_FILENAME)
+    expectation = Expectation.new(source)
+    inspect_source(expectation.source, filename)
+    offenses = cop.offenses.map(&method(:to_assertion)).sort
+
+    if expectation.assertions.empty?
+      raise 'Use expect_no_violations to assert no violations'
+    end
+
+    expect(offenses).to eq(expectation.assertions.sort)
+  end
+
+  def expect_no_violations(source, filename: DEFAULT_FILENAME)
+    inspect_source(source, filename)
+
+    expect(cop.offenses.empty?).to be(true)
+  end
+
+  private
+
+  def to_assertion(offense)
+    Expectation::Assertion.new(
+      message: offense.message,
+      line_number: offense.location.line,
+      column_range: offense.location.column_range
+    )
+  end
+
+  class Expectation
+    VIOLATION_LINE_PATTERN = /\A *\^/.freeze
+
+    VIOLATION = :violation
+    SOURCE    = :line
+
+    include Concord.new(:string)
+    include Adamantium
+
+    def source
+      source_map.to_s
+    end
+
+    def assertions
+      source_map.assertions
+    end
+
+    private
+
+    def source_map
+      tokens.reduce(Source::BLANK) do |source, (type, tokens)|
+        tokens.reduce(source, :"add_#{type}")
+      end
+    end
+    memoize :source_map
+
+    def tokens
+      string.each_line.chunk do |line|
+        next SOURCE unless line =~ VIOLATION_LINE_PATTERN
+
+        VIOLATION
+      end
+    end
+
+    class Source
+      include Concord.new(:lines)
+
+      BLANK = new([].freeze)
+
+      def add_line(line)
+        self.class.new(lines + [Line.new(text: line, number: lines.size + 1)])
+      end
+
+      def add_violation(violation)
+        self.class.new([*lines[0...-1], lines.last.add_violation(violation)])
+      end
+
+      def to_s
+        lines.map(&:text).join
+      end
+
+      def assertions
+        lines.flat_map(&:assertions)
+      end
+
+      class Line
+        DEFAULTS = { violations: [] }.freeze
+
+        include Anima.new(:text, :number, :violations)
+
+        def initialize(options)
+          super(DEFAULTS.merge(options))
+        end
+
+        def add_violation(violation)
+          with(violations: violations + [violation])
+        end
+
+        def assertions
+          violations.map do |violation|
+            Assertion.parse(
+              text: violation,
+              line_number: number
+            )
+          end
+        end
+      end
+    end
+
+    class Assertion
+      def self.parse(text:, line_number:)
+        parser = Parser.new(text)
+
+        new(
+          message: parser.message,
+          column_range: parser.column_range,
+          line_number: line_number
+        )
+      end
+
+      include Comparable
+      include Adamantium
+      include Anima.new(:message, :column_range, :line_number)
+
+      def <=>(other)
+        to_a <=> other.to_a
+      end
+
+      protected
+
+      def to_a
+        [line_number, column_range.first, column_range.last, message]
+      end
+
+      class Parser
+        COLUMN_PATTERN = /^ *(?<carets>\^\^*) (?<message>.+)$/.freeze
+
+        include Adamantium
+        include Concord.new(:text)
+
+        def column_range
+          Range.new(*match.offset(:carets), true)
+        end
+
+        def message
+          match[:message]
+        end
+
+        private
+
+        def match
+          text.match(COLUMN_PATTERN)
+        end
+        memoize :match
+      end
+
+      private_constant(*constants(false))
+    end
+  end
+end


### PR DESCRIPTION
This does not add the cookbook_only specs which are all failing right now. That may just be because that functionality is broken. We're not actually using it anywhere.

Signed-off-by: Tim Smith <tsmith@chef.io>