### PR TITLE
Expand ChefModernize/CustomResourceWithAllowedActions to work in HWRPs

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -580,11 +580,12 @@ ChefModernize/CustomResourceWithAttributes:
     - '**/resources/*.rb'
 
 ChefModernize/CustomResourceWithAllowedActions:
-  Description: Custom Resources don't need to define the allowed actions with allowed_actions or actions methods
+  Description: Resources no longer need to define the allowed actions using the allowed_actions / actions helper methods or within an initialize method.
   Enabled: true
   VersionAdded: '5.2.0'
   Include:
     - '**/resources/*.rb'
+    - '**/libraries/*.rb'
 
 ChefModernize/IncludingAptDefaultRecipe:
   Description: Do not include the Apt default recipe to update package cache. Instead use the apt_update resource, which is built into Chef Infra Client 12.7 and later.


### PR DESCRIPTION
We should also clean up allowed_actions in initializers when we find them. This will help folks to trim down the size of their HWRPs and more easily migrate them to DSL based custom resources.

Signed-off-by: Tim Smith <tsmith@chef.io>