### PR TITLE
Add ChefDeprecations/ChefHandlerUsesSupports

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -507,6 +507,13 @@ ChefDeprecations/UsesRunCommandHelper:
     - '**/metadata.rb'
     - 'Rakefile'
 
+ChefDeprecations/ChefHandlerUsesSupports:
+  Description: Use the type property instead of the deprecated supports property in the chef_handler resource. The supports property was removed in chef_handler cookbook version 3.0 (June 2017) and Chef Infra Client 14.0.
+  Enabled: true
+  VersionAdded: '5.9.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
@@ -1,0 +1,56 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Use the type property instead of the deprecated supports property in the chef_handler resource. The supports property was removed in chef_handler cookbook version 3.0 (June 2017) and Chef Infra Client 14.0.
+        #
+        # @example
+        #
+        #   # bad
+        #   chef_handler 'whatever' do
+        #     supports start: true, report: true, exception: true
+        #   end0
+        #
+        #   # good
+        #   chef_handler 'whatever' do
+        #     type start: true, report: true, exception: true
+        #   end
+        #
+        class ChefHandlerUsesSupports < Cop
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'Use the type property instead of the deprecated supports property in the chef_handler resource. The supports property was removed in chef_handler cookbook version 3.0 (June 2017) and Chef Infra Client 14.0.'.freeze
+
+          def on_block(node)
+            match_property_in_resource?('chef_handler', 'supports', node) do |prop_node|
+              add_offense(prop_node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, "type #{node.arguments.first.source}")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/chef_handler_supports_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_handler_supports_spec.rb
@@ -1,0 +1,44 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::ChefHandlerUsesSupports, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when chef_handler uses the supports property' do
+    expect_offense(<<~RUBY)
+    chef_handler 'Chef::Handler::ZookeeperHandler' do
+      supports start: true, report: true, exception: true
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the type property instead of the deprecated supports property in the chef_handler resource. The supports property was removed in chef_handler cookbook version 3.0 (June 2017) and Chef Infra Client 14.0.
+    end
+    RUBY
+
+    expect_correction(<<~RUBY)
+    chef_handler 'Chef::Handler::ZookeeperHandler' do
+      type start: true, report: true, exception: true
+    end
+    RUBY
+  end
+
+  it "doesn't register an offense when chef_handler uses the type action" do
+    expect_no_offenses(<<~RUBY)
+    chef_handler 'Chef::Handler::ZookeeperHandler' do
+      type start: true, report: true, exception: true
+    end
+    RUBY
+  end
+end


### PR DESCRIPTION
This allows cookbooks to run on Chef Infra Client 14 and later

Signed-off-by: Tim Smith <tsmith@chef.io>