### PR TITLE
Add Chef/LongDescriptionMetadata cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -155,6 +155,13 @@ Chef/AttributeMetadata:
   Include:
     - '**/metadata.rb'
 
+Chef/LongDescriptionMetadata:
+  Description: The long_description metadata.rb method is not used and is unnecessary in cookbooks
+  Enabled: true
+  VersionAdded: '5.2.0'
+  Include:
+    - '**/metadata.rb'
+
 Chef/CookbookDependsOnCompatResource:
   Description: Don't depend on the deprecated compat_resource cookbook made obsolete by Chef 12.19+
   Enabled: true

--- a/lib/rubocop/cop/chef/deprecation/long_description_metadata.rb
+++ b/lib/rubocop/cop/chef/deprecation/long_description_metadata.rb
@@ -1,0 +1,44 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      # The long_description metadata.rb method is not used and is unnecessary in cookbooks
+      #
+      # @example
+      #
+      #   # bad
+      #   long_description 'this is my cookbook and this description will never be seen'
+      #
+
+      class LongDescriptionMetadata < Cop
+        MSG = 'The long_description metadata.rb method is not used and is unnecessary in cookbooks'.freeze
+
+        def on_send(node)
+          add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :long_description
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.remove(node.loc.expression)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/long_description_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/long_description_metadata_spec.rb
@@ -1,0 +1,34 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::LongDescriptionMetadata, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when metadata used "conflicts"' do
+    expect_violation(<<-RUBY)
+      long_description 'foo'
+      ^^^^^^^^^^^^^^^^^^^^^^ The long_description metadata.rb method is not used and is unnecessary in cookbooks
+    RUBY
+  end
+
+  it "doesn't register an offense on normal metadata" do
+    expect_no_violations(<<-RUBY)
+      depends 'foo'
+    RUBY
+  end
+end


### PR DESCRIPTION
There's no need for long_description at this point and it just makes the metadata more complex and Chef just a tiny bit harder to use.

Signed-off-by: Tim Smith <tsmith@chef.io>