### PR TITLE
Fix ChefModernize/UnnecessaryDependsChef14 to detect version constraints

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -535,7 +535,7 @@ ChefModernize/WhyRunSupportedTrue:
     - '**/libraries/*.rb'
 
 ChefModernize/UnnecessaryDependsChef14:
-  Description: Don't depend on cookbooks made obsolete by Chef 14
+  Description: Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
   Enabled: true
   VersionAdded: '5.1.0'
   Include:

--- a/docs/cops_chef.md
+++ b/docs/cops_chef.md
@@ -1114,7 +1114,7 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-Don't depend on cookbooks made obsolete by Chef 14
+Don't depend on cookbooks made obsolete by Chef Infra Client 14+
 
 ### Examples
 

--- a/docs/cops_chefmodernize.md
+++ b/docs/cops_chefmodernize.md
@@ -765,7 +765,7 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-Don't depend on cookbooks made obsolete by Chef 14
+Don't depend on cookbooks made obsolete by Chef Infra Client 14+
 
 ### Examples
 

--- a/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
@@ -32,7 +32,7 @@ module RuboCop
         #   depends 'sysctl'
         #
         class UnnecessaryDependsChef14 < Cop
-          MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14+".freeze
+          MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.".freeze
 
           def_node_matcher :legacy_depends?, <<-PATTERN
             (send nil? :depends (str {"build-essential" "chef_handler" "chef_hostname" "dmg" "mac_os_x" "swap" "sysctl"}) ... )

--- a/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefModernize
-        # Don't depend on cookbooks made obsolete by Chef 14
+        # Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
         #
         # @example
         #
@@ -32,10 +32,10 @@ module RuboCop
         #   depends 'sysctl'
         #
         class UnnecessaryDependsChef14 < Cop
-          MSG = "Don't depend on cookbooks made obsolete by Chef 14".freeze
+          MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14+".freeze
 
           def_node_matcher :legacy_depends?, <<-PATTERN
-            (send nil? :depends (str {"build-essential" "chef_handler" "chef_hostname" "dmg" "mac_os_x" "swap" "sysctl"}))
+            (send nil? :depends (str {"build-essential" "chef_handler" "chef_hostname" "dmg" "mac_os_x" "swap" "sysctl"}) ... )
           PATTERN
 
           def on_send(node)

--- a/spec/rubocop/cop/chef/modernize/chef_14_resources_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/chef_14_resources_spec.rb
@@ -22,55 +22,62 @@ describe RuboCop::Cop::Chef::ChefModernize::UnnecessaryDependsChef14, :config do
   it 'registers an offense when a cookbook depends on "build-essential"' do
     expect_offense(<<~RUBY)
       depends 'build-essential'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef 14
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "chef_handler"' do
     expect_offense(<<~RUBY)
       depends 'chef_handler'
-      ^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef 14
+      ^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "chef_hostname"' do
     expect_offense(<<~RUBY)
       depends 'chef_hostname'
-      ^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef 14
+      ^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "dmg"' do
     expect_offense(<<~RUBY)
       depends 'dmg'
-      ^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef 14
+      ^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "mac_os_x"' do
     expect_offense(<<~RUBY)
       depends 'mac_os_x'
-      ^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef 14
+      ^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "swap"' do
     expect_offense(<<~RUBY)
       depends 'swap'
-      ^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef 14
+      ^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "sysctl"' do
     expect_offense(<<~RUBY)
       depends 'sysctl'
-      ^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef 14
+      ^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
     RUBY
   end
 
   it "doesn't register an offense when depending on any old cookbook" do
     expect_no_offenses(<<~RUBY)
       depends 'build-essentially'
+    RUBY
+  end
+
+  it 'registers an offense when a cookbook depends on "build-essential" and specifies a version constraint' do
+    expect_offense(<<~RUBY)
+      depends 'build-essential', '>= 8.0.1'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
     RUBY
   end
 end

--- a/spec/rubocop/cop/chef/modernize/chef_14_resources_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/chef_14_resources_spec.rb
@@ -22,49 +22,49 @@ describe RuboCop::Cop::Chef::ChefModernize::UnnecessaryDependsChef14, :config do
   it 'registers an offense when a cookbook depends on "build-essential"' do
     expect_offense(<<~RUBY)
       depends 'build-essential'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "chef_handler"' do
     expect_offense(<<~RUBY)
       depends 'chef_handler'
-      ^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
+      ^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "chef_hostname"' do
     expect_offense(<<~RUBY)
       depends 'chef_hostname'
-      ^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
+      ^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "dmg"' do
     expect_offense(<<~RUBY)
       depends 'dmg'
-      ^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
+      ^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "mac_os_x"' do
     expect_offense(<<~RUBY)
       depends 'mac_os_x'
-      ^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
+      ^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "swap"' do
     expect_offense(<<~RUBY)
       depends 'swap'
-      ^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
+      ^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "sysctl"' do
     expect_offense(<<~RUBY)
       depends 'sysctl'
-      ^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
+      ^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
@@ -77,7 +77,7 @@ describe RuboCop::Cop::Chef::ChefModernize::UnnecessaryDependsChef14, :config do
   it 'registers an offense when a cookbook depends on "build-essential" and specifies a version constraint' do
     expect_offense(<<~RUBY)
       depends 'build-essential', '>= 8.0.1'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 end


### PR DESCRIPTION
Update the node match to match any AST nodes after the method which will include any version constraint. I also improved the warning and docs for this cop.

Signed-off-by: Tim Smith <tsmith@chef.io>