### PR TITLE
Add ChefCorrectness/ResourceWithNothingAction cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -256,6 +256,15 @@ ChefCorrectness/IncorrectLibraryInjection:
   Include:
     - '**/libraries/*.rb'
 
+ChefCorrectness/ResourceWithNothingAction:
+  Description: There is no need to define a :nothing action in your resource as Chef Infra Client provides the :nothing action out of the box for every resource.
+  Enabled: true
+  VersionAdded: '5.12.0'
+  Include:
+    - '**/libraries/*.rb'
+    - '**/resources/*.rb'
+    - '**/providers/*.rb'
+
 ###############################
 # ChefDeprecations: Resolving Deprecations that block upgrading Chef Infra Client
 ###############################

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -221,7 +221,7 @@ ChefCorrectness/IncludingOhaiDefaultRecipe:
     - '**/metadata.rb'
 
 ChefCorrectness/UnnecessaryNameProperty:
-  Description: There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources out of the box.
+  Description: There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources by default.
   Enabled: true
   VersionAdded: '5.8.0'
   Include:
@@ -257,7 +257,7 @@ ChefCorrectness/IncorrectLibraryInjection:
     - '**/libraries/*.rb'
 
 ChefCorrectness/ResourceWithNothingAction:
-  Description: There is no need to define a :nothing action in your resource as Chef Infra Client provides the :nothing action out of the box for every resource.
+  Description: There is no need to define a :nothing action in your resource as Chef Infra Client provides the :nothing action by default for every resource.
   Enabled: true
   VersionAdded: '5.12.0'
   Include:

--- a/lib/rubocop/cop/chef/correctness/resource_with_nothing_action.rb
+++ b/lib/rubocop/cop/chef/correctness/resource_with_nothing_action.rb
@@ -1,0 +1,52 @@
+#
+# Copyright:: Copyright 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # Chef Infra Client provides the :nothing action out of the box for every resource. There is no need to define a :nothing action in your resource code.
+        #
+        # @example
+        #
+        #   # bad
+        #   action :nothing
+        #     # let's do nothing
+        #   end
+        #
+        class ResourceWithNothingAction < Cop
+          MSG = 'There is no need to define a :nothing action in your resource as Chef Infra Client provides the :nothing action out of the box for every resource.'.freeze
+
+          def_node_matcher :nothing_action?, <<-PATTERN
+            (block (send nil? :action (sym :nothing)) (args) ... )
+          PATTERN
+
+          def on_block(node)
+            nothing_action?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.remove(node.source_range)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/correctness/resource_with_nothing_action.rb
+++ b/lib/rubocop/cop/chef/correctness/resource_with_nothing_action.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefCorrectness
-        # Chef Infra Client provides the :nothing action out of the box for every resource. There is no need to define a :nothing action in your resource code.
+        # Chef Infra Client provides the :nothing action by default for every resource. There is no need to define a :nothing action in your resource code.
         #
         # @example
         #
@@ -28,7 +28,7 @@ module RuboCop
         #   end
         #
         class ResourceWithNothingAction < Cop
-          MSG = 'There is no need to define a :nothing action in your resource as Chef Infra Client provides the :nothing action out of the box for every resource.'.freeze
+          MSG = 'There is no need to define a :nothing action in your resource as Chef Infra Client provides the :nothing action by default for every resource.'.freeze
 
           def_node_matcher :nothing_action?, <<-PATTERN
             (block (send nil? :action (sym :nothing)) (args) ... )

--- a/lib/rubocop/cop/chef/correctness/unnecessary_name_property.rb
+++ b/lib/rubocop/cop/chef/correctness/unnecessary_name_property.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefCorrectness
-        # There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources out of the box.
+        # There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources by default.
         #
         # @example
         #
@@ -27,7 +27,7 @@ module RuboCop
         #   property :name, String, name_property: true
         #
         class UnnecessaryNameProperty < Cop
-          MSG = 'There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources out of the box.'.freeze
+          MSG = 'There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources by default.'.freeze
 
           def_node_matcher :name_property?, <<-PATTERN
             (send nil? :property (sym :name) (const nil? :String) $...)

--- a/spec/rubocop/cop/chef/correctness/resource_with_nothing_action_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/resource_with_nothing_action_spec.rb
@@ -1,0 +1,41 @@
+#
+# Copyright:: Copyright 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::ResourceWithNothingAction do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense with a nothing action in a resource' do
+    expect_offense(<<~RUBY)
+      action :nothing do
+      ^^^^^^^^^^^^^^^^^^ There is no need to define a :nothing action in your resource as Chef Infra Client provides the :nothing action out of the box for every resource.
+        # standard nothing action
+      end
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it 'does not register an offense with other actions' do
+    expect_no_offenses(<<~RUBY)
+      action :create do
+        # stuff
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/resource_with_nothing_action_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/resource_with_nothing_action_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Chef::ChefCorrectness::ResourceWithNothingAction do
   it 'registers an offense with a nothing action in a resource' do
     expect_offense(<<~RUBY)
       action :nothing do
-      ^^^^^^^^^^^^^^^^^^ There is no need to define a :nothing action in your resource as Chef Infra Client provides the :nothing action out of the box for every resource.
+      ^^^^^^^^^^^^^^^^^^ There is no need to define a :nothing action in your resource as Chef Infra Client provides the :nothing action by default for every resource.
         # standard nothing action
       end
     RUBY

--- a/spec/rubocop/cop/chef/correctness/unnecessary_name_property_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/unnecessary_name_property_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Chef::ChefCorrectness::UnnecessaryNameProperty, :config d
   it 'registers an offense when a resource has a property called name' do
     expect_offense(<<~RUBY)
       property :name, String
-      ^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources out of the box.
+      ^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources by default.
     RUBY
 
     expect_correction("\n")
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Chef::ChefCorrectness::UnnecessaryNameProperty, :config d
   it 'registers an offense when a resource has a property called name that is a name_property' do
     expect_offense(<<~RUBY)
       property :name, String, name_property: true
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources out of the box.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources by default.
     RUBY
 
     expect_correction("\n")


### PR DESCRIPTION
Detect defining the nothing action in a resource when that doesn't do anything.

Signed-off-by: Tim Smith <tsmith@chef.io>