### PR TITLE
Adding correctable info to json formatter

### DIFF
--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -7,6 +7,7 @@ require 'yaml'
 gem 'rubocop', "= #{Cookstyle::RUBOCOP_VERSION}"
 require 'rubocop'
 require 'rubocop/monkey_patches/comment_config.rb'
+require 'rubocop/monkey_patches/json_formatter.rb'
 
 module RuboCop
   class ConfigLoader

--- a/lib/rubocop/monkey_patches/json_formatter.rb
+++ b/lib/rubocop/monkey_patches/json_formatter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Formatter
+    # This formatter formats the report data in JSON format.
+    class JSONFormatter < BaseFormatter
+      # We need to expose the correctable status until https://github.com/rubocop-hq/rubocop/pull/7514 is merged
+      def hash_for_offense(offense)
+        {
+          severity: offense.severity.name,
+          message: offense.message,
+          cop_name: offense.cop_name,
+          corrected: offense.corrected?,
+          correctable: offense.status != :unsupported,
+          location: hash_for_location(offense),
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
This allows us to generate chef-analyze reports which tell users how
many issues can be automatically corrected by Cookstyle.

We need to remove this after
https://github.com/rubocop-hq/rubocop/pull/7514 is merged, released and
we pin to that version of Rubocop.

## Related Issue
https://github.com/rubocop-hq/rubocop/pull/7514

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
