### PR TITLE
Fix the regression where we no longer show the cookstyle version

### DIFF
--- a/bin/cookstyle
+++ b/bin/cookstyle
@@ -12,7 +12,8 @@ unless ARGV.include?('--fail-level')
   ARGV << 'C'
 end
 
-if ARGV.size == 1 && %w(-v --version).include?(ARGV.first)
+# if only -v is passed we'll get 3 args (-v, --fail-level, and C)
+if ARGV.size == 3 && %w(-v --version).include?(ARGV.first)
   puts "Cookstyle #{Cookstyle::VERSION}"
   print '  * RuboCop '
 end


### PR DESCRIPTION
We started injecting the fail-level by default which meant we went from 1 arg to 3.

```shell
≻ bin/cookstyle -v
Cookstyle 5.2.11
  * RuboCop 0.72.0
```

Signed-off-by: Tim Smith <tsmith@chef.io>