### PR TITLE
Autocorrect Apache v2.0 license to Apache-2.0

### DIFF
--- a/lib/rubocop/cop/chef/correctness/invalid_license_string.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_license_string.rb
@@ -440,6 +440,7 @@ module RuboCop
         COMMON_TYPOS = {
           "all_rights": 'all rights reserved',
           "apache 2.0": 'Apache-2.0',
+          "apache v2.0": 'Apache-2.0',
           "apache license version 2.0": 'Apache-2.0',
           "apache2": 'Apache-2.0',
           "mit": 'MIT',


### PR DESCRIPTION
A ran into this one as well. Seems like that might be common.

Signed-off-by: Tim Smith <tsmith@chef.io>