### PR TITLE
Add ChefDeprecations/SearchUsesPositionalParameters:

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -568,6 +568,13 @@ ChefDeprecations/PartialSearchHelperUsage:
   Exclude:
     - '**/metadata.rb'
 
+ChefDeprecations/SearchUsesPositionalParameters:
+  Description: Don't use deprecated positional parameters in cookbook search queries.
+  Enabled: true
+  VersionAdded: '5.11.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
+++ b/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
@@ -1,0 +1,113 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # In the cookbook search helper you need to use named parameters (key/value style) other than the first (type) and second (query string) values.
+        #
+        # @example
+        #
+        # bad:
+        #  search(:node, '*:*', 0, 1000, { :ip_address => ["ipaddress"] })
+        #  search(:node, '*:*', 0, 1000)
+        #  search(:node, '*:*', 0)
+
+        # good
+        #
+        # query(:node, '*:*')
+        #  search(:node, '*:*', start: 0, rows: 1000, filter_result: { :ip_address => ["ipaddress"] })
+        #  search(:node, '*:*', start: 0, rows: 1000)
+        #  search(:node, '*:*', start: 0)
+        #
+        class SearchUsesPositionalParameters < Cop
+          MSG = "Don't use deprecated positional parameters in cookbook search queries.".freeze
+
+          NAMED_PARAM_LOOKUP_TABLE = [nil, nil, 'start', 'rows', 'filter_results'].freeze
+
+          def_node_matcher :search_method?, <<-PATTERN
+            (send nil? :search ... )
+          PATTERN
+
+          def on_send(node)
+            search_method?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor) if positional_arguments?(node)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, corrected_string(node))
+            end
+          end
+
+          private
+
+          def positional_arguments?(node)
+            return false if node.arguments.count < 3
+            node.arguments[2..-1].each do |arg|
+              # hashes, blocks, or variable/methods are valid. Anything else is not
+              return true unless %i(send hash block_pass).include?(arg.type)
+            end
+            false
+          end
+
+          def corrected_string(node)
+            args = node.arguments
+
+            # If the 2nd argument is a String and not an Integer as a String
+            # then it's the old sort field and we need to delete it. Same thing
+            # goes for nil values here.
+            args.delete_at(2) if (args[2].str_type? && !integer_like_val?(args[2])) || args[2].nil_type?
+
+            "search(#{args.collect.with_index { |arg, i| hashify_argument(arg, i) }.join(', ')})"
+          end
+
+          # lookup the position in NAMED_PARAM_LOOKUP_TABLE to create a new
+          # hashified version of the query. Also convert Integer like Strings into Integers
+          def hashify_argument(arg, position)
+            hash_key = NAMED_PARAM_LOOKUP_TABLE[position]
+            if hash_key
+              # convert Integers stored as Strings into plain Integers
+              if integer_like_val?(arg)
+                "#{hash_key}: #{Integer(arg.value)}"
+              else
+                "#{hash_key}: #{arg.source}"
+              end
+            else
+              arg.source
+            end
+          end
+
+          #
+          # Does this value look like an Integer (it's an integer or a string)
+          #
+          # @param [<Type>] val
+          #
+          # @return [Boolean]
+          #
+          def integer_like_val?(val)
+            Integer(val.value)
+            true
+          rescue
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
+++ b/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
@@ -57,6 +57,13 @@ module RuboCop
 
           private
 
+          #
+          # Are the arguments in the passed node object positional
+          #
+          # @param [RuboCop::AST::Node] node
+          #
+          # @return [Boolean]
+          #
           def positional_arguments?(node)
             return false if node.arguments.count < 3
             node.arguments[2..-1].each do |arg|
@@ -66,6 +73,13 @@ module RuboCop
             false
           end
 
+          #
+          # Return the corrected search string
+          #
+          # @param [RuboCop::AST::Node] node
+          #
+          # @return [String]
+          #
           def corrected_string(node)
             args = node.arguments
 
@@ -77,8 +91,15 @@ module RuboCop
             "search(#{args.collect.with_index { |arg, i| hashify_argument(arg, i) }.join(', ')})"
           end
 
+          #
           # lookup the position in NAMED_PARAM_LOOKUP_TABLE to create a new
           # hashified version of the query. Also convert Integer like Strings into Integers
+          #
+          # @param [RuboCop::AST::Node] arg
+          # @param [Integer] position
+          #
+          # @return [String]
+          #
           def hashify_argument(arg, position)
             hash_key = NAMED_PARAM_LOOKUP_TABLE[position]
             if hash_key
@@ -96,7 +117,7 @@ module RuboCop
           #
           # Does this value look like an Integer (it's an integer or a string)
           #
-          # @param [<Type>] val
+          # @param [RuboCop::AST::Node] val
           #
           # @return [Boolean]
           #

--- a/spec/rubocop/cop/chef/deprecation/search_uses_positional_parameters_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/search_uses_positional_parameters_spec.rb
@@ -1,0 +1,76 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::SearchUsesPositionalParameters, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when search has 3+ args and uses positional params' do
+    expect_offense(<<~RUBY)
+      search(:node, '*:*', 0)
+      ^^^^^^^^^^^^^^^^^^^^^^^ Don't use deprecated positional parameters in cookbook search queries.
+    RUBY
+
+    expect_correction("search(:node, '*:*', start: 0)\n")
+  end
+
+  it 'corrects Integer like String positional parameters to be Integers' do
+    expect_offense(<<~RUBY)
+      search(:node, '*:*', "0")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use deprecated positional parameters in cookbook search queries.
+    RUBY
+
+    expect_correction("search(:node, '*:*', start: 0)\n")
+  end
+
+  it 'Removes the legacy sort parameter from search queries' do
+    expect_offense(<<~RUBY)
+      search(:node, "*:*", 'X_CHEF_id_CHEF_X asc', 1)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use deprecated positional parameters in cookbook search queries.
+    RUBY
+
+    expect_correction("search(:node, \"*:*\", start: 1)\n")
+  end
+
+  it "Removes the legacy sort parameter from search queries if it's a nil value" do
+    expect_offense(<<~RUBY)
+    search(:node, "*:*", nil, 0)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use deprecated positional parameters in cookbook search queries.
+    RUBY
+
+    expect_correction("search(:node, \"*:*\", start: 0)\n")
+  end
+
+  it "doesn't register an offense with the search method in another class" do
+    expect_no_offenses(<<~RUBY)
+      Foo.search(:node, '*:*', 0)
+    RUBY
+  end
+
+  it "doesn't register an offense with a 3+ arg search that has named params" do
+    expect_no_offenses(<<~RUBY)
+      search(:node, '*:*', start: 0)
+    RUBY
+  end
+
+  it "doesn't register an offense with a 2 arg search" do
+    expect_no_offenses(<<~RUBY)
+      search(:node, '*:*')
+    RUBY
+  end
+end


### PR DESCRIPTION
This detects position parameters and includes autocorrection, which also removes the legacy sort field.

Signed-off-by: Tim Smith <tsmith@chef.io>