### PR TITLE
Add ChefDeprecations/VerifyPropertyUsesFileExpansion cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -549,6 +549,13 @@ ChefDeprecations/ResourceInheritsFromCompatResource:
   Include:
     - '**/libraries/*.rb'
 
+ChefDeprecations/VerifyPropertyUsesFileExpansion:
+  Description: Use the 'path' variable in the verify property and not the 'file' property which was removed in Chef Infra Client 13.
+  Enabled: true
+  VersionAdded: '5.10.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -550,7 +550,7 @@ ChefDeprecations/ResourceInheritsFromCompatResource:
     - '**/libraries/*.rb'
 
 ChefDeprecations/VerifyPropertyUsesFileExpansion:
-  Description: Use the 'path' variable in the verify property and not the 'file' property which was removed in Chef Infra Client 13.
+  Description: Use the 'path' variable in the verify property and not the 'file' variable which was removed in Chef Infra Client 13.
   Enabled: true
   VersionAdded: '5.10.0'
   Exclude:

--- a/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
+++ b/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
@@ -1,0 +1,55 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # In Chef Infra Client 13 the "file" variable for use within the verify property was replaced with the "path" variable.
+        #
+        # @example
+        #
+        #   # bad
+        #   file '/etc/nginx.conf' do
+        #     verify 'nginx -t -c %{file}'
+        #   end
+        #
+        #   # good
+        #   file '/etc/nginx.conf' do
+        #     verify 'nginx -t -c %{path}'
+        #   end
+        #
+        class VerifyPropertyUsesFileExpansion < Cop
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = "Use the 'path' variable in the verify property and not the 'file' property which was removed in Chef Infra Client 13.".freeze
+
+          def on_block(node)
+            match_property_in_resource?(nil, 'verify', node) do |verify|
+              add_offense(verify, location: :expression, message: MSG, severity: :refactor) if verify.source.match?(/%{file}/)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, node.loc.expression.source.gsub('%{file}', '%{path}'))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
+++ b/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
@@ -35,7 +35,7 @@ module RuboCop
         class VerifyPropertyUsesFileExpansion < Cop
           include RuboCop::Chef::CookbookHelpers
 
-          MSG = "Use the 'path' variable in the verify property and not the 'file' property which was removed in Chef Infra Client 13.".freeze
+          MSG = "Use the 'path' variable in the verify property and not the 'file' variable which was removed in Chef Infra Client 13.".freeze
 
           def on_block(node)
             match_property_in_resource?(nil, 'verify', node) do |verify|

--- a/spec/rubocop/cop/chef/deprecation/verify_property_file_expansion_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/verify_property_file_expansion_spec.rb
@@ -1,0 +1,45 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::VerifyPropertyUsesFileExpansion, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using the file variable in the verify property' do
+    expect_offense(<<~RUBY)
+      file '/etc/nginx.conf' do
+        verify 'nginx -t -c %{file}'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the 'path' variable in the verify property and not the 'file' property which was removed in Chef Infra Client 13.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      file '/etc/nginx.conf' do
+        verify 'nginx -t -c %{path}'
+      end
+    RUBY
+  end
+
+  it "doesn't register an when usinng path variable in the verify property" do
+    expect_no_offenses(<<~RUBY)
+      file '/etc/nginx.conf' do
+        verify 'nginx -t -c %{path}'
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/verify_property_file_expansion_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/verify_property_file_expansion_spec.rb
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::VerifyPropertyUsesFileExpansion, 
     expect_offense(<<~RUBY)
       file '/etc/nginx.conf' do
         verify 'nginx -t -c %{file}'
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the 'path' variable in the verify property and not the 'file' property which was removed in Chef Infra Client 13.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the 'path' variable in the verify property and not the 'file' variable which was removed in Chef Infra Client 13.
       end
     RUBY
 


### PR DESCRIPTION
Detects incorrect verify property usage that breaks Chef 13+

Signed-off-by: Tim Smith <tsmith@chef.io>