### PR TITLE
RespondToInMetadata: Catch if defined in metadata as well

### DIFF
--- a/lib/rubocop/cop/chef/modernize/respond_to_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/respond_to_metadata.rb
@@ -18,24 +18,30 @@ module RuboCop
   module Cop
     module Chef
       module ChefModernize
-        # It is not longer necessary respond_to?(:foo) in metadata. This was used to support new metadata
+        # It is not longer necessary respond_to?(:foo) or defined?(foo) in metadata. This was used to support new metadata
         # methods in Chef 11 and early versions of Chef 12.
         #
         # @example
         #
         #   # bad
         #   chef_version '>= 13' if respond_to?(:chef_version)
+        #   chef_version '>= 13' if defined?(chef_version)
         #
         #   # good
         #   chef_version '>= 13'
         #
         class RespondToInMetadata < Cop
-          MSG = 'It is no longer necessary to use respond_to? in metadata.rb in Chef Infra Client 12.15 and later'.freeze
+          MSG = 'It is no longer necessary to use respond_to? or if_defined? in metadata.rb in Chef Infra Client 12.15 and later'.freeze
 
           def on_if(node)
             if_respond_to?(node) do
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
+          end
+
+          def on_defined?(node)
+            node = node.parent if node.parent.if? # we want the whole if statement
+            add_offense(node, location: :expression, message: MSG, severity: :refactor)
           end
 
           def_node_matcher :if_respond_to?, <<~PATTERN

--- a/spec/rubocop/cop/chef/modernize/respond_to_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/respond_to_metadata_spec.rb
@@ -19,10 +19,21 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ChefModernize::RespondToInMetadata, :config do
   subject(:cop) { described_class.new(config) }
 
-  it "registers an offense when metadata includes the 'if respond_to?(:foo)' gate" do
+  # it "registers an offense when metadata includes the 'if respond_to?(:foo)' gate" do
+  #   expect_offense(<<~RUBY)
+  #     chef_version '> 13' if respond_to?(:chef_version)
+  #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It is no longer necessary to use respond_to? or if_defined? in metadata.rb in Chef Infra Client 12.15 and later
+  #   RUBY
+
+  #   expect_correction(<<~RUBY)
+  #     chef_version '> 13'
+  #   RUBY
+  # end
+
+  it "registers an offense when metadata includes the 'if defined?(foo)' gate" do
     expect_offense(<<~RUBY)
-      chef_version '> 13' if respond_to?(:chef_version)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It is no longer necessary to use respond_to? in metadata.rb in Chef Infra Client 12.15 and later
+      chef_version '> 13' if defined?(chef_version)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It is no longer necessary to use respond_to? or if_defined? in metadata.rb in Chef Infra Client 12.15 and later
     RUBY
 
     expect_correction(<<~RUBY)


### PR DESCRIPTION
This is less common, but some people did this in their metadata and we should clean it up. I didn't think it warranted creating another cop so I just extended the existing cop.

Signed-off-by: Tim Smith <tsmith@chef.io>