### PR TITLE
Speed up MetadataMissingName

### DIFF
--- a/lib/rubocop/cop/chef/correctness/metadata_missing_name.rb
+++ b/lib/rubocop/cop/chef/correctness/metadata_missing_name.rb
@@ -32,6 +32,7 @@ module RuboCop
 
         def investigate(processed_source)
           return if processed_source.blank?
+          return unless File.basename(processed_source.file_path) == 'metadata.rb'
 
           # Using range similar to RuboCop::Cop::Naming::Filename (file_name.rb)
           range = source_range(processed_source.buffer, 1, 0)


### PR DESCRIPTION
We can skip this if the file we're in isn't metadata.rb.

Signed-off-by: Tim Smith <tsmith@chef.io>