### PR TITLE
Catch use_inline_resources if respond_to?(:use_inline_resources)

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
@@ -26,6 +26,7 @@ module RuboCop
         #   # bad
         #   use_inline_resources
         #   use_inline_resources if defined?(use_inline_resources)
+        #   use_inline_resources if respond_to?(:use_inline_resources)
         #
         class UseInlineResourcesDefined < Cop
           MSG = 'use_inline_resources is now the default for resources in Chef Infra Client 13+ and does not need to be specified.'.freeze
@@ -37,7 +38,7 @@ module RuboCop
               return if node.parent && node.parent.defined_type?
 
               # catch the full offense if the method is gated like this: use_inline_resources if defined?(use_inline_resources)
-              if node.parent && node.parent.if_type? && node.parent.children.first.method_name == :defined?
+              if node.parent && node.parent.if_type? && %i(defined? respond_to?).include?(node.parent.children.first.method_name)
                 node = node.parent
               end
               add_offense(node, location: :expression, message: MSG, severity: :refactor)

--- a/spec/rubocop/cop/chef/deprecation/use_inline_resources_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/use_inline_resources_spec.rb
@@ -37,6 +37,15 @@ describe RuboCop::Cop::Chef::ChefDeprecations::UseInlineResourcesDefined, :confi
     expect_correction("\n")
   end
 
+  it 'registers an offense when a resource includes use_inline_resources if respond_to?(:use_inline_resources)' do
+    expect_offense(<<~RUBY)
+      use_inline_resources if respond_to?(:use_inline_resources)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use_inline_resources is now the default for resources in Chef Infra Client 13+ and does not need to be specified.
+    RUBY
+
+    expect_correction("\n")
+  end
+
   it "doesn't register an offense when a resource calls not_use_inline_resources" do
     expect_no_offenses(<<~RUBY)
       not_use_inline_resources


### PR DESCRIPTION
This is far less common than use_inline_resources if
defined?(use_inline_resources), but there's a few of them on the
supermarket and without this we break that code.

Resolves #297 

Signed-off-by: Tim Smith <tsmith@chef.io>