### PR TITLE
Add ChefDeprecations/PartialSearchClassUsage

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -575,6 +575,13 @@ ChefDeprecations/SearchUsesPositionalParameters:
   Exclude:
     - '**/metadata.rb'
 
+ChefDeprecations/PartialSearchClassUsage:
+  Description: Legacy Chef::PartialSearch class usage should be updated to use the search helper instead with the filter_result key.
+  Enabled: true
+  VersionAdded: '5.11.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -562,7 +562,7 @@ ChefDeprecations/PoiseArchiveUsage:
   VersionAdded: '5.11.0'
 
 ChefDeprecations/PartialSearchHelperUsage:
-  Description: Legacy partial_search usage should be updated to use :filter_keys in the search helper instead.
+  Description: Legacy partial_search usage should be updated to use :filter_result in the search helper instead.
   Enabled: true
   VersionAdded: '5.11.0'
   Exclude:

--- a/lib/rubocop/cop/chef/deprecation/partial_search_class_usage.rb
+++ b/lib/rubocop/cop/chef/deprecation/partial_search_class_usage.rb
@@ -1,0 +1,65 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Legacy Chef::PartialSearch class usage should be updated to use the `search` helper instead with the `filter_results` key.
+        #
+        # @example
+        #
+        #   # bad
+        #   ::Chef::PartialSearch.new.search((:node, 'role:web',
+        #     keys: { 'name' => [ 'name' ],
+        #             'ip' => [ 'ipaddress' ],
+        #             'kernel_version' => %w(kernel version),
+        #               }
+        #   ).each do |result|
+        #     puts result['name']
+        #     puts result['ip']
+        #     puts result['kernel_version']
+        #   end
+        #
+        #   # good
+        #   search(:node, 'role:web',
+        #     filter_result: { 'name' => [ 'name' ],
+        #                      'ip' => [ 'ipaddress' ],
+        #                      'kernel_version' => %w(kernel version),
+        #               }
+        #   ).each do |result|
+        #     puts result['name']
+        #     puts result['ip']
+        #     puts result['kernel_version']
+        #   end
+        #
+        class PartialSearchClassUsage < Cop
+          MSG = 'Legacy Chef::PartialSearch class usage should be updated to use the search helper instead with the filter_results key.'.freeze
+
+          def_node_matcher :partial_search_class?, <<-PATTERN
+            (send (const (const ... :Chef) :PartialSearch) :new)
+          PATTERN
+
+          def on_send(node)
+            partial_search_class?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/deprecation/partial_search_class_usage.rb
+++ b/lib/rubocop/cop/chef/deprecation/partial_search_class_usage.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefDeprecations
-        # Legacy Chef::PartialSearch class usage should be updated to use the `search` helper instead with the `filter_results` key.
+        # Legacy Chef::PartialSearch class usage should be updated to use the `search` helper instead with the `filter_result` key.
         #
         # @example
         #
@@ -47,7 +47,7 @@ module RuboCop
         #   end
         #
         class PartialSearchClassUsage < Cop
-          MSG = 'Legacy Chef::PartialSearch class usage should be updated to use the search helper instead with the filter_results key.'.freeze
+          MSG = 'Legacy Chef::PartialSearch class usage should be updated to use the search helper instead with the filter_result key.'.freeze
 
           def_node_matcher :partial_search_class?, <<-PATTERN
             (send (const (const ... :Chef) :PartialSearch) :new)

--- a/lib/rubocop/cop/chef/deprecation/partial_search_helper_usage.rb
+++ b/lib/rubocop/cop/chef/deprecation/partial_search_helper_usage.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefDeprecations
-        # Legacy partial_search usage should be updated to use :filter_keys in the search helper instead
+        # Legacy partial_search usage should be updated to use :filter_result in the search helper instead
         #
         # @example
         #
@@ -47,7 +47,7 @@ module RuboCop
         #   end
         #
         class PartialSearchHelperUsage < Cop
