### PR TITLE
Add autocorrect to MetadataMissingName

### DIFF
--- a/lib/rubocop/cop/chef/correctness/metadata_missing_name.rb
+++ b/lib/rubocop/cop/chef/correctness/metadata_missing_name.rb
@@ -40,6 +40,16 @@ module RuboCop
         end
 
         def_node_search :cb_name, '(send nil? :name str ...)'
+
+        def autocorrect(_node)
+          lambda do |_corrector|
+            path = processed_source.path
+            cb_name = File.basename(File.dirname(path))
+
+            metadata = IO.read(path)
+            IO.write(path, "name '#{cb_name}'\n" + metadata)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This adds a name field based on the cookbook folder name. That's not
100% accurate, but it's is almost all the time, which is good enough. I'm
also using IO here since metadata.rb has a relatively small amount of
data and this is a much simpler was to dump some data into the file.

Signed-off-by: Tim Smith <tsmith@chef.io>