### PR TITLE
Add additional helpers for working with resources

### DIFF
--- a/lib/rubocop/chef/cookbook_helpers.rb
+++ b/lib/rubocop/chef/cookbook_helpers.rb
@@ -8,6 +8,19 @@ module RuboCop
         end
       end
 
+      # Match a particular resource
+      #
+      # @param [String] resource_name The name of the resource to match
+      # @param [RuboCop::AST::Node] node The rubocop ast node to search
+      #
+      # @yield
+      #
+      def match_resource_type?(resource_name, node)
+        return unless looks_like_resource?(node)
+        # bail out if we're not in the resource we care about or nil was passed (all resources)
+        yield(node) if node.children.first.method?(resource_name.to_sym)
+      end
+
       # Match particular properties within a resource
       #
       # @param [String] resource_name The name of the resource to match

--- a/lib/rubocop/chef/cookbook_helpers.rb
+++ b/lib/rubocop/chef/cookbook_helpers.rb
@@ -61,6 +61,7 @@ module RuboCop
 
       #
       # given a node object does it look like a chef resource or not?
+      # warning: currently this requires a resource with properties since we key off blocks and property-less resources look like methods
       #
       # @param [RuboCop::AST::Node] node AST object to test
       #

--- a/lib/rubocop/chef/cookbook_helpers.rb
+++ b/lib/rubocop/chef/cookbook_helpers.rb
@@ -60,7 +60,7 @@ module RuboCop
       private
 
       #
-      # given a node object does it lookk like a chef resource or not?
+      # given a node object does it look like a chef resource or not?
       #
       # @param [RuboCop::AST::Node] node AST object to test
       #

--- a/spec/rubocop/chef/cookbook_helpers_spec.rb
+++ b/spec/rubocop/chef/cookbook_helpers_spec.rb
@@ -26,142 +26,180 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
 
   let (:running_true_ast) { s(:send, nil, :running, s(:true)) }
 
-  describe 'single property in a resource' do
-    let(:resource_source) { "service 'single_property' do; running true; end" }
+  describe '#resource_block_name_if_string' do
+    describe 'when the the resource name is a string' do
+      let(:resource_source) { "service 'foo' do; running true; end" }
 
-    it "should yield a single 'running' property ast objects" do
-      expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
-    end
-  end
-
-  describe 'multiple properties in a resource' do
-    let(:resource_source) { "service 'single_property' do; not_running true; running true; end" }
-
-    it "should yield a single 'running' property ast objects" do
-      expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
-    end
-  end
-
-  describe 'extracts a property from a resource with an if statement' do
-    let(:resource_source) do
-      <<~RUBY
-      service 'if statement' do
-        if platform?('mac_os_x')
-          running true
-        end
+      it 'should return the resource name string' do
+        expect(resource_block_name_if_string(parse_source(resource_source).ast)).to eq 'foo'
       end
-      RUBY
     end
 
-    it "should yield a single 'running' property ast objects" do
-      expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
-    end
-  end
+    describe 'when the the resource name is a variable' do
+      let(:resource_source) { 'service foo_service do; running true; end' }
 
-  describe 'extracts a property from a resource with a case statement' do
-    let(:resource_source) do
-      <<~RUBY
-      service 'case statement' do
-        case node['platform']
-        when 'windows'
-          running true
-        else
-          running false
-        end
+      it 'should return nil' do
+        expect(resource_block_name_if_string(parse_source(resource_source).ast)).to be_nil
       end
-      RUBY
-    end
-
-    it "should yield both 'running' property ast objects" do
-      expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast, running_false_ast)
     end
   end
 
-  describe 'extracts a property from a resource with nested conditionals' do
-    let(:resource_source) do
-      <<~RUBY
-      service 'nested conditionals' do
-        case node['platform']
-        when 'windows'
-          if node['platform_version'].to_f == '6.1'
+  describe '#match_resource_type?' do
+    describe 'when the passed name matches the resource' do
+      let(:resource_source) { "service 'foo' do; running true; end" }
+
+      it 'should yield a the service block ast objects' do
+        expect { |b| match_resource_type?(:service, parse_source(resource_source).ast, &b) }.to yield_successive_args(s(:block, s(:send, nil, :service, s(:str, 'foo')), s(:args), s(:send, nil, :running, s(:true))))
+      end
+    end
+
+    describe "when the passed name doesn't match the resource" do
+      let(:resource_source) { "service 'foo' do; running true; end" }
+
+      it 'should not yield anything' do
+        expect { |b| match_resource_type?(:archive_file, parse_source(resource_source).ast, &b) }.not_to yield_control
+      end
+    end
+  end
+
+  describe '#match_property_in_resource?' do
+    describe 'single property in a resource' do
+      let(:resource_source) { "service 'single_property' do; running true; end" }
+
+      it "should yield a single 'running' property ast objects" do
+        expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
+      end
+    end
+
+    describe 'multiple properties in a resource' do
+      let(:resource_source) { "service 'single_property' do; not_running true; running true; end" }
+
+      it "should yield a single 'running' property ast objects" do
+        expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
+      end
+    end
+
+    describe 'extracts a property from a resource with an if statement' do
+      let(:resource_source) do
+        <<~RUBY
+        service 'if statement' do
+          if platform?('mac_os_x')
+            running true
+          end
+        end
+        RUBY
+      end
+
+      it "should yield a single 'running' property ast objects" do
+        expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
+      end
+    end
+
+    describe 'extracts a property from a resource with a case statement' do
+      let(:resource_source) do
+        <<~RUBY
+        service 'case statement' do
+          case node['platform']
+          when 'windows'
             running true
           else
             running false
           end
