### PR TITLE
Detect poise-service in addition to just poise

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/depends_poise.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_poise.rb
@@ -18,13 +18,14 @@ module RuboCop
   module Cop
     module Chef
       module ChefDeprecations
-        # Cookbooks should not depend on the deprecated Poise framework. They should instead
-        # be refactored as standard custom resources.
+        # Cookbooks should not depend on the deprecated Poise framework cookbooks. They should instead be refactored to use standard Chef Infra custom resources.
         #
         # @example
         #
         #   # bad
         #   depends 'poise'
+        #   depends 'poise-service'
+        #
         class CookbookDependsOnPoise < Cop
           MSG = 'Cookbooks should not depend on the deprecated Poise framework'.freeze
 
@@ -34,7 +35,7 @@ module RuboCop
 
           def on_send(node)
             depends_method?(node) do |arg|
-              add_offense(node, location: :expression, message: MSG, severity: :refactor) if arg == s(:str, 'poise')
+              add_offense(node, location: :expression, message: MSG, severity: :refactor) if %w(poise poise-service).include?(arg.value)
             end
           end
         end

--- a/spec/rubocop/cop/chef/deprecation/depends_poise_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/depends_poise_spec.rb
@@ -26,6 +26,13 @@ describe RuboCop::Cop::Chef::ChefDeprecations::CookbookDependsOnPoise, :config d
     RUBY
   end
 
+  it 'registers an offense when a cookbook depends on "poise-service"' do
+    expect_offense(<<~RUBY)
+      depends 'poise-service'
+      ^^^^^^^^^^^^^^^^^^^^^^^ Cookbooks should not depend on the deprecated Poise framework
+    RUBY
+  end
+
   it "doesn't register an offense when depending on any old cookbook" do
     expect_no_offenses(<<~RUBY)
       depends 'poise-ish'


### PR DESCRIPTION
poise-service is the real one that folks need to migrate off of so we
should detect that as well.

Signed-off-by: Tim Smith <tsmith@chef.io>