### PR TITLE
Add new TargetChefVersion config option

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1,5 +1,6 @@
 AllCops:
   TargetRubyVersion: 2.4
+  TargetChefVersion: ~
   Exclude:
     - files/**/*
     - vendor/**/*

--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -9,6 +9,11 @@ require 'rubocop'
 require 'rubocop/monkey_patches/comment_config.rb'
 require 'rubocop/monkey_patches/json_formatter.rb'
 
+# monkey patches needed for the TargetChefVersion config option
+require 'rubocop/monkey_patches/config.rb'
+require 'rubocop/monkey_patches/cop.rb'
+require 'rubocop/monkey_patches/commissioner.rb'
+
 module RuboCop
   class ConfigLoader
     RUBOCOP_HOME.gsub!(
@@ -35,6 +40,7 @@ end
 require 'rubocop/chef'
 require 'rubocop/chef/cookbook_helpers'
 require 'rubocop/chef/cookbook_only'
+require 'rubocop/cop/target_chef_version'
 
 # Chef specific cops
 Dir.glob(File.dirname(__FILE__) + '/rubocop/cop/chef/**/*.rb') do |file|

--- a/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
@@ -29,7 +29,7 @@ module RuboCop
         #
         #   rewind "user[postgres]" do
         #     home '/var/lib/pgsql/9.2'
-        #     cookbook 'my-postgresql'    # or `cookbook cookbook_name()`
+        #     cookbook 'my-postgresql'
         #   end
         #
         #   unwind "user[postgres]"

--- a/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
@@ -36,6 +36,9 @@ module RuboCop
         #
         class ChefRewind < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version '12.10'
 
           MAPPING = {
             rewind: 'edit_resource',

--- a/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
@@ -19,7 +19,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefDeprecations
-        # Use delete_resource / edit_resource instead of functionality in the deprecated chef-rewind gem
+        # Use delete_resource / edit_resource introduced in Chef Infra Client 12.10 instead of functionality in the deprecated chef-rewind gem
         #
         # @example
         #
@@ -42,7 +42,7 @@ module RuboCop
             unwind: 'delete_resource',
           }.freeze
 
-          MSG = 'Use delete_resource / edit_resource instead of functionality in the deprecated chef-rewind gem'.freeze
+          MSG = 'Use delete_resource / edit_resource introduced in Chef Infra Client 12.10 instead of functionality in the deprecated chef-rewind gem'.freeze
 
           def_node_matcher :rewind_gem_install?, <<-PATTERN
             (send nil? :chef_gem (str "chef-rewind"))

--- a/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
@@ -28,7 +28,7 @@ module RuboCop
         class CookbookDependsOnCompatResource < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 12.19
+          minimum_target_chef_version '12.19'
 
           MSG = "Don't depend on the deprecated compat_resource cookbook made obsolete by Chef 12.19+".freeze
 

--- a/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
@@ -26,6 +26,10 @@ module RuboCop
         #   depends 'compat_resource'
         #
         class CookbookDependsOnCompatResource < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 12.19
+
           MSG = "Don't depend on the deprecated compat_resource cookbook made obsolete by Chef 12.19+".freeze
 
           def_node_matcher :depends_compat_resource?, <<-PATTERN

--- a/lib/rubocop/cop/chef/modernize/apt_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/apt_default_recipe.rb
@@ -31,6 +31,10 @@ module RuboCop
         #   apt_update
         #
         class IncludingAptDefaultRecipe < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 12.7
+
           MSG = 'Do not include the Apt default recipe to update package cache. Instead use the apt_update resource, which is built into Chef Infra Client 12.7 and later.'.freeze
 
           def_node_matcher :apt_recipe_usage?, <<-PATTERN

--- a/lib/rubocop/cop/chef/modernize/apt_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/apt_default_recipe.rb
@@ -33,7 +33,7 @@ module RuboCop
         class IncludingAptDefaultRecipe < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 12.7
+          minimum_target_chef_version '12.7'
 
           MSG = 'Do not include the Apt default recipe to update package cache. Instead use the apt_update resource, which is built into Chef Infra Client 12.7 and later.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/build_essential.rb
+++ b/lib/rubocop/cop/chef/modernize/build_essential.rb
@@ -31,6 +31,10 @@ module RuboCop
         #   build_essential 'install compilation tools'
         #
         class UseBuildEssentialResource < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 14.0
+
           MSG = 'Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+'.freeze
 
           def_node_matcher :build_essential_recipe_usage?, <<-PATTERN

--- a/lib/rubocop/cop/chef/modernize/build_essential.rb
+++ b/lib/rubocop/cop/chef/modernize/build_essential.rb
@@ -31,10 +31,6 @@ module RuboCop
         #   build_essential 'install compilation tools'
         #
         class UseBuildEssentialResource < Cop
-          extend TargetChefVersion
-
-          minimum_target_chef_version 14.0
-
           MSG = 'Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+'.freeze
 
           def_node_matcher :build_essential_recipe_usage?, <<-PATTERN

--- a/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
@@ -34,7 +34,7 @@ module RuboCop
         class UnnecessaryDependsChef14 < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 14.0
+          minimum_target_chef_version '14.0'
 
           MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.".freeze
 

--- a/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
@@ -32,6 +32,10 @@ module RuboCop
         #   depends 'sysctl'
         #
         class UnnecessaryDependsChef14 < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 14.0
+
           MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.".freeze
 
           def_node_matcher :legacy_depends?, <<-PATTERN

--- a/lib/rubocop/cop/chef/modernize/cron_manage_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_manage_resource.rb
@@ -29,6 +29,10 @@ module RuboCop
         #   cron_access 'mike'
         #
         class CronManageResource < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 14.4
+
           MSG = 'The cron_manage resource was renamed to cron_access in the 6.1 release of the cron cookbook and later shipped in Chef Infra Client 14.4. The new resource name should be used.'.freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/cron_manage_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_manage_resource.rb
@@ -31,7 +31,7 @@ module RuboCop
         class CronManageResource < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 14.4
+          minimum_target_chef_version '14.4'
 
           MSG = 'The cron_manage resource was renamed to cron_access in the 6.1 release of the cron cookbook and later shipped in Chef Infra Client 14.4. The new resource name should be used.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
@@ -26,6 +26,10 @@ module RuboCop
         #   depends 'zypper'
         #
         class DependsOnZypperCookbook < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 13.3
+
           MSG = "Don't include the zypper cookbook as the zypper_repository resource is built into Chef Infra Client 13.3+".freeze
 
           def_node_matcher :zypper_depends?, <<-PATTERN

--- a/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
@@ -28,7 +28,7 @@ module RuboCop
         class DependsOnZypperCookbook < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 13.3
+          minimum_target_chef_version '13.3'
 
           MSG = "Don't include the zypper cookbook as the zypper_repository resource is built into Chef Infra Client 13.3+".freeze
 

--- a/lib/rubocop/cop/chef/modernize/execute_tzutil.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_tzutil.rb
@@ -40,7 +40,7 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
 
-          minimum_target_chef_version 14.6
+          minimum_target_chef_version '14.6'
 
           MSG = 'Use the timezone resource included in Chef Infra Client 14.6+ instead of shelling out to tzutil'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/execute_tzutil.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_tzutil.rb
@@ -38,6 +38,9 @@ module RuboCop
         #
         class ExecuteTzUtil < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version 14.6
 
           MSG = 'Use the timezone resource included in Chef Infra Client 14.6+ instead of shelling out to tzutil'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/libarchive_file.rb
+++ b/lib/rubocop/cop/chef/modernize/libarchive_file.rb
@@ -31,7 +31,7 @@ module RuboCop
         class LibarchiveFileResource < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 15.0
+          minimum_target_chef_version '15.0'
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/libarchive_file.rb
+++ b/lib/rubocop/cop/chef/modernize/libarchive_file.rb
@@ -29,6 +29,10 @@ module RuboCop
         #   end
         #
         class LibarchiveFileResource < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 15.0
+
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource'.freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/macos_user_defaults.rb
+++ b/lib/rubocop/cop/chef/modernize/macos_user_defaults.rb
@@ -36,6 +36,10 @@ module RuboCop
         #   end
         #
         class MacOsXUserdefaults < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 14.0
+
           MSG = 'The mac_os_x_userdefaults resource was renamed to macos_userdefaults when it was added to Chef Infra Client 14.0. The new resource name should be used.'.freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/macos_user_defaults.rb
+++ b/lib/rubocop/cop/chef/modernize/macos_user_defaults.rb
@@ -38,7 +38,7 @@ module RuboCop
         class MacOsXUserdefaults < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 14.0
+          minimum_target_chef_version '14.0'
 
           MSG = 'The mac_os_x_userdefaults resource was renamed to macos_userdefaults when it was added to Chef Infra Client 14.0. The new resource name should be used.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/openssl_rsa_key_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/openssl_rsa_key_resource.rb
@@ -34,7 +34,7 @@ module RuboCop
         class OpensslRsaKeyResource < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 14.0
+          minimum_target_chef_version '14.0'
 
           MSG = 'The openssl_rsa_key resource was renamed to openssl_rsa_private_key in Chef Infra Client 14.0. The new resource name should be used.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/openssl_rsa_key_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/openssl_rsa_key_resource.rb
@@ -32,6 +32,10 @@ module RuboCop
         #   end
         #
         class OpensslRsaKeyResource < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 14.0
+
           MSG = 'The openssl_rsa_key resource was renamed to openssl_rsa_private_key in Chef Infra Client 14.0. The new resource name should be used.'.freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/openssl_x509_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/openssl_x509_resource.rb
@@ -40,7 +40,7 @@ module RuboCop
         class OpensslX509Resource < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 14.4
+          minimum_target_chef_version '14.4'
 
           MSG = 'The openssl_x509 resource was renamed to openssl_x509_certificate in Chef Infra Client 14.4. The new resource name should be used.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/openssl_x509_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/openssl_x509_resource.rb
@@ -38,6 +38,10 @@ module RuboCop
         #   end
         #
         class OpensslX509Resource < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 14.4
+
           MSG = 'The openssl_x509 resource was renamed to openssl_x509_certificate in Chef Infra Client 14.4. The new resource name should be used.'.freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/powershell_expand_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_expand_archive.rb
@@ -32,7 +32,7 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
 
-          minimum_target_chef_version 15.0
+          minimum_target_chef_version '15.0'
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of using Expand-Archive in a powershell_script resource'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/powershell_expand_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_expand_archive.rb
@@ -30,6 +30,9 @@ module RuboCop
         #
         class PowershellScriptExpandArchive < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version 15.0
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of using Expand-Archive in a powershell_script resource'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
@@ -38,7 +38,7 @@ module RuboCop
           include RangeHelp
           extend TargetChefVersion
 
-          minimum_target_chef_version 13.0
+          minimum_target_chef_version '13.0'
 
           MSG = 'PowerShell is already set as the default guard interpreter for powershell_script resources in Chef Infra Client 13 and later and does not need to be specified.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
@@ -36,6 +36,9 @@ module RuboCop
         class PowerShellGuardInterpreter < Cop
           include RuboCop::Chef::CookbookHelpers
           include RangeHelp
+          extend TargetChefVersion
+
+          minimum_target_chef_version 13.0
 
           MSG = 'PowerShell is already set as the default guard interpreter for powershell_script resources in Chef Infra Client 13 and later and does not need to be specified.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/powershell_install_package.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_install_package.rb
@@ -33,6 +33,9 @@ module RuboCop
         #
         class PowershellInstallPackage < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version 12.16
 
           MSG = 'Use the powershell_package resource built into Chef Infra Client 12.16+ instead of using Install-Package in a powershell_script resource'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/powershell_install_package.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_install_package.rb
@@ -35,7 +35,7 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
 
-          minimum_target_chef_version 12.16
+          minimum_target_chef_version '12.16'
 
           MSG = 'Use the powershell_package resource built into Chef Infra Client 12.16+ instead of using Install-Package in a powershell_script resource'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/powershell_install_windowsfeature.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_install_windowsfeature.rb
@@ -36,6 +36,9 @@ module RuboCop
         #
         class PowershellInstallWindowsFeature < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version 13.0
 
           MSG = 'Use the windows_feature resource built into Chef Infra Client 13+ instead of using Install-WindowsFeature or Add-WindowsFeature in a powershell_script resource'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/powershell_install_windowsfeature.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_install_windowsfeature.rb
@@ -38,7 +38,7 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
 
-          minimum_target_chef_version 13.0
+          minimum_target_chef_version '13.0'
 
           MSG = 'Use the windows_feature resource built into Chef Infra Client 13+ instead of using Install-WindowsFeature or Add-WindowsFeature in a powershell_script resource'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/respond_to_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/respond_to_metadata.rb
@@ -34,6 +34,10 @@ module RuboCop
         #   chef_version '>= 13'
         #
         class RespondToInMetadata < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 12.15
+
           MSG = 'It is no longer necessary to use respond_to? or if_defined? in metadata.rb in Chef Infra Client 12.15 and later'.freeze
 
           def on_if(node)

--- a/lib/rubocop/cop/chef/modernize/respond_to_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/respond_to_metadata.rb
@@ -36,7 +36,7 @@ module RuboCop
         class RespondToInMetadata < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 12.15
+          minimum_target_chef_version '12.15'
 
           MSG = 'It is no longer necessary to use respond_to? or if_defined? in metadata.rb in Chef Infra Client 12.15 and later'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
@@ -29,6 +29,10 @@ module RuboCop
         #   end
         #
         class SevenZipArchiveResource < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 15.0
+
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the seven_zip_archive'.freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
@@ -31,7 +31,7 @@ module RuboCop
         class SevenZipArchiveResource < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 15.0
+          minimum_target_chef_version '15.0'
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the seven_zip_archive'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/systctl_param_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/systctl_param_resource.rb
@@ -18,8 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefModernize
-        # The sysctl_param resource was renamed to sysctl when it was added to Chef Infra Client
-        # 14.0. The new resource name should be used.
+        # The sysctl_param resource was renamed to sysctl when it was added to Chef Infra Client 14.0. The new resource name should be used.
         #
         #   # bad
         #   sysctl_param 'fs.aio-max-nr' do
@@ -33,6 +32,9 @@ module RuboCop
         #
         class SysctlParamResource < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version 14.0
 
           MSG = 'The sysctl_param resource was renamed to sysctl when it was added to Chef Infra Client 14.0. The new resource name should be used.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/systctl_param_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/systctl_param_resource.rb
@@ -34,7 +34,7 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
 
-          minimum_target_chef_version 14.0
+          minimum_target_chef_version '14.0'
 
           MSG = 'The sysctl_param resource was renamed to sysctl when it was added to Chef Infra Client 14.0. The new resource name should be used.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/whyrun_supported_true.rb
+++ b/lib/rubocop/cop/chef/modernize/whyrun_supported_true.rb
@@ -28,6 +28,10 @@ module RuboCop
         #   end
         #
         class WhyRunSupportedTrue < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 13.0
+
           MSG = 'whyrun_supported? no longer needs to be set to true as it is the default in Chef Infra Client 13+'.freeze
 
           def on_def(node)

--- a/lib/rubocop/cop/chef/modernize/whyrun_supported_true.rb
+++ b/lib/rubocop/cop/chef/modernize/whyrun_supported_true.rb
@@ -30,7 +30,7 @@ module RuboCop
         class WhyRunSupportedTrue < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 13.0
+          minimum_target_chef_version '13.0'
 
           MSG = 'whyrun_supported? no longer needs to be set to true as it is the default in Chef Infra Client 13+'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/windows_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_default_recipe.rb
@@ -18,8 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefModernize
-        # Don't include the windows default recipe that is either full of gem install that are part
-        # of the Chef Infra Client, or empty (depends on version).
+        # Don't include the windows default recipe that is either full of gem install that are part of the Chef Infra Client, or empty (depends on version).
         #
         # @example
         #

--- a/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
@@ -30,7 +30,7 @@ module RuboCop
         class WindowsZipfileUsage < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 15.0
+          minimum_target_chef_version '15.0'
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the windows_zipfile from the Windows cookbook'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
@@ -28,6 +28,10 @@ module RuboCop
         #   end
         #
         class WindowsZipfileUsage < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 15.0
+
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the windows_zipfile from the Windows cookbook'.freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
@@ -32,7 +32,7 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
 
-          minimum_target_chef_version 15.0
+          minimum_target_chef_version '15.0'
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the zipfile resource from the zipfile cookbook.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
@@ -30,6 +30,9 @@ module RuboCop
         #
         class ZipfileResource < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version 15.0
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the zipfile resource from the zipfile cookbook.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/zypper_repo.rb
+++ b/lib/rubocop/cop/chef/modernize/zypper_repo.rb
@@ -41,7 +41,7 @@ module RuboCop
         class UsesZypperRepo < Cop
           extend TargetChefVersion
 
-          minimum_target_chef_version 13.3
+          minimum_target_chef_version '13.3'
 
           MSG = 'The zypper_repo resource was renamed zypper_repository when it was added to Chef Infra Client 13.3.'.freeze
 

--- a/lib/rubocop/cop/chef/modernize/zypper_repo.rb
+++ b/lib/rubocop/cop/chef/modernize/zypper_repo.rb
@@ -39,6 +39,10 @@ module RuboCop
         #   end
         #
         class UsesZypperRepo < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version 13.3
+
           MSG = 'The zypper_repo resource was renamed zypper_repository when it was added to Chef Infra Client 13.3.'.freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
@@ -26,7 +26,6 @@ module RuboCop
         #   # bad
         #   long_description 'this is my cookbook and this description will never be seen'
         #
-
         class LongDescriptionMetadata < Cop
           include RangeHelp
 

--- a/lib/rubocop/cop/target_chef_version.rb
+++ b/lib/rubocop/cop/target_chef_version.rb
@@ -11,7 +11,7 @@ module RuboCop
       end
 
       def support_target_chef_version?(version)
-        @minimum_target_chef_version <= version
+        Gem::Version.new(@minimum_target_chef_version) <= Gem::Version.new(version)
       end
     end
   end

--- a/lib/rubocop/cop/target_chef_version.rb
+++ b/lib/rubocop/cop/target_chef_version.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# shamelessly borrowed from rubocop-rails. Thanks!
+
+module RuboCop
+  module Cop
+    # Common functionality for checking target chef version.
+    module TargetChefVersion
+      def minimum_target_chef_version(version)
+        @minimum_target_chef_version = version
+      end
+
+      def support_target_chef_version?(version)
+        @minimum_target_chef_version <= version
+      end
+    end
+  end
+end

--- a/lib/rubocop/monkey_patches/commissioner.rb
+++ b/lib/rubocop/monkey_patches/commissioner.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    class Commissioner
+      def remove_irrelevant_cops(filename)
+        @cops.reject! { |cop| cop.excluded_file?(filename) }
+        @cops.reject! do |cop|
+          cop.class.respond_to?(:support_target_ruby_version?) &&
+            !cop.class.support_target_ruby_version?(cop.target_ruby_version)
+        end
+        @cops.reject! do |cop|
+          cop.class.respond_to?(:support_target_rails_version?) &&
+            !cop.class.support_target_rails_version?(cop.target_rails_version)
+        end
+
+        ### START COOKSTYLE MODIFICATION
+        @cops.reject! do |cop|
+          cop.class.respond_to?(:support_target_chef_version?) &&
+            !cop.class.support_target_chef_version?(cop.target_chef_version)
+        end
+        ### END COOKSTYLE MODIFICATION
+      end
+    end
+  end
+end

--- a/lib/rubocop/monkey_patches/config.rb
+++ b/lib/rubocop/monkey_patches/config.rb
@@ -2,15 +2,13 @@
 
 module RuboCop
   class Config
-    DEFAULT_CHEF_VERSION = 15
-
     # This is a copy of the #target_rails_version method from Rubocop
     def target_chef_version
       @target_chef_version ||=
         if for_all_cops['TargetChefVersion']
           for_all_cops['TargetChefVersion'].to_f
         else
-          DEFAULT_CHEF_VERSION
+          99 # just set a high number so we don't need to update this later
         end
     end
   end

--- a/lib/rubocop/monkey_patches/config.rb
+++ b/lib/rubocop/monkey_patches/config.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class Config
+    DEFAULT_CHEF_VERSION = 15
+
+    # This is a copy of the #target_rails_version method from Rubocop
+    def target_chef_version
+      @target_chef_version ||=
+        if for_all_cops['TargetChefVersion']
+          for_all_cops['TargetChefVersion'].to_f
+        else
+          DEFAULT_CHEF_VERSION
+        end
+    end
+  end
+end

--- a/lib/rubocop/monkey_patches/cop.rb
+++ b/lib/rubocop/monkey_patches/cop.rb
@@ -1,0 +1,10 @@
+module RuboCop
+  module Cop
+    class Cop
+      # This is a copy of the #target_rails_version method from rubocop-rails
+      def target_chef_version
+        @config.target_chef_version
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/chef_rewind_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_rewind_spec.rb
@@ -98,4 +98,23 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ChefRewind, :config do
       require 'chef/resource'
     RUBY
   end
+
+  context 'with TargetChefVersion set to 12.9' do
+    let(:config) { target_chef_version(12.9) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        chef_gem 'chef-rewind'
+
+        require 'chef/rewind'
+
+        unwind 'user[postgres]'
+
+        rewind 'user[postgres]' do
+          home '/var/lib/pgsql/9.2'
+          cookbook 'my-postgresql'
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/chef_rewind_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_rewind_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ChefRewind, :config do
   it 'registers an offense with a non-block chef_gem chef-rewind install' do
     expect_offense(<<~RUBY)
       chef_gem 'chef-rewind'
-      ^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource instead of functionality in the deprecated chef-rewind gem
+      ^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource introduced in Chef Infra Client 12.10 instead of functionality in the deprecated chef-rewind gem
     RUBY
 
     expect_correction("\n")
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ChefRewind, :config do
   it 'registers an offense with a block form chef_gem chef-rewind install' do
     expect_offense(<<~RUBY)
       chef_gem 'chef-rewind' do
-      ^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource instead of functionality in the deprecated chef-rewind gem
+      ^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource introduced in Chef Infra Client 12.10 instead of functionality in the deprecated chef-rewind gem
         compile_time true
       end
     RUBY
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ChefRewind, :config do
   it 'registers an offense with chef_gem installing chef_rewind with the package_name property' do
     expect_offense(<<~RUBY)
       chef_gem 'Install chef-rewind gem' do
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource instead of functionality in the deprecated chef-rewind gem
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource introduced in Chef Infra Client 12.10 instead of functionality in the deprecated chef-rewind gem
         package_name 'chef-rewind'
       end
     RUBY
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ChefRewind, :config do
   it 'registers an offense when requiring chef/rewind' do
     expect_offense(<<~RUBY)
       require 'chef/rewind'
-      ^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource instead of functionality in the deprecated chef-rewind gem
+      ^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource introduced in Chef Infra Client 12.10 instead of functionality in the deprecated chef-rewind gem
     RUBY
 
     expect_correction("\n")
@@ -62,7 +62,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ChefRewind, :config do
   it 'registers an offense when using the rewind resource' do
     expect_offense(<<~RUBY)
       rewind 'user[postgres]' do
-      ^^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource instead of functionality in the deprecated chef-rewind gem
+      ^^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource introduced in Chef Infra Client 12.10 instead of functionality in the deprecated chef-rewind gem
         home '/var/lib/pgsql/9.2'
         cookbook 'my-postgresql' # or `cookbook cookbook_name()`
       end
@@ -79,7 +79,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ChefRewind, :config do
   it 'registers an offense when using the unwind resource' do
     expect_offense(<<~RUBY)
       unwind 'user[postgres]'
-      ^^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource instead of functionality in the deprecated chef-rewind gem
+      ^^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource introduced in Chef Infra Client 12.10 instead of functionality in the deprecated chef-rewind gem
     RUBY
 
     expect_correction(<<~RUBY)

--- a/spec/rubocop/cop/chef/deprecation/chef_rewind_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_rewind_spec.rb
@@ -64,14 +64,14 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ChefRewind, :config do
       rewind 'user[postgres]' do
       ^^^^^^^^^^^^^^^^^^^^^^^ Use delete_resource / edit_resource introduced in Chef Infra Client 12.10 instead of functionality in the deprecated chef-rewind gem
         home '/var/lib/pgsql/9.2'
-        cookbook 'my-postgresql' # or `cookbook cookbook_name()`
+        cookbook 'my-postgresql'
       end
     RUBY
 
     expect_correction(<<~RUBY)
     edit_resource 'user[postgres]' do
       home '/var/lib/pgsql/9.2'
-      cookbook 'my-postgresql' # or `cookbook cookbook_name()`
+      cookbook 'my-postgresql'
     end
     RUBY
   end

--- a/spec/rubocop/cop/chef/deprecation/depends_compat_resource_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/depends_compat_resource_spec.rb
@@ -33,4 +33,14 @@ describe RuboCop::Cop::Chef::ChefDeprecations::CookbookDependsOnCompatResource, 
       depends 'foo'
     RUBY
   end
+
+  context 'with TargetChefVersion set to 12' do
+    let(:config) { target_chef_version(12) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'compat_resource'
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/apt_default_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/apt_default_recipe_spec.rb
@@ -38,4 +38,14 @@ describe RuboCop::Cop::Chef::ChefModernize::IncludingAptDefaultRecipe, :config d
       include_recipe 'foo'
     RUBY
   end
+
+  context 'with TargetChefVersion set to 12' do
+    let(:config) { target_chef_version(12) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+      include_recipe 'apt::default'
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/chef_14_resources_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/chef_14_resources_spec.rb
@@ -80,4 +80,14 @@ describe RuboCop::Cop::Chef::ChefModernize::UnnecessaryDependsChef14, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
+
+  context 'with TargetChefVersion set to 13' do
+    let(:config) { target_chef_version(13) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'build-essential', '>= 8.0.1'
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/cron_manage_resource_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/cron_manage_resource_spec.rb
@@ -35,4 +35,14 @@ describe RuboCop::Cop::Chef::ChefModernize::CronManageResource, :config do
     cron_access 'mike'
     RUBY
   end
+
+  context 'with TargetChefVersion set to 14.3' do
+    let(:config) { target_chef_version(14.3) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        cron_manage 'mike'
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/depends_zypper_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/depends_zypper_cookbook_spec.rb
@@ -31,4 +31,14 @@ describe RuboCop::Cop::Chef::ChefModernize::DependsOnZypperCookbook, :config do
       depends 'foo'
     RUBY
   end
+
+  context 'with TargetChefVersion set to 13.2' do
+    let(:config) { target_chef_version(13.2) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'zypper'
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/execute_tzutil_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/execute_tzutil_spec.rb
@@ -50,4 +50,16 @@ describe RuboCop::Cop::Chef::ChefModernize::ExecuteTzUtil, :config do
     timezone 'UTC'
     RUBY
   end
+
+  context 'with TargetChefVersion set to 14.5' do
+    let(:config) { target_chef_version(14.5) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        execute 'set tz' do
+          command 'tzutil.exe /s UTC'
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/libarchive_file_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/libarchive_file_spec.rb
@@ -37,4 +37,17 @@ describe RuboCop::Cop::Chef::ChefModernize::LibarchiveFileResource, :config do
       end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 14' do
+    let(:config) { target_chef_version(14) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        libarchive_file 'Precompiled.zip' do
+          path "foo/bar.zip"
+          extract_to "/foo/bar"
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/macos_user_defaults_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/macos_user_defaults_spec.rb
@@ -47,4 +47,18 @@ describe RuboCop::Cop::Chef::ChefModernize::MacOsXUserdefaults, :config do
     end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 13' do
+    let(:config) { target_chef_version(13) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        mac_os_x_userdefaults 'full keyboard access to all controls' do
+          domain 'AppleKeyboardUIMode'
+          global true
+          value '2'
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/openssl_rsa_key_resource_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/openssl_rsa_key_resource_spec.rb
@@ -41,4 +41,16 @@ describe RuboCop::Cop::Chef::ChefModernize::OpensslRsaKeyResource, :config do
     end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 13' do
+    let(:config) { target_chef_version(13) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        openssl_rsa_key '/etc/httpd/ssl/server.key' do
+          key_length 2048
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/openssl_x509_resource_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/openssl_x509_resource_spec.rb
@@ -50,4 +50,19 @@ describe RuboCop::Cop::Chef::ChefModernize::OpensslX509Resource, :config do
     end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 14.3' do
+    let(:config) { target_chef_version(14.3) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        openssl_x509 '/etc/httpd/ssl/mycert.pem' do
+          common_name 'www.f00bar.com'
+          org 'Foo Bar'
+          org_unit 'Lab'
+          country 'US'
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/powershell_expand_archive_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/powershell_expand_archive_spec.rb
@@ -35,4 +35,16 @@ describe RuboCop::Cop::Chef::ChefModernize::PowershellScriptExpandArchive, :conf
       end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 14' do
+    let(:config) { target_chef_version(14) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        powershell_script 'Expand website' do
+          code 'Expand-Archive "C:\\file.zip" -DestinationPath "C:\\inetpub\\wwwroot\\" -Force'
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/powershell_guard_interpreter_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/powershell_guard_interpreter_spec.rb
@@ -43,4 +43,17 @@ describe RuboCop::Cop::Chef::ChefModernize::PowerShellGuardInterpreter, :config 
     end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 12' do
+    let(:config) { target_chef_version(12) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+      powershell_script 'whatever' do
+        code "mkdir test_dir"
+        guard_interpreter :powershell_script
+      end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/powershell_install_package_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/powershell_install_package_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ChefModernize::PowershellInstallPackage, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when using the libarchive_file resource' do
+  it 'registers an offense when using powershell_script to run Install-Package' do
     expect_offense(<<~RUBY)
       powershell_script 'Expand website' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the powershell_package resource built into Chef Infra Client 12.16+ instead of using Install-Package in a powershell_script resource
@@ -34,5 +34,17 @@ describe RuboCop::Cop::Chef::ChefModernize::PowershellInstallPackage, :config do
         code 'Nope nope nope'
       end
     RUBY
+  end
+
+  context 'with TargetChefVersion set to 12.15' do
+    let(:config) { target_chef_version(12.15) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        powershell_script 'Expand website' do
+          code 'Install-Package -Name docker'
+        end
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/chef/modernize/powershell_install_windowsfeature_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/powershell_install_windowsfeature_spec.rb
@@ -44,4 +44,16 @@ describe RuboCop::Cop::Chef::ChefModernize::PowershellInstallWindowsFeature, :co
       end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 12' do
+    let(:config) { target_chef_version(12) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        powershell_script 'Install Feature' do
+          code 'Install-WindowsFeature -Name "Net-framework-Core"'
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/respond_to_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/respond_to_metadata_spec.rb
@@ -59,4 +59,14 @@ describe RuboCop::Cop::Chef::ChefModernize::RespondToInMetadata, :config do
       chef_version '> 13'
     RUBY
   end
+
+  context 'with TargetChefVersion set to 12.14' do
+    let(:config) { target_chef_version(12.14) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        chef_version '> 13' if defined?(chef_version)
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/seven_zip_archive_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/seven_zip_archive_spec.rb
@@ -37,4 +37,17 @@ describe RuboCop::Cop::Chef::ChefModernize::SevenZipArchiveResource, :config do
       end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 14' do
+    let(:config) { target_chef_version(14) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        seven_zip_archive 'extract files' do
+          path 'C:\path'
+          source 'C:\file.zip'
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/systctl_param_resource_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/systctl_param_resource_spec.rb
@@ -41,4 +41,16 @@ describe RuboCop::Cop::Chef::ChefModernize::SysctlParamResource, :config do
     end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 13' do
+    let(:config) { target_chef_version(13) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        sysctl_param 'fs.aio-max-nr' do
+          value '1048576'
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/whyrun_supported_true_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/whyrun_supported_true_spec.rb
@@ -33,4 +33,14 @@ describe RuboCop::Cop::Chef::ChefModernize::WhyRunSupportedTrue, :config do
       def whyrun_supported?; false; end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 12' do
+    let(:config) { target_chef_version(12) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        def whyrun_supported?; true; end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/windows_zipfile_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/windows_zipfile_spec.rb
@@ -37,4 +37,17 @@ describe RuboCop::Cop::Chef::ChefModernize::WindowsZipfileUsage, :config do
       end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 14' do
+    let(:config) { target_chef_version(14) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        windows_zipfile 'Precompiled.zip' do
+          some_prop 'foo'
+          another_prop 'bar'
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/zipfile_resource_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/zipfile_resource_spec.rb
@@ -37,6 +37,15 @@ describe RuboCop::Cop::Chef::ChefModernize::ZipfileResource, :config do
     RUBY
   end
 
+  it "doesn't register an offense when using the archive_file resource" do
+    expect_no_offenses(<<~RUBY)
+      archive_file 'Precompiled.zip' do
+        path '/tmp/Precompiled.zip'
+        destination '/srv/files'
+      end
+    RUBY
+  end
+
   context 'with TargetChefVersion set to 14' do
     let(:config) { target_chef_version(14) }
 

--- a/spec/rubocop/cop/chef/modernize/zipfile_resource_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/zipfile_resource_spec.rb
@@ -37,12 +37,13 @@ describe RuboCop::Cop::Chef::ChefModernize::ZipfileResource, :config do
     RUBY
   end
 
-  it "doesn't register an offense when using the archive_file resource" do
-    expect_no_offenses(<<~RUBY)
-      archive_file 'Precompiled.zip' do
-        path '/tmp/Precompiled.zip'
-        destination '/srv/files'
-      end
-    RUBY
+  context 'with TargetChefVersion set to 14' do
+    let(:config) { target_chef_version(14) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'zipfile'
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/chef/modernize/zypper_repo_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/zypper_repo_spec.rb
@@ -50,4 +50,19 @@ describe RuboCop::Cop::Chef::ChefModernize::UsesZypperRepo, :config do
     end
     RUBY
   end
+
+  context 'with TargetChefVersion set to 13.2' do
+    let(:config) { target_chef_version(13.2) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        zypper_repo 'apache' do
+          baseurl 'http://download.opensuse.org/repositories/Apache'
+          path '/openSUSE_Leap_42.2'
+          type 'rpm-md'
+          priority '100'
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,14 +14,6 @@ RSpec.configure do |config|
   config.filter_run(:focus)
   config.order = :random
 
-  config.expect_with :rspec do |expectations|
-    expectations.syntax = :expect # Disable `should`
-  end
-
-  config.mock_with :rspec do |mocks|
-    mocks.syntax = :expect # Disable `should_receive` and `stub`
-  end
-
   config.include RuboCop::RSpec::ExpectOffense
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,4 +20,9 @@ end
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
+# small helper for use in let blocks
+def target_chef_version(version)
+  RuboCop::Config.new('AllCops' => { 'TargetChefVersion' => version })
+end
+
 require 'cookstyle'


### PR DESCRIPTION
This allows the user to disable any cop that would suggest updating a
cookbook in a way that would make it incompatible with earlier versions
of Chef Infra. This is necessary to allow users to step upgrade from 12
-> 13 -> 14 -> 15 without breaking a cookbook in a way where it will
only work in Chef Infra 15. Most of this is monkeypatching rubocop
itself to add / modify methods the same way Rubocop core already
supports this code with Rails. Lots of patching. Ideally, Rubocop can do
this natively without the monkeypatching soon.

Signed-off-by: Tim Smith <tsmith@chef.io>