### PR TITLE
Add ChefModernize/PowerShellGuardInterpreter cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -748,6 +748,13 @@ ChefModernize/MacOsXUserdefaults:
   Exclude:
     - '**/metadata.rb'
 
+ChefModernize/PowerShellGuardInterpreter:
+  Description: PowerShell is already set as the default guard interpreter for powershell_script resources in Chef Infra Client 13 and later and does not need to be specified.
+  Enabled: true
+  VersionAdded: '5.9.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # Migrating to new patterns
 ###############################

--- a/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
@@ -1,0 +1,59 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefModernize
+        # PowerShell is already set as the default guard interpreter for powershell_script resources in Chef Infra Client 13 and later and does not need to be specified.
+        #
+        # @example
+        #
+        #   # bad
+        #   powershell_script 'whatever' do
+        #     code "mkdir test_dir"
+        #     guard_interpreter :powershell_script
+        #   end
+        #
+        #   # good
+        #   powershell_script 'whatever' do
+        #     code "mkdir test_dir"
+        #   end
+        #
+        class PowerShellGuardInterpreter < Cop
+          include RuboCop::Chef::CookbookHelpers
+          include RangeHelp
+
+          MSG = 'PowerShell is already set as the default guard interpreter for powershell_script resources in Chef Infra Client 13 and later and does not need to be specified.'.freeze
+
+          def on_block(node)
+            match_property_in_resource?(:powershell_script, 'guard_interpreter', node) do |interpreter|
+              if interpreter.arguments.first.source == ':powershell_script'
+                add_offense(interpreter, location: :expression, message: MSG, severity: :refactor)
+              end
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/powershell_guard_interpreter_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/powershell_guard_interpreter_spec.rb
@@ -1,0 +1,46 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefModernize::PowerShellGuardInterpreter, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using the guard_interpreter is set to :powershell_script in a powershell_script resource' do
+    expect_offense(<<~RUBY)
+    powershell_script 'whatever' do
+      code "mkdir test_dir"
+      guard_interpreter :powershell_script
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PowerShell is already set as the default guard interpreter for powershell_script resources in Chef Infra Client 13 and later and does not need to be specified.
+    end
+    RUBY
+
+    expect_correction(<<~RUBY)
+    powershell_script 'whatever' do
+      code "mkdir test_dir"
+    end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard_interpreter is set to something else in powershell_script" do
+    expect_no_offenses(<<~RUBY)
+    powershell_script 'whatever' do
+      code "mkdir test_dir"
+      guard_interpreter :foo
+    end
+    RUBY
+  end
+end


### PR DESCRIPTION
PowerShell is already set as the default guard interpreter for powershell_script resources in Chef Infra Client 13 and later and does not need to be specified.

Signed-off-by: Tim Smith <tsmith@chef.io>