### PR TITLE
Add Chef/IncludingMixinShelloutInResources cop

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-### 9 New Chef Cops
+### 10 New Chef Cops
 
 #### Chef/IncludingOhaiDefaultRecipe
 
@@ -19,6 +19,8 @@
 #### Chef/WindowsZipfileUsage
 
 #### Chef/NodeMethodsInsteadofAttributes
+
+#### Chef/IncludingMixinShelloutInResources
 
 ### Other fixes and changes
 

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -251,6 +251,14 @@ Chef/UsesDeprecatedMixins:
     - '**/libraries/*.rb'
     - '**/providers/*.rb'
 
+Chef/IncludingMixinShelloutInResources:
+  Description: There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client.
+  Enabled: true
+  VersionAdded: '5.4.0'
+  Include:
+    - '**/resources/*.rb'
+    - '**/providers/*.rb'
+
 Chef/LegacyYumCookbookRecipes:
   Description: The elrepo, epel, ius, remi, and repoforge recipes were split into their own cookbooks and the yum recipe was renamed to be default with the release of yum cookbook 3.0 (Dec 2013).
   Enabled: true

--- a/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
+++ b/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
@@ -27,7 +27,7 @@ module RuboCop
       #   include Chef::Mixin::ShellOut
 
       class IncludingMixinShelloutInResources < Cop
-        MSG = "There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client.".freeze
+        MSG = 'There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client.'.freeze
 
         def_node_matcher :include_shellout?, <<-PATTERN
           (send nil? :include (const (const (const nil? :Chef) :Mixin) :ShellOut))

--- a/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
+++ b/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
@@ -1,0 +1,58 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      # There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client.
+      #
+      # @example
+      #
+      #   # bad
+      #   require 'chef/mixin/shell_out'
+      #   include Chef::Mixin::ShellOut
+
+      class IncludingMixinShelloutInResources < Cop
+        MSG = "There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client.".freeze
+
+        def_node_matcher :include_shellout?, <<-PATTERN
+          (send nil? :include (const (const (const nil? :Chef) :Mixin) :ShellOut))
+        PATTERN
+
+        def_node_matcher :require_shellout?, <<-PATTERN
+          (send nil? :require ( str "chef/mixin/shell_out"))
+        PATTERN
+
+        def on_send(node)
+          require_shellout?(node) do
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
+          end
+
+          include_shellout?(node) do
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.remove(node.loc.expression)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/apt_default_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/apt_default_recipe_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::IncludingAptDefaultRecipe, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an when including the "apt" recipe' do
+  it 'registers an offense when including the "apt" recipe' do
     expect_offense(<<~RUBY)
       include_recipe 'apt'
       ^^^^^^^^^^^^^^^^^^^^ Do not include the Apt default recipe to update package cache. Instead use the apt_update resource, which is built into Chef Infra Client 12.7 and later.

--- a/spec/rubocop/cop/chef/modernize/build_essential_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/build_essential_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::UseBuildEssentialResource, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an when including the "build-essential" recipe' do
+  it 'registers an offense when including the "build-essential" recipe' do
     expect_offense(<<~RUBY)
       include_recipe 'build-essential'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+

--- a/spec/rubocop/cop/chef/modernize/execute_apt_update_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/execute_apt_update_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ExecuteAptUpdate, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an when using execute to run apt-get update' do
+  it 'registers an offense when using execute to run apt-get update' do
     expect_offense(<<~RUBY)
     execute 'apt-get update' do
     ^^^^^^^^^^^^^^^^^^^^^^^^ Use the apt_update resource instead of the execute resource to run an apt-get update package cache update

--- a/spec/rubocop/cop/chef/modernize/includes_mixin_shellout_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/includes_mixin_shellout_spec.rb
@@ -1,0 +1,50 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::IncludingMixinShelloutInResources, :config do
+  subject(:cop) { described_class.new(config) }
+
+      #
+      #   include Chef::Mixin::ShellOut
+
+  it 'registers an error when requiring "chef/mixin/shell_out"' do
+    expect_offense(<<~RUBY)
+    require 'chef/mixin/shell_out'
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client.
+    RUBY
+  end
+
+  it 'registers an error when including "Chef::Mixin::ShellOut"' do
+    expect_offense(<<~RUBY)
+    include Chef::Mixin::ShellOut
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client.
+    RUBY
+  end
+
+  it "doesn't register an offense when including Chef::Mixin::Foo" do
+    expect_no_offenses(<<~RUBY)
+    include Chef::Mixin::Foo
+    RUBY
+  end
+
+  it "doesn't register an offense when requirinng chef/mixin/foo" do
+    expect_no_offenses(<<~RUBY)
+    require 'chef/mixin/foo'
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/includes_mixin_shellout_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/includes_mixin_shellout_spec.rb
@@ -19,9 +19,6 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::IncludingMixinShelloutInResources, :config do
   subject(:cop) { described_class.new(config) }
 
-      #
-      #   include Chef::Mixin::ShellOut
-
   it 'registers an error when requiring "chef/mixin/shell_out"' do
     expect_offense(<<~RUBY)
     require 'chef/mixin/shell_out'

--- a/spec/rubocop/cop/chef/modernize/windows_default_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/windows_default_recipe_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::IncludingWindowsDefaultRecipe, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an when including the "windows" recipe' do
+  it 'registers an offense when including the "windows" recipe' do
     expect_offense(<<~RUBY)
       include_recipe 'windows'
       ^^^^^^^^^^^^^^^^^^^^^^^^ Do not include the Windows default recipe, which only installs win32 gems already included in Chef Infra Client

--- a/spec/rubocop/cop/chef/modernize/windows_version_helper_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/windows_version_helper_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::WindowsVersionHelper, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an when using execute to run apt-get update' do
+  it 'registers an offense when using execute to run apt-get update' do
     expect_offense(<<~RUBY)
     if Windows::VersionHelper.nt_version == 10
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['platform_version'] data instead of the Windows::VersionHelper helper from the Windows cookbook.

--- a/spec/rubocop/cop/chef/modernize/windows_zipfile_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/windows_zipfile_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::WindowsZipfileUsage, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an when including the "build-essential" recipe' do
+  it 'registers an offense when including the "build-essential" recipe' do
     expect_offense(<<~RUBY)
       windows_zipfile 'Precompiled.zip' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the archive_file resource built into Chef Infra Client 15+ instead of the windows_zipfile from the Windows cookbook


### PR DESCRIPTION
Detect when someone is requiring / including the shellout mixin within a custom resource or LWRP. You don't need to do that.

Signed-off-by: Tim Smith <tsmith@chef.io>