### PR TITLE
Add ChefModernize/UnnecessaryMixlibShelloutRequire

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -897,6 +897,14 @@ ChefModernize/ZipfileResource:
   Enabled: true
   VersionAdded: '5.12.0'
 
+ChefModernize/UnnecessaryMixlibShelloutRequire:
+  Description: Chef Infra Client includes mixlib/shellout automatically in resources and providers.
+  Enabled: true
+  VersionAdded: '5.12.0'
+  Include:
+    - '**/resources/*.rb'
+    - '**/providers/*.rb'
+
 ###############################
 # Migrating to new patterns
 ###############################

--- a/lib/rubocop/cop/chef/modernize/unnecessary_mixlib_shellout_require.rb
+++ b/lib/rubocop/cop/chef/modernize/unnecessary_mixlib_shellout_require.rb
@@ -1,0 +1,51 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefModernize
+        # Chef Infra Client includes mixlib/shellout automatically in resources and providers.
+        #
+        # @example
+        #
+        #   # bad
+        #   require 'mixlib/shellout'
+        #
+        class UnnecessaryMixlibShelloutRequire < Cop
+          MSG = 'Chef Infra Client includes mixlib/shellout automatically in resources and providers.'.freeze
+
+          def_node_matcher :require_mixlibshellout?, <<-PATTERN
+          (send nil? :require ( str "mixlib/shellout"))
+          PATTERN
+
+          def on_send(node)
+            require_mixlibshellout?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.remove(node.loc.expression)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/unnecessary_mixlib_shellout_require_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/unnecessary_mixlib_shellout_require_spec.rb
@@ -1,0 +1,31 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefModernize::UnnecessaryMixlibShelloutRequire, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a resource / provider requires mixlib/shellout' do
+    expect_offense(<<~RUBY)
+      require 'mixlib/shellout'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client includes mixlib/shellout automatically in resources and providers.
+    RUBY
+
+    expect_correction("\n")
+  end
+end


### PR DESCRIPTION
Just simplify things a bit. No need for this.

Signed-off-by: Tim Smith <tsmith@chef.io>