### PR TITLE
Add Chef/CustomResourceWithAllowedActions

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -286,6 +286,13 @@ Chef/CustomResourceWithAttributes:
   Include:
     - '**/resources/*.rb'
 
+Chef/CustomResourceWithAllowedActions:
+  Description: Custom Resources don't need to define the allowed actions with allowed_actions or actions methods
+  Enabled: true
+  VersionAdded: '5.2.0'
+  Include:
+    - '**/resources/*.rb'
+
 ###############################
 # Detecting code that breaks Chef
 ###############################

--- a/lib/rubocop/cop/chef/modernize/resource_with_allowed_action.rb
+++ b/lib/rubocop/cop/chef/modernize/resource_with_allowed_action.rb
@@ -55,7 +55,7 @@ module RuboCop
         PATTERN
 
         def_node_search :resource_actions?, <<-PATTERN
-          (send nil? :action ... )
+          (block (send nil? :action ... ) ... )
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/resource_with_allowed_action.rb
+++ b/lib/rubocop/cop/chef/modernize/resource_with_allowed_action.rb
@@ -1,0 +1,67 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      # In HWRPs and LWRPs it was necessary to define the allowed actions within the resource.
+      # In custom resources this is no longer necessary as Chef will determine it based on the
+      # actions defined in the resource.
+      #
+      # @example
+      #
+      #   # bad
+      #   property :something, String
+      #
+      #   allowed_actions [:create, :remove]
+      #   action :create do
+      #     # some action code because we're in a custom resource
+      #   end
+      #
+      #   # good
+      #   property :something, String
+      #
+      #   action :create do
+      #     # some action code because we're in a custom resource
+      #   end
+      #
+      class CustomResourceWithAllowedActions < Cop
+        MSG = "Custom Resources don't need to define allowed_actions".freeze
+
+        def_node_matcher :allowed_actions?, <<-PATTERN
+          (send nil? :allowed_actions ... )
+        PATTERN
+
+        def_node_search :resource_actions?, <<-PATTERN
+          (send nil? :action ... )
+        PATTERN
+
+        def on_send(node)
+          allowed_actions?(node) do
+            add_offense(node, location: :expression, message: MSG, severity: :refactor) if resource_actions?(processed_source.ast)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.remove(node.loc.expression)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/modernize/resource_with_allowed_action.rb
+++ b/lib/rubocop/cop/chef/modernize/resource_with_allowed_action.rb
@@ -32,6 +32,14 @@ module RuboCop
       #     # some action code because we're in a custom resource
       #   end
       #
+      #   # also bad
+      #   property :something, String
+      #
+      #   actions [:create, :remove]
+      #   action :create do
+      #     # some action code because we're in a custom resource
+      #   end
+      #
       #   # good
       #   property :something, String
       #
@@ -40,10 +48,10 @@ module RuboCop
       #   end
       #
       class CustomResourceWithAllowedActions < Cop
-        MSG = "Custom Resources don't need to define allowed_actions".freeze
+        MSG = "Custom Resources don't need to define the allowed actions with allowed_actions or actions methods".freeze
 
         def_node_matcher :allowed_actions?, <<-PATTERN
-          (send nil? :allowed_actions ... )
+          (send nil? {:allowed_actions :actions} ... )
         PATTERN
 
         def_node_search :resource_actions?, <<-PATTERN

--- a/spec/rubocop/cop/chef/modernize/resource_with_allowed_actions_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/resource_with_allowed_actions_spec.rb
@@ -1,0 +1,51 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::CustomResourceWithAllowedActions, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense with a custom resource that uses allowed_actions' do
+    expect_violation(<<-RUBY)
+      property :something, String
+
+      allowed_actions [:create, :remove]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Custom Resources don't need to define allowed_actions
+      action :create do
+        # some action code because we're in a custom resource
+      end
+    RUBY
+  end
+
+  it 'does not register an offense with a custom resource that does not use allowed_actions' do
+    expect_no_violations(<<-RUBY)
+      property :something, String
+
+      action :create do
+        # some action code because we're in a custom resource
+      end
+    RUBY
+  end
+
+  it 'does not register an offense with a LWRP that uses allowed_actions' do
+    expect_no_violations(<<-RUBY)
+      attribute :something, String
+
+      allowed_actions [:create, :remove]
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/resource_with_allowed_actions_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/resource_with_allowed_actions_spec.rb
@@ -19,19 +19,31 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::CustomResourceWithAllowedActions, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense with a custom resource that uses allowed_actions' do
+  it 'registers an offense with a custom resource that uses allowed_actions method' do
     expect_violation(<<-RUBY)
       property :something, String
 
       allowed_actions [:create, :remove]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Custom Resources don't need to define allowed_actions
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Custom Resources don't need to define the allowed actions with allowed_actions or actions methods
       action :create do
         # some action code because we're in a custom resource
       end
     RUBY
   end
 
-  it 'does not register an offense with a custom resource that does not use allowed_actions' do
+  it 'registers an offense with a custom resource that uses actions method' do
+    expect_violation(<<-RUBY)
+      property :something, String
+
+      actions [:create, :remove]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Custom Resources don't need to define the allowed actions with allowed_actions or actions methods
+      action :create do
+        # some action code because we're in a custom resource
+      end
+    RUBY
+  end
+
+  it 'does not register an offense with a custom resource that does not use allowed_actions or actions methods' do
     expect_no_violations(<<-RUBY)
       property :something, String
 
@@ -41,11 +53,19 @@ describe RuboCop::Cop::Chef::CustomResourceWithAllowedActions, :config do
     RUBY
   end
 
-  it 'does not register an offense with a LWRP that uses allowed_actions' do
+  it 'does not register an offense with a LWRP that uses allowed_actions method' do
     expect_no_violations(<<-RUBY)
       attribute :something, String
 
       allowed_actions [:create, :remove]
+    RUBY
+  end
+
+  it 'does not register an offense with a LWRP that uses actions method' do
+    expect_no_violations(<<-RUBY)
+      attribute :something, String
+
+      actions [:create, :remove]
     RUBY
   end
 end


### PR DESCRIPTION
Detect when a custom resource uses allowed_actions, which is no longer necessary.

Signed-off-by: Tim Smith <tsmith@chef.io>