### PR TITLE
Fix autocorrection of multiple platform helpers in a recipe

### DIFF
--- a/lib/rubocop/cop/chef/style/use_platform_helpers.rb
+++ b/lib/rubocop/cop/chef/style/use_platform_helpers.rb
@@ -38,18 +38,16 @@ module RuboCop
           PATTERN
 
           def on_send(node)
-            platform_check?(node) do |type, plat|
-              # set these so we can use them in the auto_correct method
-              @type = type
-              @plat = plat
-
+            platform_check?(node) do
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
           end
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.replace(node.loc.expression, "#{@type.value}?('#{@plat.value}')")
+              platform_check?(node) do |type, plat|
+                corrector.replace(node.loc.expression, "#{type.value}?('#{plat.value}')")
+              end
             end
           end
         end


### PR DESCRIPTION
This is a major facepalm here and looking back it makes total sense. All the on_* hooks run and then all the autocorrects run. That means when I set @type and @plat they'd get used by all the autocorrectors and every node['platform'
] == 'foo' would be autocorrected to the last platform found in the recipe.

resolves #301

Signed-off-by: Tim Smith <tsmith@chef.io>