### PR TITLE
Add ChefDeprecations/EOLAuditModeUsage

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -535,6 +535,13 @@ ChefDeprecations/DeprecatedYumRepositoryProperties:
   Exclude:
     - '**/metadata.rb'
 
+ChefDeprecations/EOLAuditModeUsage:
+  Description: The beta Audit Mode feature in Chef Infra Client was removed in Chef Infra Client 15.0. Users should instead use InSpec and the audit cookbook. See https://www.inspec.io/ for more informmation.
+  Enabled: true
+  VersionAdded: '5.10.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/correctness/node_normal.rb
+++ b/lib/rubocop/cop/chef/correctness/node_normal.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2019-2019, Chef Software Inc.
+# Copyright:: Copyright 2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/rubocop/cop/chef/correctness/node_normal_unless.rb
+++ b/lib/rubocop/cop/chef/correctness/node_normal_unless.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2019-2019, Chef Software Inc.
+# Copyright:: Copyright 2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/rubocop/cop/chef/deprecation/eol_audit_mode.rb
+++ b/lib/rubocop/cop/chef/deprecation/eol_audit_mode.rb
@@ -1,0 +1,48 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # The beta Audit Mode for Chef Infra Client was removed in Chef Infra Client 15.0. Users should instead use InSpec and the audit cookbook. See https://www.inspec.io/ for more informmation.
+        #
+        # @example
+        #
+        #   # bad
+        #   control_group 'Baseline' do
+        #     control 'SSH' do
+        #       it 'should be listening on port 22' do
+        #         expect(port(22)).to be_listening
+        #       end
+        #     end
+        #   end
+
+        class EOLAuditModeUsage < Cop
+          MSG = 'The beta Audit Mode feature in Chef Infra Client was removed in Chef Infra Client 15.0. Users should instead use InSpec and the audit cookbook. See https://www.inspec.io/ for more informmation.'.freeze
+
+          def_node_matcher :control_group?, '(send nil? :control_group ...)'
+
+          def on_send(node)
+            control_group?(node) do
+              add_offense(node, location: :selector, message: MSG, severity: :refactor)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/deprecation/node_set.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2019-2019, Chef Software Inc.
+# Copyright:: Copyright 2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2019-2019, Chef Software Inc.
+# Copyright:: Copyright 2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/rubocop/cop/chef/correctness/node_normal_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/node_normal_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2019-2019, Chef Software Inc.
+# Copyright:: Copyright 2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/rubocop/cop/chef/deprecation/eol_audit_mode_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/eol_audit_mode_spec.rb
@@ -1,0 +1,34 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::EOLAuditModeUsage, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it "registers an offense when using the audit mode control_group resource'" do
+    expect_offense(<<~RUBY)
+      control_group 'Baseline' do
+      ^^^^^^^^^^^^^ The beta Audit Mode feature in Chef Infra Client was removed in Chef Infra Client 15.0. Users should instead use InSpec and the audit cookbook. See https://www.inspec.io/ for more informmation.
+        control 'SSH' do
+          it 'should be listening on port 22' do
+            expect(port(22)).to be_listening
+          end
+        end
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/node_set_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/node_set_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2019-2019, Chef Software Inc.
+# Copyright:: Copyright 2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/rubocop/cop/chef/deprecation/node_set_unless_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/node_set_unless_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2019-2019, Chef Software Inc.
+# Copyright:: Copyright 2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Detect the legacy audit mode and suggest folks check out InSpec
instead. This also cleans up some bad copyright dates.

33 occurrences of this were detected on Supermarket

Signed-off-by: Tim Smith <tsmith@chef.io>