### PR TITLE
Remove the newline when autocorrecting long_description in metadata

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/long_description_metadata.rb
+++ b/lib/rubocop/cop/chef/deprecation/long_description_metadata.rb
@@ -44,7 +44,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression))
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/long_description_metadata.rb
+++ b/lib/rubocop/cop/chef/deprecation/long_description_metadata.rb
@@ -28,6 +28,8 @@ module RuboCop
         #
 
         class LongDescriptionMetadata < Cop
+          include RangeHelp
+
           MSG = 'The long_description metadata.rb method is not used and is unnecessary in cookbooks'.freeze
 
           def_node_matcher :long_description?, <<-PATTERN
@@ -42,7 +44,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(node.loc.expression)
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression))
             end
           end
         end

--- a/spec/rubocop/cop/chef/deprecation/long_description_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/long_description_metadata_spec.rb
@@ -21,11 +21,13 @@ describe RuboCop::Cop::Chef::ChefDeprecations::LongDescriptionMetadata, :config 
 
   it 'registers an offense when metadata used "conflicts"' do
     expect_offense(<<~RUBY)
+      description 'foo'
       long_description 'foo'
       ^^^^^^^^^^^^^^^^^^^^^^ The long_description metadata.rb method is not used and is unnecessary in cookbooks
+      version '1.0.0'
     RUBY
 
-    expect_correction('')
+    expect_correction("description 'foo'\nversion '1.0.0'\n")
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/deprecation/long_description_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/long_description_metadata_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::LongDescriptionMetadata, :config 
       ^^^^^^^^^^^^^^^^^^^^^^ The long_description metadata.rb method is not used and is unnecessary in cookbooks
     RUBY
 
-    expect_correction("\n")
+    expect_correction('')
   end
 
   it "doesn't register an offense on normal metadata" do


### PR DESCRIPTION
Avoid replacing a bogus metadata entry with a bogus empty line

Signed-off-by: Tim Smith <tsmith@chef.io>