### PR TITLE
Exclude the files directory for scans

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1,6 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.4
   Exclude:
+    - files/**/*
     - vendor/**/*
     - Guardfile
   ChefAttributes:


### PR DESCRIPTION
This will only work when you're in the root of a cookbook, but that's
the safe way to do it.

Fixes #247 

Signed-off-by: Tim Smith <tsmith@chef.io>