### PR TITLE
DefaultActionFromInitialize: don't insert dupe default_action

### DIFF
--- a/lib/rubocop/cop/chef/modernize/default_action_initializer.rb
+++ b/lib/rubocop/cop/chef/modernize/default_action_initializer.rb
@@ -47,13 +47,17 @@ module RuboCop
             end
           end
 
+          def_node_search :default_action_method?, '(send nil? :default_action ... )'
+
           def_node_search :intialize_method, '(def :initialize ... )'
 
           def autocorrect(node)
             lambda do |corrector|
-              # insert the new default_action call above the initialize method
-              initialize_node = intialize_method(processed_source.ast).first
-              corrector.insert_before(initialize_node.source_range, "default_action #{node.descendants.first.source}\n\n")
+              # insert the new default_action call above the initialize method, but not if one already exists (this is sadly common)
+              unless default_action_method?(processed_source.ast)
+                initialize_node = intialize_method(processed_source.ast).first
+                corrector.insert_before(initialize_node.source_range, "default_action #{node.descendants.first.source}\n\n")
+              end
 
               # remove the variable from the initialize method
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))

--- a/spec/rubocop/cop/chef/modernize/default_action_initializer_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/default_action_initializer_spec.rb
@@ -38,6 +38,26 @@ describe RuboCop::Cop::Chef::ChefModernize::DefaultActionFromInitialize, :config
     RUBY
   end
 
+  it 'Deletes the intializer usage it if the DSL method already exists' do
+    expect_offense(<<~RUBY)
+      default_action :create
+
+      def initialize(*args)
+        super
+        @action = :create
+        ^^^^^^^^^^^^^^^^^ The default action of a resource can be set with the "default_action" helper instead of using the initialize method.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      default_action :create
+
+      def initialize(*args)
+        super
+      end
+    RUBY
+  end
+
   it 'does not register an offense with an empty initialize method' do
     expect_no_offenses(<<~RUBY)
     def initialize(*args)


### PR DESCRIPTION
For some reason a lot of people used both the DSL and the old intializer
method. We need to handle that and avoid double DSL usage

Signed-off-by: Tim Smith <tsmith@chef.io>