### PR TITLE
Add Chef/LibarchiveFile and Chef/SevenZipArchiveResource

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -397,13 +397,6 @@ Chef/ExecuteAptUpdate:
   Exclude:
     - '**/metadata.rb'
 
-Chef/WindowsZipfileUsage:
-  Description: Use the archive_file resource built into Chef Infra Client 15+ instead of the windows_zipfile from the Windows cookbook
-  Enabled: true
-  VersionAdded: '5.4.0'
-  Exclude:
-    - '**/metadata.rb'
-
 Chef/WindowsVersionHelper:
   Description: Use node['platform_version'] data instead of the Windows::VersionHelper helper from the Windows cookbook.
   Enabled: true
@@ -472,6 +465,29 @@ Chef/UseBuildEssentialResource:
   Description: Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+
   Enabled: true
   VersionAdded: '5.1.0'
+  Exclude:
+    - '**/metadata.rb'
+
+Chef/WindowsZipfileUsage:
+  Description: Use the archive_file resource built into Chef Infra Client 15+ instead of the windows_zipfile from the Windows cookbook
+  Enabled: true
+  VersionAdded: '5.5.0'
+  Exclude:
+    - '**/metadata.rb'
+
+Chef/SevenZipArchiveResource:
+  Description: Use the archive_file resource built into Chef Infra Client 15+ instead of the seven_zip_archive
+  Enabled: true
+  VersionAdded: '5.5.0'
+  Exclude:
+    - '**/metadata.rb'
+
+Chef/LibarchiveFileResource:
+  Description: Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource
+  Enabled: true
+  VersionAdded: '5.5.0'
+  Exclude:
+    - '**/metadata.rb'
 
 ###############################
 # Migrating to new patterns

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -471,7 +471,7 @@ Chef/UseBuildEssentialResource:
 Chef/WindowsZipfileUsage:
   Description: Use the archive_file resource built into Chef Infra Client 15+ instead of the windows_zipfile from the Windows cookbook
   Enabled: true
-  VersionAdded: '5.5.0'
+  VersionAdded: '5.4.0'
   Exclude:
     - '**/metadata.rb'
 

--- a/lib/rubocop/cop/chef/modernize/libarchive_file.rb
+++ b/lib/rubocop/cop/chef/modernize/libarchive_file.rb
@@ -1,0 +1,39 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      # Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive_file resource
+      #
+      # @example
+      #
+      #   # bad
+      #   libarchive "C:\file.zip" do
+      #     path 'C:\expand_here'
+      #   end
+      #
+      class LibarchiveFileResource < Cop
+        MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource'.freeze
+
+        def on_send(node)
+          add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :libarchive_file
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
@@ -1,0 +1,39 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      # Use the archive_file resource built into Chef Infra Client 15+ instead of the seven_zip_archive
+      #
+      # @example
+      #
+      #   # bad
+      #   seven_zip_archive "C:\file.zip" do
+      #     path 'C:\expand_here'
+      #   end
+      #
+      class SevenZipArchiveResource < Cop
+        MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the seven_zip_archive'.freeze
+
+        def on_send(node)
+          add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :seven_zip_archive
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/libarchive_file_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/libarchive_file_spec.rb
@@ -1,0 +1,40 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::LibarchiveFileResource, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using the libarchive_file resource' do
+    expect_offense(<<~RUBY)
+    libarchive_file 'Precompiled.zip' do
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource
+      path "foo/bar.zip"
+      extract_to "/foo/bar"
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when using the archive_file resource" do
+    expect_no_offenses(<<~RUBY)
+      archive_file 'Precompiled.zip' do
+        path '/tmp/Precompiled.zip'
+        destination '/srv/files'
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/seven_zip_archive_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/seven_zip_archive_spec.rb
@@ -1,0 +1,40 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::SevenZipArchiveResource, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using the seven_zip_archive resource" recipe' do
+    expect_offense(<<~RUBY)
+    seven_zip_archive 'extract files' do
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the archive_file resource built into Chef Infra Client 15+ instead of the seven_zip_archive
+      path 'C:\path'
+      source 'C:\file.zip'
+    end
+    RUBY
+  end
+
+  it "doesn't register an offense when using the archive_file resource" do
+    expect_no_offenses(<<~RUBY)
+      archive_file 'Precompiled.zip' do
+        path '/tmp/Precompiled.zip'
+        destination '/srv/files'
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Get people using the built in archive_file resource instead of external dependencies.

Signed-off-by: Tim Smith <tsmith@chef.io>