### PR TITLE
Fix autocorrection of comments that are indented with more than one space

### DIFF
--- a/lib/rubocop/cop/chef/style/comments_format.rb
+++ b/lib/rubocop/cop/chef/style/comments_format.rb
@@ -56,7 +56,8 @@ module RuboCop
         def autocorrect(comment)
           # Extract the type and the actual value. Strip out "Name" or "File"
           # 'Cookbook Name' should be 'Cookbook'. Also skip a :: if present
-          match = /^# ?([A-Za-z]+)\s?(?:Name|File)?(?:::)?\s(.*)/.match(comment.text)
+          # https://rubular.com/r/Do9fpLWXlCmvdJ
+          match = /^#\s*([A-Za-z]+)\s?(?:Name|File)?(?:::)?\s(.*)/.match(comment.text)
           comment_type, value = match.captures
           correct_comment = "# #{comment_type}:: #{value}"
 


### PR DESCRIPTION
Our regex would only work with a single space. This corrects that.

Signed-off-by: Tim Smith <tsmith@chef.io>