### PR TITLE
Add ChefDeprecations/UsesRunCommandHelper cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -499,6 +499,14 @@ ChefDeprecations/ChefSpecLegacyRunner:
   Include:
     - '**/spec/*.rb'
 
+ChefDeprecations/UsesRunCommandHelper:
+  Description: Use 'shell_out!' instead of the legacy 'run_command' helper for shelling out. The run_command helper was removed in Chef Infra Client 13.
+  Enabled: true
+  VersionAdded: '5.9.0'
+  Exclude:
+    - '**/metadata.rb'
+    - 'Rakefile'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
@@ -35,7 +35,7 @@ module RuboCop
           def_node_search :defines_run_command?, '(def :run_command ...)'
 
           def on_send(node)
-            calls_run_command?(node) do |call|
+            calls_run_command?(node) do
               add_offense(node, location: :expression, message: MSG, severity: :refactor) unless defines_run_command?(processed_source.ast)
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
@@ -1,0 +1,46 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Use 'shell_out!' instead of the legacy 'run_command' helper for shelling out. The run_command helper was removed in Chef Infra Client 13.
+        #
+        # @example
+        #
+        #   # bad
+        #   run_command('/bin/foo')
+        #
+        #   # good
+        #   shell_out!('/bin/foo')
+        #
+        class UsesRunCommandHelper < Cop
+          MSG = "Use 'shell_out!' instead of the legacy 'run_command' helper for shelling out. The run_command helper was removed in Chef Infra Client 13.".freeze
+
+          def_node_matcher :calls_run_command?, '(send nil? :run_command ...)'
+          def_node_search :defines_run_command?, '(def :run_command ...)'
+
+          def on_send(node)
+            calls_run_command?(node) do |call|
+              add_offense(node, location: :expression, message: MSG, severity: :refactor) unless defines_run_command?(processed_source.ast)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/run_command_helper_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/run_command_helper_spec.rb
@@ -1,0 +1,38 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::UsesRunCommandHelper, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a cookbook uses the run_command helper' do
+    expect_offense(<<~RUBY)
+      run_command(foo)
+      ^^^^^^^^^^^^^^^^ Use 'shell_out!' instead of the legacy 'run_command' helper for shelling out. The run_command helper was removed in Chef Infra Client 13.
+    RUBY
+  end
+
+  it "doesn't register an offense when using the run_command helper if it's defined in the same file" do
+    expect_no_offenses(<<~RUBY)
+    run_command(foo)
+
+    def run_command(bar)
+      baz(bar)
+    end
+    RUBY
+  end
+end


### PR DESCRIPTION
Use 'shell_out!' instead of the legacy 'run_command' helper for shelling out. The run_command helper was removed in Chef Infra Client 13.

Signed-off-by: Tim Smith <tsmith@chef.io>