-        else
-          running true
         end
+        RUBY
       end
-      RUBY
+
+      it "should yield both 'running' property ast objects" do
+        expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast, running_false_ast)
+      end
     end
 
-    it "should yield three 'running' property ast objects" do
-      expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast, running_false_ast, running_true_ast)
-    end
-  end
+    describe 'extracts a property from a resource with nested conditionals' do
+      let(:resource_source) do
+        <<~RUBY
+        service 'nested conditionals' do
+          case node['platform']
+          when 'windows'
+            if node['platform_version'].to_f == '6.1'
+              running true
+            else
+              running false
+            end
+          else
+            running true
+          end
+        end
+        RUBY
+      end
 
-  describe 'extracts a property from a resource with case statement with an empty when' do
-    let(:resource_source) do
-      <<~RUBY
-      service 'case statement with an empty when' do
-        case node['platform']
-        when 'windows'
+      it "should yield three 'running' property ast objects" do
+        expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast, running_false_ast, running_true_ast)
+      end
+    end
+
+    describe 'extracts a property from a resource with case statement with an empty when' do
+      let(:resource_source) do
+        <<~RUBY
+        service 'case statement with an empty when' do
+          case node['platform']
+          when 'windows'
+            running false
+          when 'mac_os_x'
+            # haha there's nothing here
+          end
+        end
+        RUBY
+      end
+
+      it "should yield a single 'running' property ast objects" do
+        expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_false_ast)
+      end
+    end
+
+    describe 'extracts a property from a resource with a while loop' do
+      let(:resource_source) do
+        <<~RUBY
+        service 'while conditional' do
+          while true
+            running false
+          end
+        end
+        RUBY
+      end
+
+      it "should yield a single 'running' property ast objects" do
+        expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_false_ast)
+      end
+    end
+
+    describe "doesn't extract methods that look like properties but aren't" do
+      let(:resource_source) do
+        <<~RUBY
+        service 'while conditional' do
+          while true
+            running false
+          end
+        end
+        RUBY
+      end
+
+      it "should yield a single 'running' property ast objects" do
+        expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_false_ast)
+      end
+    end
+
+    describe "doesn't extract methods from blocks that don't look like resources" do
+      let(:resource_source) do
+        <<~RUBY
+        method_with_a_block_and_no_string_arg do |desired|
           running false
-        when 'mac_os_x'
-          # haha there's nothing here
         end
+        RUBY
       end
-      RUBY
-    end
 
-    it "should yield a single 'running' property ast objects" do
-      expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_false_ast)
-    end
-  end
-
-  describe 'extracts a property from a resource with a while loop' do
-    let(:resource_source) do
-      <<~RUBY
-      service 'while conditional' do
-        while true
-          running false
-        end
+      it 'should not yield anything' do
+        expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.not_to yield_control
       end
-      RUBY
-    end
-
-    it "should yield a single 'running' property ast objects" do
-      expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_false_ast)
-    end
-  end
-
-  describe "doesn't extract methods that look like properties but aren't" do
-    let(:resource_source) do
-      <<~RUBY
-      service 'while conditional' do
-        while true
-          running false
-        end
-      end
-      RUBY
-    end
-
-    it "should yield a single 'running' property ast objects" do
-      expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_false_ast)
-    end
-  end
-
-  describe "doesn't extract methods from blocks that don't look like resources" do
-    let(:resource_source) do
-      <<~RUBY
-      method_with_a_block_and_no_string_arg do |desired|
-        running false
-      end
-      RUBY
-    end
-
-    it 'should not yield anything' do
-      expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.not_to yield_control
     end
   end
 end


### PR DESCRIPTION
resource_block_name_if_string returns the name of the resource block if it's a string or nil if it's a variable and we can't parse it

match_resource_type? yields the node object if it finds a resource that matches the name passed

Signed-off-by: Tim Smith <tsmith@chef.io>