### PR TITLE
Add ChefDeprecations/LegacyNotifySyntax

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -610,6 +610,13 @@ ChefDeprecations/Cheffile:
   Include:
     - '**/Cheffile'
 
+ChefDeprecations/LegacyNotifySyntax:
+  Description: Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.
+  Enabled: true
+  VersionAdded: '5.13.0'
+  Exclude:
+    - '**/metadata.rb'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -44,7 +44,7 @@ module RuboCop
           MSG = 'Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.'.freeze
 
           def_node_matcher :legacy_notify?, <<-PATTERN
-            (send nil? :notifies $(sym _) (send nil? :resources (hash (pair $(sym _) $(...) ) ) ) $(...) )
+            (send nil? :notifies $(sym _) (send nil? :resources (hash (pair $(sym _) $(...) ) ) ) $... )
           PATTERN
 
           def on_send(node)
@@ -57,7 +57,7 @@ module RuboCop
             lambda do |corrector|
               legacy_notify?(node) do |action, type, name, timing|
                 new_val = "notifies #{action.source}, '#{type.source}[#{name.str_type? ? name.value : name.source}]'"
-                new_val << ", #{timing.source}" if timing
+                new_val << ", #{timing.first.source}" unless timing.empty?
                 corrector.replace(node.loc.expression, new_val)
               end
             end

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -56,7 +56,8 @@ module RuboCop
           def autocorrect(node)
             lambda do |corrector|
               legacy_notify?(node) do |action, type, name, timing|
-                new_val = "notifies #{action.source}, '#{type.source}[#{name.source}]'"
+                new_val = "notifies #{action.source}, '#{type.source}[#{name.str_type? ? name.value : name.source}]'"
+                new_val << ", #{timing.source}" if timing
                 corrector.replace(node.loc.expression, new_val)
               end
             end

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -27,9 +27,17 @@ module RuboCop
         #     notifies :restart, resources(service: 'apache')
         #   end
         #
+        #   template '/etc/www/configures-apache.conf' do
+        #     notifies :restart, resources(service: 'apache'), :immediately
+        #   end
+        #
         #   # good
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, 'service[apache]'
+        #   end
+        #
+        #   template '/etc/www/configures-apache.conf' do
+        #     notifies :restart, 'service[apache]', :immediately
         #   end
         #
         class LegacyNotifySyntax < Cop

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -1,0 +1,60 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.
+        #
+        # @example
+        #
+        #   # bad
+        #   template '/etc/www/configures-apache.conf' do
+        #     notifies :restart, resources(service: 'apache')
+        #   end
+        #
+        #   # good
+        #   template '/etc/www/configures-apache.conf' do
+        #     notifies :restart, 'service[apache]'
+        #   end
+        #
+        class LegacyNotifySyntax < Cop
+          MSG = 'Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.'.freeze
+
+          def_node_matcher :legacy_notify?, <<-PATTERN
+            (send nil? :notifies $(sym _) (send nil? :resources (hash (pair $(sym _) $(...) ) ) ) ... )
+          PATTERN
+
+          def on_send(node)
+            legacy_notify?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              legacy_notify?(node) do |action, type, name|
+                new_val = "notifies #{action.source}, '#{type.source}[#{name.source}]'"
+                corrector.replace(node.loc.expression, new_val)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -36,7 +36,7 @@ module RuboCop
           MSG = 'Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.'.freeze
 
           def_node_matcher :legacy_notify?, <<-PATTERN
-            (send nil? :notifies $(sym _) (send nil? :resources (hash (pair $(sym _) $(...) ) ) ) ... )
+            (send nil? :notifies $(sym _) (send nil? :resources (hash (pair $(sym _) $(...) ) ) ) $(...) )
           PATTERN
 
           def on_send(node)
@@ -47,7 +47,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              legacy_notify?(node) do |action, type, name|
+              legacy_notify?(node) do |action, type, name, timing|
                 new_val = "notifies #{action.source}, '#{type.source}[#{name.source}]'"
                 corrector.replace(node.loc.expression, new_val)
               end

--- a/spec/rubocop/cop/chef/deprecation/legacy_notify_syntax_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/legacy_notify_syntax_spec.rb
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::LegacyNotifySyntax, :config do
 
     expect_correction(<<~RUBY)
       foo 'bar' do
-        notifies :action, 'service[apache]'
+        notifies :restart, 'service[apache]'
       end
     RUBY
   end
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::LegacyNotifySyntax, :config do
 
     expect_correction(<<~RUBY)
     foo 'bar' do
-      notifies :action, 'service[apache]', :immediately
+      notifies :restart, 'service[apache]', :immediately
     end
     RUBY
   end

--- a/spec/rubocop/cop/chef/deprecation/legacy_notify_syntax_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/legacy_notify_syntax_spec.rb
@@ -49,6 +49,21 @@ describe RuboCop::Cop::Chef::ChefDeprecations::LegacyNotifySyntax, :config do
     RUBY
   end
 
+  it 'registers an offense when a resource uses the legacy notification syntax with a variable for the resource name' do
+    expect_offense(<<~RUBY)
+    foo 'bar' do
+      notifies :enable, resources(service: service_name + foo), :immediately
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.
+    end
+    RUBY
+
+    expect_correction(<<~RUBY)
+    foo 'bar' do
+      notifies :enable, 'service[service_name + foo]', :immediately
+    end
+    RUBY
+  end
+
   it "doesn't register an offense when using the modern notifies syntax" do
     expect_no_offenses(<<~RUBY)
     foo 'bar' do

--- a/spec/rubocop/cop/chef/deprecation/legacy_notify_syntax_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/legacy_notify_syntax_spec.rb
@@ -26,6 +26,12 @@ describe RuboCop::Cop::Chef::ChefDeprecations::LegacyNotifySyntax, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.
     end
     RUBY
+
+    expect_correction(<<~RUBY)
+      foo 'bar' do
+        notifies :action, 'service[apache]'
+      end
+    RUBY
   end
 
   it 'registers an offense when a resource uses the legacy notification syntax with the timing' do
@@ -33,6 +39,12 @@ describe RuboCop::Cop::Chef::ChefDeprecations::LegacyNotifySyntax, :config do
     foo 'bar' do
       notifies :restart, resources(service: 'apache'), :immediately
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.
+    end
+    RUBY
+
+    expect_correction(<<~RUBY)
+    foo 'bar' do
+      notifies :action, 'service[apache]', :immediately
     end
     RUBY
   end

--- a/spec/rubocop/cop/chef/deprecation/legacy_notify_syntax_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/legacy_notify_syntax_spec.rb
@@ -1,0 +1,47 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::LegacyNotifySyntax, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a resource uses the legacy notification syntax w/o the timing' do
+    expect_offense(<<~RUBY)
+    foo 'bar' do
+      notifies :restart, resources(service: 'apache')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.
+    end
+    RUBY
+  end
+
+  it 'registers an offense when a resource uses the legacy notification syntax with the timing' do
+    expect_offense(<<~RUBY)
+    foo 'bar' do
+      notifies :restart, resources(service: 'apache'), :immediately
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.
+    end
+    RUBY
+  end
+
+  it "doesn't register an offense when using the modern notifies syntax" do
+    expect_no_offenses(<<~RUBY)
+    foo 'bar' do
+      notifies :restart, 'service[apache]'
+    end
+    RUBY
+  end
+end


### PR DESCRIPTION
We had this in Foodcritic already so there aren't a ton of them, but we should catch them and nuke them from orbit

Signed-off-by: Tim Smith <tsmith@chef.io>