### PR TITLE
Validate that all cops are in the config in CI + add missing Chef/CookbookUsesNodeSave

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ end
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
-  spec.pattern = FileList['spec/**/*_spec.rb']
+  spec.pattern = FileList['spec/cop/**/*.rb']
 end
 
 desc 'Run RSpec with code coverage'

--- a/Rakefile
+++ b/Rakefile
@@ -36,9 +36,26 @@ task :coverage do
   Rake::Task['spec'].execute
 end
 
-desc 'Run RuboCop over this gem'
+desc 'Run Cookstyle over this gem'
 task :internal_investigation do
-  sh('bundle exec rubocop --require rubocop-rspec')
+  sh('bundle exec cookstyle')
+end
+
+desc 'Ensure that all cops are defined in the cookstyle.yml config'
+task :validate_config do
+  require 'cookstyle'
+  require 'yaml'
+  status = 0
+  config = YAML.load_file('config/cookstyle.yml')
+
+  RuboCop::Cop::Chef.constants.each do |cop|
+    unless config["Chef/#{cop}"]
+      puts "Error: Chef/#{cop} not found in config/cookstyle.yml"
+      status = 1
+    end
+  end
+
+  exit status
 end
 
 begin

--- a/Rakefile
+++ b/Rakefile
@@ -20,9 +20,8 @@ task :vendor do
 end
 
 require 'cookstyle'
-require 'rubocop/rake_task'
-RuboCop::RakeTask.new(:style) do |task|
-  task.options << '--display-cop-names'
+task :style do
+  sh('bundle exec cookstyle')
 end
 
 require 'rspec/core/rake_task'
@@ -36,11 +35,6 @@ task :coverage do
   Rake::Task['spec'].execute
 end
 
-desc 'Run Cookstyle over this gem'
-task :internal_investigation do
-  sh('bundle exec cookstyle')
-end
-
 desc 'Ensure that all cops are defined in the cookstyle.yml config'
 task :validate_config do
   require 'cookstyle'
@@ -48,12 +42,16 @@ task :validate_config do
   status = 0
   config = YAML.load_file('config/cookstyle.yml')
 
+  puts 'Checking that all cops are defined in config/cookstyle.yml:'
+
   RuboCop::Cop::Chef.constants.each do |cop|
     unless config["Chef/#{cop}"]
       puts "Error: Chef/#{cop} not found in config/cookstyle.yml"
       status = 1
     end
   end
+
+  puts 'All Cops found in the config. Good work.' if status == 0
 
   exit status
 end
@@ -71,4 +69,4 @@ task :console do
   ARGV.clear
   IRB.start
 end
-task default: [:style, :spec]
+task default: [:style, :spec, :validate_config]

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -128,6 +128,13 @@ Chef/InvalidPlatformMetadata:
   Include:
     - '**/metadata.rb'
 
+Chef/CookbookUsesNodeSave:
+  Description: Don't use node.save to save partial node data to the Chef Infra Server mid-run unless it's absolutely necessary. Node.save can result in failed Chef Infra runs appearing in search and increases load on the Chef Infra Server.
+  Enabled: true
+  VersionAdded: '5.5.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # Resolving Deprecations
 ###############################

--- a/lib/rubocop/cop/chef/correctness/node_save.rb
+++ b/lib/rubocop/cop/chef/correctness/node_save.rb
@@ -24,7 +24,7 @@ module RuboCop
       #   # bad
       #   node.save
       class CookbookUsesNodeSave < Cop
-        MSG = 'Do not use node.save with Effortless as there is no server to save node state back to'.freeze
+        MSG = "Don't use node.save to save partial node data to the Chef Infra Server mid-run unless it's absolutely necessary. Node.save can result in failed Chef Infra runs appearing in search and increases load on the Chef Infra Server.".freeze
 
         def_node_matcher :node_save?, <<-PATTERN
           (send (send nil? :node) :save)

--- a/lib/rubocop/cop/chef/correctness/node_save.rb
+++ b/lib/rubocop/cop/chef/correctness/node_save.rb
@@ -17,7 +17,9 @@
 module RuboCop
   module Cop
     module Chef
-      # Do not use node.save with effortless as there is no server to save node state back to
+      # Don't use node.save to save partial node data to the Chef Infra Server mid-run unless it's
+      # absolutely necessary. Node.save can result in failed Chef Infra runs appearing in search and
+      # increases load on the Chef Infra Server."
       #
       # @example
       #


### PR DESCRIPTION
Add a rake task to check that all cops are in the config file. This will run in Buildkite and keep me from missing cops in the config. This also moves and enables Chef/CookbookUsesNodeSave which snuck in but was missing in the config. 