### PR TITLE
Add Chef/NodeMethodsInsteadofAttributes cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -205,6 +205,13 @@ Chef/RequireRecipe:
   Enabled: true
   VersionAdded: '5.2.0'
 
+Chef/NodeMethodsInsteadofAttributes:
+  Description: Use node attributes to access Ohai data instead of node methods, which were deprecated in Chef Infra Client 13.
+  Enabled: true
+  VersionAdded: '5.4.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # Cleaning up Legacy Code
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
@@ -39,7 +39,7 @@ module RuboCop
         MSG = 'Use node attributes to access Ohai data instead of node methods, which were deprecated in Chef Infra Client 13.'.freeze
 
         def_node_matcher :node_ohai_methods?, <<-PATTERN
-          (send (send nil? :node) ${:fqdn :platform :platform_version :platform_family :hostname})
+          (send (send nil? :node) #non_nested_ohai_attribute?)
         PATTERN
 
         def on_send(node)
@@ -52,6 +52,31 @@ module RuboCop
           lambda do |corrector|
             corrector.replace(node.loc.expression, "node['#{node.method_name}']")
           end
+        end
+
+        private
+
+        def non_nested_ohai_attribute?(attribute)
+          %i(
+            current_user
+            domain
+            fqdn
+            hostname
+            ip6address
+            ipaddress
+            macaddress
+            machinename
+            ohai_time
+            os
+            os_version
+            platform
+            platform_build
+            platform_family
+            platform_version
+            root_group
+            shard_seed
+            uptime
+            uptime_seconds).include?(attribute)
         end
       end
     end

--- a/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
@@ -1,0 +1,59 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      # Incorrectly using node methods for Ohai data when you really want node attributes
+      #
+      # @example
+      #
+      #   # bad
+      #   node.fqdn
+      #   node.platform
+      #   node.platform_family
+      #   node.platform_version
+      #   node.hostname
+      #
+      #   # good
+      #   node['fqdn']
+      #   node['platform']
+      #   node['platform_family']
+      #   node['platform_version']
+      #   node['hostname']
+      #
+      class NodeMethodsInsteadofAttributes < Cop
+        MSG = 'Use node attributes to access Ohai data instead of node methods, which were deprecated in Chef Infra Client 13.'.freeze
+
+        def_node_matcher :node_ohai_methods?, <<-PATTERN
+          (send (send nil? :node) ${:fqdn :platform :platform_version :platform_family :hostname})
+        PATTERN
+
+        def on_send(node)
+          node_ohai_methods?(node) do
+            add_offense(node, location: :selector, message: MSG, severity: :refactor)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.loc.expression, "node['#{node.method_name}']")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/node_methods_not_attributes_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/node_methods_not_attributes_spec.rb
@@ -1,0 +1,76 @@
+#
+# Copyright:: Copyright 2019, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::NodeMethodsInsteadofAttributes, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using node.platform', :config do
+    expect_offense(<<~RUBY)
+      node.platform
+           ^^^^^^^^ Use node attributes to access Ohai data instead of node methods, which were deprecated in Chef Infra Client 13.
+    RUBY
+
+    expect_correction(<<~RUBY)
+    node['platform']
+    RUBY
+  end
+
+  it 'registers an offense when using node.platform_family', :config do
+    expect_offense(<<~RUBY)
+      node.platform_family
+           ^^^^^^^^^^^^^^^ Use node attributes to access Ohai data instead of node methods, which were deprecated in Chef Infra Client 13.
+    RUBY
+
+    expect_correction(<<~RUBY)
+    node['platform_family']
+    RUBY
+  end
+
+  it 'registers an offense when using node.platform_version', :config do
+    expect_offense(<<~RUBY)
+      node.platform_version
+           ^^^^^^^^^^^^^^^^ Use node attributes to access Ohai data instead of node methods, which were deprecated in Chef Infra Client 13.
+    RUBY
+
+    expect_correction(<<~RUBY)
+    node['platform_version']
+    RUBY
+  end
+
+  it 'registers an offense when using node.fqdn', :config do
+    expect_offense(<<~RUBY)
+      node.fqdn
+           ^^^^ Use node attributes to access Ohai data instead of node methods, which were deprecated in Chef Infra Client 13.
+    RUBY
+
+    expect_correction(<<~RUBY)
+    node['fqdn']
+    RUBY
+  end
+
+  it 'registers an offense when using node.hostname', :config do
+    expect_offense(<<~RUBY)
+      node.hostname
+           ^^^^^^^^ Use node attributes to access Ohai data instead of node methods, which were deprecated in Chef Infra Client 13.
+    RUBY
+
+    expect_correction(<<~RUBY)
+    node['hostname']
+    RUBY
+  end
+end


### PR DESCRIPTION
This detects changes due our the removal of the node method missing behavior in Chef 13. I'm not calling it that because no one knows what method missing is who just needs to clean up some cookbooks. This catches the bad methods we can be 100% sure of. There's 250 of these on the supermarket. Obviously it's not going to catch all your cookbook attributes, but it gets you a bit closer.

Signed-off-by: Tim Smith <tsmith@chef.io>