### PR TITLE
Add ChefCorrectness/InvalidVersionMetadata cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -230,6 +230,13 @@ ChefCorrectness/EmptyMetadataField:
   Include:
     - '**/metadata.rb'
 
+ChefCorrectness/InvalidVersionMetadata:
+  Description: Cookbook metadata.rb version field should follow X.Y.Z version format.
+  Enabled: true
+  VersionAdded: '5.8.0'
+  Include:
+    - '**/metadata.rb'
+
 ###############################
 # ChefDeprecations: Resolving Deprecations that block upgrading Chef Infra Client
 ###############################

--- a/lib/rubocop/cop/chef/correctness/invalid_version_metadata.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_version_metadata.rb
@@ -1,0 +1,48 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # Cookbook metadata.rb version field should follow X.Y.Z version format.
+        #
+        # @example
+        #
+        #   # bad
+        #   version '1.2.3.4'
+        #
+        #   # good
+        #   version '1.2.3'
+        #
+        class InvalidVersionMetadata < Cop
+          MSG = 'Cookbook metadata.rb version field should follow X.Y.Z version format.'.freeze
+
+          def_node_matcher :version?, '(send nil? :version $str ...)'
+
+          def on_send(node)
+            version?(node) do |ver|
+              if ver.value !~ /\A\d+\.\d+(\.\d+)?\z/ # entirely borrowed from Foodcritic.
+                add_offense(ver, location: :expression, message: MSG, severity: :refactor)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/invalid_version_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/invalid_version_metadata_spec.rb
@@ -1,0 +1,34 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::InvalidVersionMetadata, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a cookbook sets has an invalid version in metadata.rb' do
+    expect_offense(<<~RUBY)
+      version '1.2.3.4'
+              ^^^^^^^^^ Cookbook metadata.rb version field should follow X.Y.Z version format.
+    RUBY
+  end
+
+  it "doesn't register an offense with a valid version in metadata.rb" do
+    expect_no_offenses(<<~RUBY)
+    version '1.2.3'
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/invalid_version_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/invalid_version_metadata_spec.rb
@@ -26,6 +26,13 @@ describe RuboCop::Cop::Chef::ChefCorrectness::InvalidVersionMetadata, :config do
     RUBY
   end
 
+  it 'registers an offense when a cookbook has a rubygems prerelease style version in metadata.rb' do
+    expect_offense(<<~RUBY)
+      version '1.2.3-alpha'
+              ^^^^^^^^^^^^^ Cookbook metadata.rb version field should follow X.Y.Z version format.
+    RUBY
+  end
+
   it "doesn't register an offense with a valid version in metadata.rb" do
     expect_no_offenses(<<~RUBY)
     version '1.2.3'


### PR DESCRIPTION
This is from Foodcritic and is just as valid today as it was in 2013.

Signed-off-by: Tim Smith <tsmith@chef.io>