### PR TITLE
Add Chef/DefaultMetadataMaintainer

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -55,6 +55,13 @@ Chef/CommentFormat:
   Enabled: true
   VersionAdded: '5.0.0'
 
+Chef/DefaultMetadataMaintainer:
+  Description: Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.
+  Enabled: true
+  VersionAdded: '5.4.0'
+  Include:
+    - '**/metadata.rb'
+
 ###############################
 # Avoiding potential problems
 ###############################

--- a/lib/rubocop/cop/chef/correctness/default_maintainer_metadata.rb
+++ b/lib/rubocop/cop/chef/correctness/default_maintainer_metadata.rb
@@ -1,0 +1,48 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      # Metadata contains default maintainer information from the `chef generate cookbook`
+      # command. This should be updated to reflect that actual maintainer of the cookbook.
+      #
+      # @example
+      #
+      #   # bad
+      #   maintainer 'YOUR_COMPANY_NAME'
+      #   maintainer_email 'YOUR_EMAIL'
+      #
+      #   # good
+      #   maintainer 'Bob Bobberson'
+      #   maintainer_email 'bob@bobberson.com'
+      #
+
+      class DefaultMetadataMaintainer < Cop
+        MSG = 'Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.'.freeze
+
+        def_node_matcher :default_metadata?, '(send nil? {:maintainer :maintainer_email} (str {"YOUR_COMPANY_NAME" "YOUR_EMAIL"}))'
+
+        def on_send(node)
+          default_metadata?(node) do
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/default_maintainer_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/default_maintainer_metadata_spec.rb
@@ -1,0 +1,41 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::DefaultMetadataMaintainer, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a cookbook uses the default maintainer from the generator' do
+    expect_offense(<<~RUBY)
+      maintainer 'YOUR_COMPANY_NAME'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.
+    RUBY
+  end
+
+  it 'registers an offense when a cookbook the default default maintainer_email from the generator' do
+    expect_offense(<<~RUBY)
+      maintainer_email 'YOUR_EMAIL'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.
+    RUBY
+  end
+
+  it "doesn't register an offense with a unique maintainer" do
+    expect_no_offenses(<<~RUBY)
+      maintainer 'Tim Smith'
+    RUBY
+  end
+end


### PR DESCRIPTION
This is a port of a Foodcritic rule

Signed-off-by: Tim Smith <tsmith@chef.io>