### PR TITLE
Add autocorrecting to CookbooksDependsOnSelf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem

--- a/lib/rubocop/cop/chef/correctness/cb_depends_on_self.rb
+++ b/lib/rubocop/cop/chef/correctness/cb_depends_on_self.rb
@@ -39,9 +39,16 @@ module RuboCop
           cb_name?(node) do
             dependencies(processed_source.ast).each do |dep|
               if dep.arguments == node.arguments
-                add_offense(node, location: node.source_range, message: MSG, severity: :refactor)
+                node = dep # set our dependency node as the node for autocorrecting later
+                add_offense(node, location: dep.source_range, message: MSG, severity: :refactor)
               end
             end
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.remove(node.source_range)
           end
         end
       end

--- a/spec/rubocop/cop/chef/correctness/cb_depends_on_self_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/cb_depends_on_self_spec.rb
@@ -22,8 +22,8 @@ describe RuboCop::Cop::Chef::CookbooksDependsOnSelf, :config do
   it 'registers an offense when a cookbook depends on itself' do
     expect_violation(<<-RUBY)
       name 'foo'
-      ^^^^^^^^^^ A cookbook cannot depend on itself
       depends 'foo'
+      ^^^^^^^^^^^^^ A cookbook cannot depend on itself
     RUBY
   end
 


### PR DESCRIPTION
If we change the node to the depends node we found then we can delete it easily.

Signed-off-by: Tim Smith <tsmith@chef.io>