### PR TITLE
Add ChefDeprecations/ChefSpecCoverageReport & ChefDeprecations/ChefSpecLegacyRunner cops

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -456,6 +456,13 @@ ChefDeprecations/ResourceUsesProviderBaseMethod:
     - '**/libraries/*.rb'
     - '**/resources/*.rb'
 
+ChefDeprecations/ChefSpecCoverageReport:
+  Description: Don't use the deprecated ChefSpec coverage report functionality in your specs.
+  Enabled: true
+  VersionAdded: '5.8.0'
+  Include:
+    - '**/spec/*.rb'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -463,6 +463,13 @@ ChefDeprecations/ChefSpecCoverageReport:
   Include:
     - '**/spec/*.rb'
 
+ChefDeprecations/ChefSpecLegacyRunner:
+  Description: Use ChefSpec::SoloRunner or ChefSpec::ServerRunner instead of the deprecated ChefSpec::Runner.
+  Enabled: true
+  VersionAdded: '5.8.0'
+  Include:
+    - '**/spec/*.rb'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/docs/cops.md
+++ b/docs/cops.md
@@ -25,6 +25,7 @@
 
 * [ChefDeprecations/AttributeMetadata](cops_chefdeprecations.md#chefdeprecationsattributemetadata)
 * [ChefDeprecations/ChefSpecCoverageReport](cops_chefdeprecations.md#chefdeprecationschefspeccoveragereport)
+* [ChefDeprecations/ChefSpecLegacyRunner](cops_chefdeprecations.md#chefdeprecationschefspeclegacyrunner)
 * [ChefDeprecations/ChocolateyPackageUninstallAction](cops_chefdeprecations.md#chefdeprecationschocolateypackageuninstallaction)
 * [ChefDeprecations/ConflictsMetadata](cops_chefdeprecations.md#chefdeprecationsconflictsmetadata)
 * [ChefDeprecations/CookbookDependsOnCompatResource](cops_chefdeprecations.md#chefdeprecationscookbookdependsoncompatresource)

--- a/docs/cops.md
+++ b/docs/cops.md
@@ -24,6 +24,7 @@
 #### Department [ChefDeprecations](cops_chefdeprecations.md)
 
 * [ChefDeprecations/AttributeMetadata](cops_chefdeprecations.md#chefdeprecationsattributemetadata)
+* [ChefDeprecations/ChefSpecCoverageReport](cops_chefdeprecations.md#chefdeprecationschefspeccoveragereport)
 * [ChefDeprecations/ChocolateyPackageUninstallAction](cops_chefdeprecations.md#chefdeprecationschocolateypackageuninstallaction)
 * [ChefDeprecations/ConflictsMetadata](cops_chefdeprecations.md#chefdeprecationsconflictsmetadata)
 * [ChefDeprecations/CookbookDependsOnCompatResource](cops_chefdeprecations.md#chefdeprecationscookbookdependsoncompatresource)

--- a/docs/cops_chefdeprecations.md
+++ b/docs/cops_chefdeprecations.md
@@ -51,6 +51,41 @@ Name | Default value | Configurable values
 VersionAdded | `5.8.0` | String
 Include | `**/spec/*.rb` | Array
 
+## ChefDeprecations/ChefSpecLegacyRunner
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | Yes
+
+Use ChefSpec::SoloRunner or ChefSpec::ServerRunner instead of the deprecated ChefSpec::Runner. These new runners were introduced in ChefSpec 4.1 (Oct 2014).
+
+### Examples
+
+```ruby
+# bad
+
+describe 'foo::default' do
+  subject { ChefSpec::Runner.new.converge(described_recipe) }
+
+  # some spec code
+end
+
+# good
+
+describe 'foo::default' do
+  subject { ChefSpec::ServerRunner.new.converge(described_recipe) }
+
+  # some spec code
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+VersionAdded | `5.8.0` | String
+Include | `**/spec/*.rb` | Array
+
 ## ChefDeprecations/ChocolateyPackageUninstallAction
 
 Enabled by default | Supports autocorrection

--- a/docs/cops_chefdeprecations.md
+++ b/docs/cops_chefdeprecations.md
@@ -28,6 +28,29 @@ Name | Default value | Configurable values
 VersionAdded | `5.1.0` | String
 Include | `**/metadata.rb` | Array
 
+## ChefDeprecations/ChefSpecCoverageReport
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | Yes
+
+Don't use the deprecated ChefSpec Coverage report functionality in your specs. This feature has been removed as coverage reports encourage cookbook authors to write ineffective specs. Focus on testing your logic instead of achieving 100% code coverage.
+
+### Examples
+
+```ruby
+# bad
+
+at_exit { ChefSpec::Coverage.report! }
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+VersionAdded | `5.8.0` | String
+Include | `**/spec/*.rb` | Array
+
 ## ChefDeprecations/ChocolateyPackageUninstallAction
 
 Enabled by default | Supports autocorrection

--- a/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
@@ -30,7 +30,6 @@ module RuboCop
         class ChefSpecCoverageReport < Cop
           MSG = "Don't use the deprecated ChefSpec coverage report functionality in your specs.".freeze
 
-
           def_node_matcher :coverage_reporter?, <<-PATTERN
           (block (send nil? :at_exit ) (args) (send (const (const nil? :ChefSpec) :Coverage) :report!))
           PATTERN

--- a/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
@@ -1,0 +1,53 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Don't use the deprecated ChefSpec Coverage report functionality in your specs. This feature has been removed as coverage reports encourage cookbook authors to write ineffective specs. Focus on testing your logic instead of achieving 100% code coverage.
+        #
+        # @example
+        #
+        #   # bad
+        #
+        #   at_exit { ChefSpec::Coverage.report! }
+        #
+        class ChefSpecCoverageReport < Cop
+          MSG = "Don't use the deprecated ChefSpec coverage report functionality in your specs.".freeze
+
+
+          def_node_matcher :coverage_reporter?, <<-PATTERN
+          (block (send nil? :at_exit ) (args) (send (const (const nil? :ChefSpec) :Coverage) :report!))
+          PATTERN
+
+          def on_block(node)
+            coverage_reporter?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.remove(node.loc.expression)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
@@ -40,8 +40,7 @@ module RuboCop
         #   end
         #
         class ChefSpecLegacyRunner < Cop
-          MSG = "Use ChefSpec::SoloRunner or ChefSpec::ServerRunner instead of the deprecated ChefSpec::Runner.".freeze
-
+          MSG = 'Use ChefSpec::SoloRunner or ChefSpec::ServerRunner instead of the deprecated ChefSpec::Runner.'.freeze
 
           def_node_matcher :chefspec_runner?, <<-PATTERN
           (const (const nil? :ChefSpec) :Runner)

--- a/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
@@ -1,0 +1,65 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Use ChefSpec::SoloRunner or ChefSpec::ServerRunner instead of the deprecated ChefSpec::Runner. These new runners were introduced in ChefSpec 4.1 (Oct 2014).
+        #
+        # @example
+        #
+        #   # bad
+        #
+        #   describe 'foo::default' do
+        #     subject { ChefSpec::Runner.new.converge(described_recipe) }
+        #
+        #     # some spec code
+        #   end
+        #
+        #   # good
+        #
+        #   describe 'foo::default' do
+        #     subject { ChefSpec::ServerRunner.new.converge(described_recipe) }
+        #
+        #     # some spec code
+        #   end
+        #
+        class ChefSpecLegacyRunner < Cop
+          MSG = "Use ChefSpec::SoloRunner or ChefSpec::ServerRunner instead of the deprecated ChefSpec::Runner.".freeze
+
+
+          def_node_matcher :chefspec_runner?, <<-PATTERN
+          (const (const nil? :ChefSpec) :Runner)
+          PATTERN
+
+          def on_const(node)
+            chefspec_runner?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, 'ChefSpec::ServerRunner')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/chefspec_coverage_report_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chefspec_coverage_report_spec.rb
@@ -1,0 +1,30 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::ChefSpecCoverageReport, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when spec calls the coverage reporter' do
+    expect_offense(<<~RUBY)
+      at_exit { ChefSpec::Coverage.report! }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use the deprecated ChefSpec coverage report functionality in your specs.
+    RUBY
+
+    expect_correction("\n")
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/chefspec_legacy_runner_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chefspec_legacy_runner_spec.rb
@@ -1,0 +1,36 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::ChefSpecLegacyRunner, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when spec calls the coverage reporter' do
+    expect_offense(<<~RUBY)
+    describe 'foo::default' do
+      subject { ChefSpec::Runner.new.converge(described_recipe) }
+                ^^^^^^^^^^^^^^^^ Use ChefSpec::SoloRunner or ChefSpec::ServerRunner instead of the deprecated ChefSpec::Runner.
+    end
+    RUBY
+
+    expect_correction(<<~RUBY)
+    describe 'foo::default' do
+      subject { ChefSpec::ServerRunner.new.converge(described_recipe) }
+    end
+    RUBY
+  end
+end


### PR DESCRIPTION
Detect usage of the deprecated ChefSpec coverage reporter and the usage of pre-ChefSpec 4.1 (2014) spec runners.

Resolves #302 

Signed-off-by: Tim Smith <tsmith@chef.io>