### PR TITLE
Add ChefDeprecations/WindowsTaskChangeAction

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -390,6 +390,13 @@ ChefDeprecations/IncludingYumDNFCompatRecipe:
   Exclude:
     - '**/metadata.rb'
 
+ChefDeprecations/WindowsTaskChangeAction:
+  Description: The :change action in the windows_task resource was removed when windows_task was added to Chef Infra Client 13+. The default action of :create should can now be used to create an update tasks.
+  Enabled: true
+  VersionAdded: '5.6.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
@@ -1,0 +1,82 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # The :change action in the windows_task resource was removed when windows_task was added to Chef Infra Client 13+
+        # The default action of :create should can now be used to create an update tasks.
+        #
+        # @example
+        #
+        #   # bad
+        #   windows_task 'chef ad-join leave start time' do
+        #     task_name 'chef ad-join leave'
+        #     start_day '06/09/2016'
+        #     start_time '01:00'
+        #     action [:change, :create]
+        #   end
+        #
+        #   # good
+        #   windows_task 'chef ad-join leave start time' do
+        #     task_name 'chef ad-join leave'
+        #     start_day '06/09/2016'
+        #     start_time '01:00'
+        #     action :create
+        #   end
+        #
+        class WindowsTaskChangeAction < Cop
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'The :change action in the windows_task resource was removed when windows_task was added to Chef Infra Client 13+. The default action of :create should can now be used to create an update tasks.'.freeze
+
+          def on_block(node)
+            match_property_in_resource?(:windows_task, 'action', node) do |action_node|
+              action_values = action_node.arguments.first
+
+              if action_values.sym_type? # there's only a single action given
+                check_action(action_values)
+              else # it was an array of actions
+                action_values.node_parts.each { |action| check_action(action) }
+              end
+            end
+          end
+
+          def autocorrect(node)
+            if node.parent.send_type? # :change was the only action
+              lambda do |corrector|
+                corrector.replace(node.loc.expression, ':create')
+              end
+            # chances are it's [:create, :change] since that's all that makes sense, but double check that theory
+            elsif node.parent.child_nodes.count == 2 &&
+                  node.parent.child_nodes.map(&:value).sort == [:change, :create]
+              lambda do |corrector|
+                corrector.replace(node.parent.loc.expression, ':create')
+              end
+            end
+          end
+
+          private
+
+          def check_action(ast_obj)
+            add_offense(ast_obj, location: :expression, message: MSG, severity: :refactor) if ast_obj.value == :change
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/windows_task_change_action_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/windows_task_change_action_spec.rb
@@ -1,0 +1,74 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::WindowsTaskChangeAction, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when windows_task uses the :change action' do
+    expect_offense(<<~RUBY)
+      windows_task 'chef ad-join leave start time' do
+        task_name 'chef ad-join leave'
+        start_day '06/09/2016'
+        start_time '01:00'
+        action :change
+               ^^^^^^^ The :change action in the windows_task resource was removed when windows_task was added to Chef Infra Client 13+. The default action of :create should can now be used to create an update tasks.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      windows_task 'chef ad-join leave start time' do
+        task_name 'chef ad-join leave'
+        start_day '06/09/2016'
+        start_time '01:00'
+        action :create
+      end
+    RUBY
+  end
+
+  it 'registers an offense when windows_task uses the :change action along with another action' do
+    expect_offense(<<~RUBY)
+      windows_task 'chef ad-join leave start time' do
+        task_name 'chef ad-join leave'
+        start_day '06/09/2016'
+        start_time '01:00'
+        action [:change, :create]
+                ^^^^^^^ The :change action in the windows_task resource was removed when windows_task was added to Chef Infra Client 13+. The default action of :create should can now be used to create an update tasks.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      windows_task 'chef ad-join leave start time' do
+        task_name 'chef ad-join leave'
+        start_day '06/09/2016'
+        start_time '01:00'
+        action :create
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when windows_task uses the :create action" do
+    expect_no_offenses(<<~RUBY)
+      windows_task 'chef ad-join leave start time' do
+        task_name 'chef ad-join leave'
+        start_day '06/09/2016'
+        start_time '01:00'
+        action :create
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Catch the use of the old :change action. The cleanup in the autocorrect is a bit funky because we have to handle these two scenarios

action :change -> action :create
action [:create, :change] -> action :create

Signed-off-by: Tim Smith <tsmith@chef.io>