### PR TITLE
Catch additional formats for default maintainer information in metadata

### DIFF
--- a/lib/rubocop/cop/chef/correctness/default_maintainer_metadata.rb
+++ b/lib/rubocop/cop/chef/correctness/default_maintainer_metadata.rb
@@ -26,7 +26,8 @@ module RuboCop
       #   # bad
       #   maintainer 'YOUR_COMPANY_NAME'
       #   maintainer_email 'YOUR_EMAIL'
-      #
+      #   maintainer 'The Authors'
+      #   maintainer_email 'you@example.com'
       #   # good
       #   maintainer 'Bob Bobberson'
       #   maintainer_email 'bob@bobberson.com'
@@ -35,7 +36,7 @@ module RuboCop
       class DefaultMetadataMaintainer < Cop
         MSG = 'Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.'.freeze
 
-        def_node_matcher :default_metadata?, '(send nil? {:maintainer :maintainer_email} (str {"YOUR_COMPANY_NAME" "YOUR_EMAIL"}))'
+        def_node_matcher :default_metadata?, '(send nil? {:maintainer :maintainer_email} (str {"YOUR_COMPANY_NAME" "The Authors" "YOUR_EMAIL" "you@example.com"}))'
 
         def on_send(node)
           default_metadata?(node) do

--- a/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
@@ -18,7 +18,7 @@
 module RuboCop
   module Cop
     module Chef
-      # The long_description metadata.rb method is not used and is unnecessary in cookbooks
+      # Don't use deprecated Mixins no longer included in Chef Infra Client 14 and later
       #
       # @example
       #
@@ -28,9 +28,9 @@ module RuboCop
       #   include Chef::Mixin::LanguageIncludeRecipe
       #   include Chef::Mixin::Language
       #   include Chef::DSL::Recipe::FullDSL
-      #   require 'chef/mixin/language
-      #   require 'chef/mixin/language_include_attribute
-      #   require 'chef/mixin/language_include_recipe
+      #   require 'chef/mixin/language'
+      #   require 'chef/mixin/language_include_attribute'
+      #   require 'chef/mixin/language_include_recipe'
 
       class UsesDeprecatedMixins < Cop
         MSG = "Don't use deprecated Mixins no longer included in Chef Infra Client 14 and later.".freeze

--- a/spec/rubocop/cop/chef/correctness/default_maintainer_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/default_maintainer_metadata_spec.rb
@@ -26,7 +26,21 @@ describe RuboCop::Cop::Chef::DefaultMetadataMaintainer, :config do
     RUBY
   end
 
-  it 'registers an offense when a cookbook the default default maintainer_email from the generator' do
+  it 'registers an offense when a cookbook the default maintainer_email from the generator' do
+    expect_offense(<<~RUBY)
+      maintainer_email 'YOUR_EMAIL'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.
+    RUBY
+  end
+
+  it 'registers an offense when a cookbook uses the alt maintainer format from the generator' do
+    expect_offense(<<~RUBY)
+      maintainer 'YOUR_COMPANY_NAME'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.
+    RUBY
+  end
+
+  it 'registers an offense when a cookbook the alt maintainer_email from the generator' do
     expect_offense(<<~RUBY)
       maintainer_email 'YOUR_EMAIL'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.

--- a/spec/rubocop/cop/chef/correctness/default_maintainer_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/default_maintainer_metadata_spec.rb
@@ -35,15 +35,15 @@ describe RuboCop::Cop::Chef::DefaultMetadataMaintainer, :config do
 
   it 'registers an offense when a cookbook uses the alt maintainer format from the generator' do
     expect_offense(<<~RUBY)
-      maintainer 'YOUR_COMPANY_NAME'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.
+      maintainer 'The Authors'
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.
     RUBY
   end
 
   it 'registers an offense when a cookbook the alt maintainer_email from the generator' do
     expect_offense(<<~RUBY)
-      maintainer_email 'YOUR_EMAIL'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.
+      maintainer_email 'you@example.com'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.
     RUBY
   end
 


### PR DESCRIPTION
This is the format we use in the generator now

Signed-off-by: Tim Smith <tsmith@chef.io>