### PR TITLE
Add ChefDeprecations/RecipeMetadata cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -274,6 +274,13 @@ ChefDeprecations/LongDescriptionMetadata:
   Include:
     - '**/metadata.rb'
 
+ChefDeprecations/RecipeMetadata:
+  Description: The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the README.md file instead.
+  Enabled: true
+  VersionAdded: '5.6.0'
+  Include:
+    - '**/metadata.rb'
+
 ChefDeprecations/CookbookDependsOnCompatResource:
   Description: Don't depend on the deprecated compat_resource cookbook made obsolete by Chef 12.19+
   Enabled: true

--- a/lib/rubocop/cop/chef/deprecation/recipe_metadata.rb
+++ b/lib/rubocop/cop/chef/deprecation/recipe_metadata.rb
@@ -1,0 +1,47 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented
+        # in the README.md file instead.
+        #
+        # @example
+        #
+        #   # bad
+        #   recipe 'openldap::default', 'Install and configure OpenLDAP'
+        #
+        #
+        class RecipeMetadata < Cop
+          MSG = 'The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the README.md file instead.'.freeze
+
+          def on_send(node)
+            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :recipe
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.remove(node.loc.expression)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/recipe_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/recipe_metadata_spec.rb
@@ -1,0 +1,36 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::RecipeMetadata, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when metadata uses "recipe"' do
+    expect_offense(<<~RUBY)
+      recipe 'chef-client::config', 'Configures the client.rb from a template.'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the README.md file instead.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense on normal metadata" do
+    expect_no_offenses(<<~RUBY)
+      depends 'foo'
+    RUBY
+  end
+end


### PR DESCRIPTION
Detect recipe metadata and remove it. Metadata.rb is for machines and they don't use this data. Document this stuff in the readme.md instead.

Signed-off-by: Tim Smith <tsmith@chef.io>