### PR TITLE
Allow # cookstyle comments in addition to # rubocop comments

### DIFF
--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -6,6 +6,7 @@ require 'yaml'
 # ensure the desired target version of RuboCop is gem activated
 gem 'rubocop', "= #{Cookstyle::RUBOCOP_VERSION}"
 require 'rubocop'
+require 'rubocop/monkey_patches/comment_config.rb'
 
 module RuboCop
   class ConfigLoader

--- a/lib/rubocop/monkey_patches/comment_config.rb
+++ b/lib/rubocop/monkey_patches/comment_config.rb
@@ -1,0 +1,10 @@
+module RuboCop
+  # we're monkey patching the config regex to allow for # cookstyle: disable whatever
+  # in addition to the # rubocop: disable whatever that comes with Rubocop
+  class CommentConfig
+    remove_const('COMMENT_DIRECTIVE_REGEXP')
+    COMMENT_DIRECTIVE_REGEXP = Regexp.new(
+      ('# (?:rubocop|cookstyle) : ((?:dis|en)able)\b ' + COPS_PATTERN).gsub(' ', '\s*')
+    )
+  end
+end

--- a/spec/rubocop/monkey_patches/cookstyle_comment_spec.rb
+++ b/spec/rubocop/monkey_patches/cookstyle_comment_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::CommentConfig do
     let(:source) do
       [
         'node.normal[:foo] # rubocop: disable ChefCorrectness/Bar',
-        'node.normal[:foo] # cookstyle: disable ChefCorrectness/Foo'
+        'node.normal[:foo] # cookstyle: disable ChefCorrectness/Foo',
       ].join("\n")
     end
 

--- a/spec/rubocop/monkey_patches/cookstyle_comment_spec.rb
+++ b/spec/rubocop/monkey_patches/cookstyle_comment_spec.rb
@@ -1,0 +1,46 @@
+#
+# Copyright:: Copyright 2019, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# this is shamelessly copied from the rubocop rspec for this class
+# since we're just monkeypatching it and we want to ensure our monkeypatch
+# continues to function when we upgrade the engine
+RSpec.describe RuboCop::CommentConfig do
+  subject(:comment_config) { described_class.new(parse_source(source)) }
+
+  describe '#cop_enabled_at_line?' do
+    let(:source) do
+      [
+        'node.normal[:foo] # rubocop: disable ChefCorrectness/Bar',
+        'node.normal[:foo] # cookstyle: disable ChefCorrectness/Foo'
+      ].join("\n")
+    end
+
+    def disabled_lines_of_cop(cop)
+      (1..source.size).each_with_object([]) do |line_number, disabled_lines|
+        enabled = comment_config.cop_enabled_at_line?(cop, line_number)
+        disabled_lines << line_number unless enabled
+      end
+    end
+
+    it 'supports disabling cops with the rubocop: disable comment' do
+      expect(disabled_lines_of_cop('ChefCorrectness/Bar')).to eq([1])
+    end
+
+    it 'supports disabling cops with the cookstyle: disable comment' do
+      expect(disabled_lines_of_cop('ChefCorrectness/Foo')).to eq([2])
+    end
+  end
+end


### PR DESCRIPTION
It seems weird to have a tool named Cookstyle that is controlled with Rubocop comments.

Now you can do this:

```ruby
node.normal['something']['something'] # cookstyle: disable ChefCorrectness/NodeNormal
```
Signed-off-by: Tim Smith <tsmith@chef.io>