### PR TITLE
Add Chef/CookbookDependsOnPoise rule

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -108,6 +108,13 @@ Chef/EpicFail:
   Enabled: true
   VersionAdded: '5.1.0'
 
+Chef/CookbookDependsOnPoise:
+  Description: Cookbooks should not depend on the deprecated Poise framework
+  Enabled: true
+  VersionAdded: '5.1.0'
+  Include:
+    - '**/metadata.rb'
+
 ###############################
 # Cleaning up Legacy Code
 ###############################

--- a/lib/rubocop/cop/chef/poise.rb
+++ b/lib/rubocop/cop/chef/poise.rb
@@ -1,0 +1,42 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      # Cookbooks should not depend on the deprecated Poise framework. They should instead
+      # be refactored as standard custom resources.
+      #
+      # @example
+      #
+      #   # bad
+      #   depends 'poise'
+      class CookbookDependsOnPoise < Cop
+        MSG = 'Cookbooks should not depend on the deprecated Poise framework'.freeze
+
+        def_node_matcher :depends_method?, <<-PATTERN
+          (send nil? :depends $str)
+        PATTERN
+
+        def on_send(node)
+          depends_method?(node) do |arg|
+            add_offense(node, location: :expression, message: MSG, severity: :refactor) if arg == s(:str, 'poise')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/poise_spec.rb
+++ b/spec/rubocop/cop/chef/poise_spec.rb
@@ -1,0 +1,34 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::CookbookDependsOnPoise, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a cookbook depends on "poise"' do
+    expect_violation(<<-RUBY)
+      depends 'poise'
+      ^^^^^^^^^^^^^^^ Cookbooks should not depend on the deprecated Poise framework
+    RUBY
+  end
+
+  it "doesn't register an offense when depending on any old cookbook" do
+    expect_no_violations(<<-RUBY)
+      depends 'poise-ish'
+    RUBY
+  end
+end


### PR DESCRIPTION
This detects a cookbook that depends on the poise cookbook, which is no longer being maintained. These should be refactored to use custom resources instead.

Fixes #135 

Signed-off-by: Tim Smith <tsmith@chef.io>