### PR TITLE
Update CustomResourceWithAllowedActions to trigger on LWRPs as well

### DIFF
--- a/docs/cops_chefmodernize.md
+++ b/docs/cops_chefmodernize.md
@@ -29,9 +29,7 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-In HWRPs and LWRPs it was necessary to define the allowed actions within the resource.
-In custom resources this is no longer necessary as Chef will determine it based on the
-actions defined in the resource.
+In Chef Infra Client releases after 12.5 it is no longer necessary to set `actions` or `allowed_actions` as Chef Infra Client determines these automatically from the set of all actions defined in the resource.
 
 ### Examples
 
@@ -40,24 +38,14 @@ actions defined in the resource.
 property :something, String
 
 allowed_actions [:create, :remove]
-action :create do
-  # some action code because we're in a custom resource
-end
 
 # also bad
 property :something, String
 
 actions [:create, :remove]
-action :create do
-  # some action code because we're in a custom resource
-end
 
 # good
 property :something, String
-
-action :create do
-  # some action code because we're in a custom resource
-end
 ```
 
 ### Configurable attributes

--- a/lib/rubocop/cop/chef/modernize/resource_with_allowed_actions.rb
+++ b/lib/rubocop/cop/chef/modernize/resource_with_allowed_actions.rb
@@ -19,9 +19,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefModernize
-        # In HWRPs and LWRPs it was necessary to define the allowed actions within the resource.
-        # In custom resources this is no longer necessary as Chef will determine it based on the
-        # actions defined in the resource.
+        # In Chef Infra Client releases after 12.5 it is no longer necessary to set `actions` or `allowed_actions` as Chef Infra Client determines these automatically from the set of all actions defined in the resource.
         #
         # @example
         #
@@ -29,39 +27,25 @@ module RuboCop
         #   property :something, String
         #
         #   allowed_actions [:create, :remove]
-        #   action :create do
-        #     # some action code because we're in a custom resource
-        #   end
         #
         #   # also bad
         #   property :something, String
         #
         #   actions [:create, :remove]
-        #   action :create do
-        #     # some action code because we're in a custom resource
-        #   end
         #
         #   # good
         #   property :something, String
         #
-        #   action :create do
-        #     # some action code because we're in a custom resource
-        #   end
-        #
         class CustomResourceWithAllowedActions < Cop
-          MSG = "Custom Resources don't need to define the allowed actions with allowed_actions or actions methods".freeze
+          MSG = 'Resources no longer need to define the allowed actions with allowed_actions or actions methods.'.freeze
 
           def_node_matcher :allowed_actions?, <<-PATTERN
             (send nil? {:allowed_actions :actions} ... )
           PATTERN
 
-          def_node_search :resource_actions?, <<-PATTERN
-            (block (send nil? :action ... ) ... )
-          PATTERN
-
           def on_send(node)
             allowed_actions?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor) if resource_actions?(processed_source.ast)
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
           end
 

--- a/spec/rubocop/cop/chef/modernize/resource_with_allowed_actions_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/resource_with_allowed_actions_spec.rb
@@ -19,12 +19,12 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ChefModernize::CustomResourceWithAllowedActions, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense with a custom resource that uses allowed_actions method' do
+  it 'registers an offense with a resource that uses allowed_actions method' do
     expect_offense(<<~RUBY)
       property :something, String
 
       allowed_actions [:create, :remove]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Custom Resources don't need to define the allowed actions with allowed_actions or actions methods
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resources no longer need to define the allowed actions with allowed_actions or actions methods.
       action :create do
         # some action code because we're in a custom resource
       end
@@ -40,12 +40,12 @@ describe RuboCop::Cop::Chef::ChefModernize::CustomResourceWithAllowedActions, :c
     RUBY
   end
 
-  it 'registers an offense with a custom resource that uses actions method' do
+  it 'registers an offense with a resource that uses actions method' do
     expect_offense(<<~RUBY)
       property :something, String
 
       actions [:create, :remove]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Custom Resources don't need to define the allowed actions with allowed_actions or actions methods
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Resources no longer need to define the allowed actions with allowed_actions or actions methods.
       action :create do
         # some action code because we're in a custom resource
       end
@@ -61,29 +61,13 @@ describe RuboCop::Cop::Chef::ChefModernize::CustomResourceWithAllowedActions, :c
     RUBY
   end
 
-  it 'does not register an offense with a custom resource that does not use allowed_actions or actions methods' do
+  it 'does not register an offense with a resource that does not use allowed_actions or actions methods' do
     expect_no_offenses(<<~RUBY)
       property :something, String
 
       action :create do
         # some action code because we're in a custom resource
       end
-    RUBY
-  end
-
-  it 'does not register an offense with a LWRP that uses allowed_actions method' do
-    expect_no_offenses(<<~RUBY)
-      attribute :something, String
-
-      allowed_actions [:create, :remove]
-    RUBY
-  end
-
-  it 'does not register an offense with a LWRP that uses actions method' do
-    expect_no_offenses(<<~RUBY)
-      attribute :something, String
-
-      actions [:create, :remove]
     RUBY
   end
 end


### PR DESCRIPTION
As lamont pointed out the improvements in 12.5 that we call custom resources also apply to existing LWRPs. Previously this cop was gated to only run on custom resources, but that's not actually necessary. This speeds it up and catches more stuff.

Signed-off-by: Tim Smith <tsmith@chef.io>