-          MSG = 'Legacy partial_search usage should be updated to use :filter_keys in the search helper instead'.freeze
+          MSG = 'Legacy partial_search usage should be updated to use :filter_result in the search helper instead'.freeze
 
           def on_send(node)
             add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :partial_search

--- a/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
+++ b/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
@@ -37,7 +37,7 @@ module RuboCop
         class SearchUsesPositionalParameters < Cop
           MSG = "Don't use deprecated positional parameters in cookbook search queries.".freeze
 
-          NAMED_PARAM_LOOKUP_TABLE = [nil, nil, 'start', 'rows', 'filter_results'].freeze
+          NAMED_PARAM_LOOKUP_TABLE = [nil, nil, 'start', 'rows', 'filter_result'].freeze
 
           def_node_matcher :search_method?, <<-PATTERN
             (send nil? :search ... )

--- a/spec/rubocop/cop/chef/deprecation/partial_search_class_usage_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/partial_search_class_usage_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::PartialSearchClassUsage, :config 
   it 'registers an offense when using the Chef::PartialSearch class directly' do
     expect_offense(<<~RUBY)
       ::Chef::PartialSearch.new.search(search_key, query, :keys => partial_search_keys, :sort => sort_key) do |config|
-      ^^^^^^^^^^^^^^^^^^^^^^^^^ Legacy Chef::PartialSearch class usage should be updated to use the search helper instead with the filter_results key.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Legacy Chef::PartialSearch class usage should be updated to use the search helper instead with the filter_result key.
         puts result['name']
       end
     RUBY

--- a/spec/rubocop/cop/chef/deprecation/partial_search_class_usage_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/partial_search_class_usage_spec.rb
@@ -1,0 +1,46 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::PartialSearchClassUsage, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using the Chef::PartialSearch class directly' do
+    expect_offense(<<~RUBY)
+      ::Chef::PartialSearch.new.search(search_key, query, :keys => partial_search_keys, :sort => sort_key) do |config|
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Legacy Chef::PartialSearch class usage should be updated to use the search helper instead with the filter_results key.
+        puts result['name']
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when using the search helper" do
+    expect_no_offenses(<<~RUBY)
+      search(:node, 'role:web',
+        filter_result: { 'name' => [ 'name' ],
+                          'ip' => [ 'ipaddress' ],
+                          'kernel_version' => %w(kernel version),
+                  }
+      ).each do |result|
+        puts result['name']
+        puts result['ip']
+        puts result['kernel_version']
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/partial_search_class_usage_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/partial_search_class_usage_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::PartialSearchClassUsage, :config 
   it 'registers an offense when using the Chef::PartialSearch class directly' do
     expect_offense(<<~RUBY)
       ::Chef::PartialSearch.new.search(search_key, query, :keys => partial_search_keys, :sort => sort_key) do |config|
-        ^^^^^^^^^^^^^^^^^^^^^^^^^ Legacy Chef::PartialSearch class usage should be updated to use the search helper instead with the filter_results key.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Legacy Chef::PartialSearch class usage should be updated to use the search helper instead with the filter_results key.
         puts result['name']
       end
     RUBY

--- a/spec/rubocop/cop/chef/deprecation/partial_search_helper_usage_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/partial_search_helper_usage_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::PartialSearchHelperUsage, :config
   it 'registers an offense when using the partial_search helper' do
     expect_offense(<<~RUBY)
       partial_search(:node, 'role:web',
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Legacy partial_search usage should be updated to use :filter_keys in the search helper instead
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Legacy partial_search usage should be updated to use :filter_result in the search helper instead
         keys: { 'name' => [ 'name' ],
                 'ip' => [ 'ipaddress' ],
                 'kernel_version' => %w(kernel version),


### PR DESCRIPTION
This detects direct usage of the PartialSearch class, which far too many people did.

Signed-off-by: Tim Smith <tsmith@chef.io>