### PR TITLE
Add Chef/ExecuteAptUpdate rule

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -321,6 +321,13 @@ Chef/DefinesChefSpecMatchers:
   Include:
     - '**/libraries/*.rb'
 
+Chef/ExecuteAptUpdate:
+  Description: Use the apt_update resource instead of the execute resource to run an apt-get update package cache update
+  Enabled: true
+  VersionAdded: '5.3.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # Detecting code that breaks Chef
 ###############################

--- a/lib/rubocop/cop/chef/modernize/execute_apt_update.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_apt_update.rb
@@ -1,0 +1,44 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      # Instead of using the execute resource to to run the `apt-get update` use Chef Infra Client's built-n
+      # apt_update resource which is available in Chef Infra Client 12.7 and later.
+      #
+      #   # bad
+      #   execute 'apt-get update'
+      #
+      #   # good
+      #   apt_update
+      #
+      class ExecuteAptUpdate < Cop
+        MSG = 'Use the apt_update resource instead of the execute resource to run an apt-get update package cache update'.freeze
+
+        def_node_matcher :execute_apt_update?, <<-PATTERN
+          (send nil? :execute (str "apt-get update"))
+        PATTERN
+
+        def on_send(node)
+          execute_apt_update?(node) do
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/execute_apt_update_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/execute_apt_update_spec.rb
@@ -1,0 +1,38 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ExecuteAptUpdate, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an when using execute to run apt-get update' do
+    expect_offense(<<~RUBY)
+    execute 'apt-get update' do
+    ^^^^^^^^^^^^^^^^^^^^^^^^ Use the apt_update resource instead of the execute resource to run an apt-get update package cache update
+      command 'apt-get update'
+    end
+    RUBY
+  end
+
+  it "doesn't register an offense when running another command in an execute resource" do
+    expect_no_offenses(<<~RUBY)
+      execute 'foo' do
+        command 'bar'
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Detect when someone is using execute to run apt-get update. This catches
the most basic offense of this. Once I have more advanced resource
inspection I'll catch commands in an execute that has a friendly
resource name.

Signed-off-by: Tim Smith <tsmith@chef.io>