### PR TITLE
Add ChefCorrectness/NotifiesActionNotSymbol cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -237,6 +237,13 @@ ChefCorrectness/InvalidVersionMetadata:
   Include:
     - '**/metadata.rb'
 
+ChefCorrectness/NotifiesActionNotSymbol:
+  Description: When notifying an action within a resource the action should always be a symbol. In Chef Infra Client releases before 14.0 this may result in double notification.
+  Enabled: true
+  VersionAdded: '5.10.0'
+  Include:
+    - '**/metadata.rb'
+
 ###############################
 # ChefDeprecations: Resolving Deprecations that block upgrading Chef Infra Client
 ###############################

--- a/lib/rubocop/cop/chef/correctness/notifies_action_not_symbol.rb
+++ b/lib/rubocop/cop/chef/correctness/notifies_action_not_symbol.rb
@@ -1,0 +1,56 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # When notifying an action within a resource the action should always be a symbol. In Chef Infra Client releases before 14.0 this may result in double notification.
+        #
+        # @example
+        #
+        #   # bad
+        #   execute 'some commmand' do
+        #     notifies 'restart', 'service[httpd]', 'delayed'
+        #   end
+        #
+        #   # good
+        #   execute 'some commmand' do
+        #     notifies :restart, 'service[httpd]', 'delayed'
+        #   end
+        #
+        class NotifiesActionNotSymbol < Cop
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'Resource notifcation actions should be symbols not strings.'.freeze
+
+          def on_block(node)
+            match_property_in_resource?(nil, 'notifies', node) do |notifies_property|
+              add_offense(notifies_property, location: :expression, message: MSG, severity: :refactor) if notifies_property.node_parts[2].str_type?
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.first_argument.loc.expression, ":#{node.node_parts[2].value}")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/notifies_action_not_symbol_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/notifies_action_not_symbol_spec.rb
@@ -1,0 +1,45 @@
+#
+# Copyright:: Copyright 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::NotifiesActionNotSymbol do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when a notifies action is a string' do
+    expect_offense(<<~RUBY)
+      execute 'some commmand' do
+        notifies 'restart', 'service[httpd]', 'delayed'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resource notifcation actions should be symbols not strings.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      execute 'some commmand' do
+        notifies :restart, 'service[httpd]', 'delayed'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the notifies action is a symbol' do
+    expect_no_offenses(<<~RUBY)
+      execute 'some commmand' do
+        notifies :restart, 'service[httpd]', 'delayed'
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
This prevents double notifications in Chef < 14 and it's just the correct way to write it.

Signed-off-by: Tim Smith <tsmith@chef.io>