### PR TITLE
Fix docs updater script to work with Rubocop 0.75+

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -135,7 +135,7 @@ begin
 
     def references(config, cop)
       cop_config = config.for_cop(cop)
-      urls = RuboCop::Cop::MessageAnnotator.new(config, cop_config, {}).urls
+      urls = RuboCop::Cop::MessageAnnotator.new(config, cop.name, config.for_cop(cop), {}).urls
       return '' if urls.empty?
 
       content = h3('References')


### PR DESCRIPTION
This is lifted from the rubocop-rspec work here https://github.com/rubocop-hq/rubocop-rspec/pull/829/files

Signed-off-by: Tim Smith <tsmith@chef.io>