### PR TITLE
Add Chef/RequireRecipe rule

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -179,6 +179,11 @@ Chef/ErlCallResource:
   Enabled: true
   VersionAdded: '5.1.0'
 
+Chef/RequireRecipe:
+  Description: Use include_recipe instead of the require_recipe method
+  Enabled: true
+  VersionAdded: '5.2.0'
+
 ###############################
 # Cleaning up Legacy Code
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/require_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/require_recipe.rb
@@ -1,0 +1,50 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      # Make sure to use include_recipe instead of require_recipe
+      #
+      # @example
+      #
+      #   # bad
+      #   require_recipe 'foo'
+      #
+      #   # good
+      #   include_recipe 'foo'
+      #
+      class RequireRecipe < Cop
+        MSG = 'Use include_recipe instead of the require_recipe method'.freeze
+
+        def_node_matcher :require_recipe?, <<-PATTERN
+          (send nil? :require_recipe $str)
+        PATTERN
+
+        def on_send(node)
+          require_recipe?(node) { add_offense(node, location: :selector, message: MSG, severity: :refactor) }
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.loc.selector, 'include_recipe')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/require_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/require_recipe_spec.rb
@@ -1,0 +1,34 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::RequireRecipe, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when require_recipe is used' do
+    expect_violation(<<-RUBY)
+      require_recipe 'foo'
+      ^^^^^^^^^^^^^^ Use include_recipe instead of the require_recipe method
+    RUBY
+  end
+
+  it "doesn't register an offense when include_recipe is used" do
+    expect_no_violations(<<-RUBY)
+      include_recipe 'foo'
+    RUBY
+  end
+end


### PR DESCRIPTION
Detect when someone does this:

```ruby
require_recipe 'foo'
```

instead of

```ruby
include_recipe 'foo'
```

Signed-off-by: Tim Smith <tsmith@chef.io>