### PR TITLE
Add autocorrection to ChefDeprecations/UserDeprecatedSupportsProperty

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/user_supports_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/user_supports_property.rb
@@ -46,6 +46,17 @@ module RuboCop
               add_offense(property, location: :expression, message: MSG, severity: :refactor)
             end
           end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              new_text = []
+              node.arguments.first.each_pair do |k, v|
+                new_text << "#{k.source} #{v.source}"
+              end
+
+              corrector.replace(node.loc.expression, new_text.join("\n  "))
+            end
+          end
         end
       end
     end

--- a/spec/rubocop/cop/chef/deprecation/user_supports_property_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/user_supports_property_spec.rb
@@ -29,6 +29,13 @@ describe RuboCop::Cop::Chef::ChefDeprecations::UserDeprecatedSupportsProperty, :
         })
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      user "betty" do
+        manage_home true
+        non_unique true
+      end
+    RUBY
   end
 
   it "doesn't register an offense when using powershell_script for other things" do


### PR DESCRIPTION
Break out the items in the has into their own properties

Signed-off-by: Tim Smith <tsmith@chef.io>