### PR TITLE
Add ChefStyle/SimplifyPlatformMajorVersionCheck

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -71,6 +71,13 @@ ChefStyle/UsePlatformHelpers:
     - '**/metadata.rb'
     - '**/libraries/*'
 
+ChefStyle/SimplifyPlatformMajorVersionCheck:
+  Description: Use node['platform_version'].to_i instead of node['platform_version'].split('.').first or node['platform_version'].split('.')[0]
+  Enabled: true
+  VersionAdded: '5.8.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # ChefCorrectness: Avoiding potential problems
 ###############################

--- a/lib/rubocop/cop/chef/style/simplify_platform_major_version_check.rb
+++ b/lib/rubocop/cop/chef/style/simplify_platform_major_version_check.rb
@@ -1,0 +1,87 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefStyle
+        # When checking the major version number of a platform you can take the node['platform_version'] attribute and transform it to an integer to strip it down to just the major version number. This simple way of determining the major version number of a platform should be used instead of splitting the platform into multiple fields with '.' as the delimiter.
+        #
+        # @example
+        #
+        #   # bad
+        #   node['platform_version'].split('.').first
+        #   node['platform_version'].split('.')[0]
+        #   node['platform_version'].split('.').first.to_i
+        #   node['platform_version'].split('.')[0].to_i
+        #
+        #   # good
+        #
+        #   # check to see if we're on RHEL 7 on a RHEL 7.6 node where node['platform_version] is 7.6.1810
+        #   if node['platform_version'].to_i == 7
+        #
+        class SimplifyPlatformMajorVersionCheck < Cop
+          MSG = "Use node['platform_version'].to_i instead of node['platform_version'].split('.').first or node['platform_version'].split('.')[0]".freeze
+
+          def_node_matcher :platform_version_check?, <<-PATTERN
+            (send (send (send nil? :node) :[] (str "platform_version") ) :split (str ".") )
+          PATTERN
+
+          def on_send(node)
+            platform_version_check?(node) do
+              if parent_method_equals?(node, :[])
+                node = node.parent
+                if node&.arguments.count == 1 &&
+                   node&.arguments&.first&.int_type? &&
+                   node&.arguments&.first.source == '0'
+                  add_offense_to_i_if_present(node)
+                end
+              elsif parent_method_equals?(node, :first)
+                node = node.parent
+                add_offense_to_i_if_present(node)
+              end
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, "node['platform_version'].to_i")
+            end
+          end
+
+          private
+
+          # if the parent is .to_i then we want to alert on that
+          def add_offense_to_i_if_present(node)
+            node = node.parent if parent_method_equals?(node, :to_i)
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
+          end
+
+          # see if the parent is a method and if it equals the passed in name
+          #
+          # @param [Rubocop::AST:Node] node The rubocop ast node to search
+          # @param [Symbol] name The method name
+          #
+          def parent_method_equals?(node, name)
+            return false if node.parent.nil?
+            return false unless node.parent.send_type?
+            name == node.parent.method_name
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/style/simplify_platform_major_version_check_spec.rb
+++ b/spec/rubocop/cop/chef/style/simplify_platform_major_version_check_spec.rb
@@ -1,0 +1,69 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefStyle::SimplifyPlatformMajorVersionCheck do
+  subject(:cop) { described_class.new }
+
+  it "registers an offense when checking platform major version using node['platform_version'].split('.').first" do
+    expect_offense(<<~RUBY)
+      node['platform_version'].split('.').first
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['platform_version'].to_i instead of node['platform_version'].split('.').first or node['platform_version'].split('.')[0]
+    RUBY
+
+    expect_correction("node['platform_version'].to_i\n")
+  end
+
+  it "registers an offense when checking platform major version using node['platform_version'].split('.')[0]" do
+    expect_offense(<<~RUBY)
+      node['platform_version'].split('.')[0]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['platform_version'].to_i instead of node['platform_version'].split('.').first or node['platform_version'].split('.')[0]
+    RUBY
+
+    expect_correction("node['platform_version'].to_i\n")
+  end
+
+  it "registers an offense when checking platform major version using node['platform_version'].split('.').first.to_i" do
+    expect_offense(<<~RUBY)
+      node['platform_version'].split('.').first.to_i
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['platform_version'].to_i instead of node['platform_version'].split('.').first or node['platform_version'].split('.')[0]
+    RUBY
+
+    expect_correction("node['platform_version'].to_i\n")
+  end
+
+  it "registers an offense when checking platform major version using node['platform_version'].split('.')[0].to_i" do
+    expect_offense(<<~RUBY)
+      node['platform_version'].split('.')[0].to_i
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['platform_version'].to_i instead of node['platform_version'].split('.').first or node['platform_version'].split('.')[0]
+    RUBY
+
+    expect_correction("node['platform_version'].to_i\n")
+  end
+
+  it "does not register an offense when with node['platform_version'].split('.')[1]" do
+    expect_no_offenses("node['platform_version'].split('.')[1]")
+  end
+
+  it "does not register an offense when with node['platform_version'].split('.')[1].to_i" do
+    expect_no_offenses("node['platform_version'].split('.')[1].to_i")
+  end
+
+  it "does not register an offense when with node['platform_version'].split('.')[0..1]" do
+    expect_no_offenses("node['platform_version'].split('.')[0..1]")
+  end
+end


### PR DESCRIPTION
When checking the major version number of a platform you can take the node['platform_version'] attribute and transform it to an integer to strip it down to just the major version number. This simple way of determining the major version number of a platform should be used instead of splitting the platform into multiple fields with '.' as the delimiter.

  # bad
  node['platform_version'].split('.').first
  node['platform_version'].split('.')[0]
  node['platform_version'].split('.').first.to_i
  node['platform_version'].split('.')[0].to_i

  # good

  if node['platform_version'].to_i == 7

Signed-off-by: Tim Smith <tsmith@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
