### PR TITLE
Add Cookstyle vs. Foodcritic section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ See the current set of cops in [config/cookstyle.yml](https://github.com/chef/co
 
 RuboCop is an incredibly active project with new cops being introduced monthly. The new cops cause existing codebases to fail CI tests and force authors to constantly update their code. With Cookstyle, we update the RuboCop engine for bug and performance fixes, but we only change the set of cops that will fail tests once a year during Chef Infra's April major release. All new cops are introduced at RuboCop's "refactor" alert level, meaning they will alert to the screen as you run Cookstyle, but they won't fail a build. This stability means you are free to upgrade releases of Cookstyle without being forced to update your infrastructure code.
 
+## Cookstyle vs. Foodcritic
+
+Cookstyle is the replacement for Foodcritic. For more information on why we made the decision to replace Foodcritic see our blog post [Goodbye Foodcritic](https://blog.chef.io/goodbye-foodcritic/)
+
 ## Installation
 
 Cookstyle is included in the [ChefDK](https://downloads.chef.io/chefdk) and [Chef Workstation](https://downloads.chef.io/chef-workstation/). If you choose not to use these packages, you can still install Cookstyle manually using the instructions below.


### PR DESCRIPTION
Link to the blog post that spells out why we're not working on
Foodcritic anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>