### PR TITLE
Move the metadata cops to ChefModernize

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -304,55 +304,6 @@ ChefDeprecations/CookbookDependsOnPoise:
   Include:
     - '**/metadata.rb'
 
-ChefDeprecations/ConflictsMetadata:
-  Description: Don't use the deprecated 'conflicts' metadata value
-  Enabled: true
-  VersionAdded: '5.1.0'
-  Include:
-    - '**/metadata.rb'
-
-ChefDeprecations/SuggestsMetadata:
-  Description: Don't use the deprecated 'suggests' metadata value
-  Enabled: true
-  VersionAdded: '5.1.0'
-  Include:
-    - '**/metadata.rb'
-
-ChefDeprecations/ProvidesMetadata:
-  Description: Don't use the deprecated 'provides' metadata value
-  Enabled: true
-  VersionAdded: '5.1.0'
-  Include:
-    - '**/metadata.rb'
-
-ChefDeprecations/ReplacesMetadata:
-  Description: Don't use the deprecated 'replaces' metadata value
-  Enabled: true
-  VersionAdded: '5.1.0'
-  Include:
-    - '**/metadata.rb'
-
-ChefDeprecations/AttributeMetadata:
-  Description: Don't use the deprecated 'attribute' metadata value
-  Enabled: true
-  VersionAdded: '5.1.0'
-  Include:
-    - '**/metadata.rb'
-
-ChefDeprecations/LongDescriptionMetadata:
-  Description: The long_description metadata.rb method is not used and is unnecessary in cookbooks
-  Enabled: true
-  VersionAdded: '5.2.0'
-  Include:
-    - '**/metadata.rb'
-
-ChefDeprecations/RecipeMetadata:
-  Description: The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the README.md file instead.
-  Enabled: true
-  VersionAdded: '5.6.0'
-  Include:
-    - '**/metadata.rb'
-
 ChefDeprecations/CookbookDependsOnCompatResource:
   Description: Don't depend on the deprecated compat_resource cookbook made obsolete by Chef 12.19+
   Enabled: true
@@ -943,6 +894,62 @@ ChefModernize/ChefGemNokogiri:
   Exclude:
     - '**/metadata.rb'
     - '**/attributes/*.rb'
+
+ChefModernize/ConflictsMetadata:
+  Description: Don't use the deprecated 'conflicts' metadata value
+  Enabled: true
+  VersionAdded: '5.1.0'
+  VersionChanged: '5.15.0'
+  Include:
+    - '**/metadata.rb'
+
+ChefModernize/SuggestsMetadata:
+  Description: Don't use the deprecated 'suggests' metadata value
+  Enabled: true
+  VersionAdded: '5.1.0'
+  VersionChanged: '5.15.0'
+  Include:
+    - '**/metadata.rb'
+
+ChefModernize/ProvidesMetadata:
+  Description: Don't use the deprecated 'provides' metadata value
+  Enabled: true
+  VersionAdded: '5.1.0'
+  VersionChanged: '5.15.0'
+  Include:
+    - '**/metadata.rb'
+
+ChefModernize/ReplacesMetadata:
+  Description: Don't use the deprecated 'replaces' metadata value
+  Enabled: true
+  VersionAdded: '5.1.0'
+  VersionChanged: '5.15.0'
+  Include:
+    - '**/metadata.rb'
+
+ChefModernize/AttributeMetadata:
+  Description: Don't use the deprecated 'attribute' metadata value
+  Enabled: true
+  VersionAdded: '5.1.0'
+  VersionChanged: '5.15.0'
+  Include:
+    - '**/metadata.rb'
+
+ChefModernize/LongDescriptionMetadata:
+  Description: The long_description metadata.rb method is not used and is unnecessary in cookbooks
+  Enabled: true
+  VersionAdded: '5.2.0'
+  VersionChanged: '5.15.0'
+  Include:
+    - '**/metadata.rb'
+
+ChefModernize/RecipeMetadata:
+  Description: The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the README.md file instead.
+  Enabled: true
+  VersionAdded: '5.6.0'
+  VersionChanged: '5.15.0'
+  Include:
+    - '**/metadata.rb'
 
 ###############################
 # Migrating to new patterns

--- a/lib/rubocop/cop/chef/modernize/attribute_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/attribute_metadata.rb
@@ -18,8 +18,8 @@
 module RuboCop
   module Cop
     module Chef
-      module ChefDeprecations
-        # Don't use the deprecated 'attribute' metadata value
+      module ChefModernize
+        # The attribute metadata.rb method is not used and is unnecessary in cookbooks.
         #
         # @example
         #
@@ -33,7 +33,7 @@ module RuboCop
         #              default: '"127.0.0.1:2181"'
         #
         class AttributeMetadata < Cop
-          MSG = "Don't use the deprecated 'attribute' metadata value".freeze
+          MSG = 'The attribute metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
             add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :attribute

--- a/lib/rubocop/cop/chef/modernize/conflicts_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/conflicts_metadata.rb
@@ -18,8 +18,8 @@
 module RuboCop
   module Cop
     module Chef
-      module ChefDeprecations
-        # Don't use the deprecated 'conflicts' metadata value
+      module ChefModernize
+        # The conflicts metadata.rb method is not used and is unnecessary in cookbooks.
         #
         # @example
         #
@@ -28,7 +28,7 @@ module RuboCop
         #   conflicts "another_cookbook"
         #
         class ConflictsMetadata < Cop
-          MSG = "Don't use the deprecated 'conflicts' metadata value".freeze
+          MSG = 'The conflicts metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
             add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :conflicts

--- a/lib/rubocop/cop/chef/modernize/long_description_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/long_description_metadata.rb
@@ -18,25 +18,27 @@
 module RuboCop
   module Cop
     module Chef
-      module ChefDeprecations
-        # Don't use the deprecated 'provides' metadata value
+      module ChefModernize
+        # The long_description metadata.rb method is not used and is unnecessary in cookbooks.
         #
         # @example
         #
-        #   # bad in metadata.rb:
+        #   # bad
+        #   long_description 'this is my cookbook and this description will never be seen'
         #
-        #   provides "some_thing"
-        #
-        class ProvidesMetadata < Cop
-          MSG = "Don't use the deprecated 'provides' metadata value".freeze
+
+        class LongDescriptionMetadata < Cop
+          include RangeHelp
+
+          MSG = 'The long_description metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :provides
+            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :long_description
           end
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(node.loc.expression)
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
             end
           end
         end

--- a/lib/rubocop/cop/chef/modernize/provides_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/provides_metadata.rb
@@ -18,20 +18,20 @@
 module RuboCop
   module Cop
     module Chef
-      module ChefDeprecations
-        # Don't use the deprecated 'suggests' metadata value
+      module ChefModernize
+        # The provides metadata.rb method is not used and is unnecessary in cookbooks.
         #
         # @example
         #
         #   # bad in metadata.rb:
         #
-        #   suggests "another_cookbook"
+        #   provides "some_thing"
         #
-        class SuggestsMetadata < Cop
-          MSG = "Don't use the deprecated 'suggests' metadata value".freeze
+        class ProvidesMetadata < Cop
+          MSG = "The provides metadata.rb method is not used and is unnecessary in cookbooks.".freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :suggests
+            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :provides
           end
 
           def autocorrect(node)

--- a/lib/rubocop/cop/chef/modernize/provides_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/provides_metadata.rb
@@ -28,7 +28,7 @@ module RuboCop
         #   provides "some_thing"
         #
         class ProvidesMetadata < Cop
-          MSG = "The provides metadata.rb method is not used and is unnecessary in cookbooks.".freeze
+          MSG = 'The provides metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
             add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :provides

--- a/lib/rubocop/cop/chef/modernize/recipe_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/recipe_metadata.rb
@@ -18,27 +18,25 @@
 module RuboCop
   module Cop
     module Chef
-      module ChefDeprecations
-        # The long_description metadata.rb method is not used and is unnecessary in cookbooks
+      module ChefModernize
+        # The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the cookbook's README.md file instead.
         #
         # @example
         #
         #   # bad
-        #   long_description 'this is my cookbook and this description will never be seen'
+        #   recipe 'openldap::default', 'Install and configure OpenLDAP'
         #
-
-        class LongDescriptionMetadata < Cop
-          include RangeHelp
-
-          MSG = 'The long_description metadata.rb method is not used and is unnecessary in cookbooks'.freeze
+        #
+        class RecipeMetadata < Cop
+          MSG = "The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the cookbook's README.md file instead.".freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :long_description
+            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :recipe
           end
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
+              corrector.remove(node.loc.expression)
             end
           end
         end

--- a/lib/rubocop/cop/chef/modernize/replaces_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/replaces_metadata.rb
@@ -28,7 +28,7 @@ module RuboCop
         #   replaces "another_cookbook"
         #
         class ReplacesMetadata < Cop
-          MSG = "The replaces metadata.rb method is not used and is unnecessary in cookbooks.".freeze
+          MSG = 'The replaces metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
             add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :replaces

--- a/lib/rubocop/cop/chef/modernize/replaces_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/replaces_metadata.rb
@@ -18,21 +18,20 @@
 module RuboCop
   module Cop
     module Chef
-      module ChefDeprecations
-        # The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented
-        # in the README.md file instead.
+      module ChefModernize
+        # The replaces metadata.rb method is not used and is unnecessary in cookbooks. Replacements for existing cookbooks should be documented in the cookbook's README.md file instead.
         #
         # @example
         #
-        #   # bad
-        #   recipe 'openldap::default', 'Install and configure OpenLDAP'
+        #   # bad in metadata.rb:
         #
+        #   replaces "another_cookbook"
         #
-        class RecipeMetadata < Cop
-          MSG = 'The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the README.md file instead.'.freeze
+        class ReplacesMetadata < Cop
+          MSG = "The replaces metadata.rb method is not used and is unnecessary in cookbooks.".freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :recipe
+            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :replaces
           end
 
           def autocorrect(node)

--- a/lib/rubocop/cop/chef/modernize/respond_to_resource_name.rb
+++ b/lib/rubocop/cop/chef/modernize/respond_to_resource_name.rb
@@ -18,9 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefModernize
-        # Chef 12.5 introduced the resource_name method for resources. Many cookbooks used
-        # respond_to?(:resource_name) to provide backwards compatibility with older chef-client
-        # releases. This backwards compatibility is no longer necessary.
+        # Chef Infra Client 12.5 introduced the resource_name method for resources. Many cookbooks used respond_to?(:resource_name) to provide backwards compatibility with older chef-client releases. This backwards compatibility is no longer necessary.
         #
         # @example
         #

--- a/lib/rubocop/cop/chef/modernize/suggests_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/suggests_metadata.rb
@@ -18,20 +18,20 @@
 module RuboCop
   module Cop
     module Chef
-      module ChefDeprecations
-        # Don't use the deprecated 'replaces' metadata value
+      module ChefModernize
+        # The suggests metadata.rb method is not used and is unnecessary in cookbooks.
         #
         # @example
         #
         #   # bad in metadata.rb:
         #
-        #   replaces "another_cookbook"
+        #   suggests "another_cookbook"
         #
-        class ReplacesMetadata < Cop
-          MSG = "Don't use the deprecated 'replaces' metadata value".freeze
+        class SuggestsMetadata < Cop
+          MSG = "The suggests metadata.rb method is not used and is unnecessary in cookbooks.".freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :replaces
+            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :suggests
           end
 
           def autocorrect(node)

--- a/lib/rubocop/cop/chef/modernize/suggests_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/suggests_metadata.rb
@@ -28,7 +28,7 @@ module RuboCop
         #   suggests "another_cookbook"
         #
         class SuggestsMetadata < Cop
-          MSG = "The suggests metadata.rb method is not used and is unnecessary in cookbooks.".freeze
+          MSG = 'The suggests metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
             add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :suggests

--- a/spec/rubocop/cop/chef/modernize/attribute_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/attribute_metadata_spec.rb
@@ -16,13 +16,13 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Chef::ChefDeprecations::AttributeMetadata, :config do
+describe RuboCop::Cop::Chef::ChefModernize::AttributeMetadata, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense when metadata uses "attribute"' do
     expect_offense(<<~RUBY)
       attribute 'foo'
-      ^^^^^^^^^^^^^^^ Don't use the deprecated 'attribute' metadata value
+      ^^^^^^^^^^^^^^^ The attribute metadata.rb method is not used and is unnecessary in cookbooks.
     RUBY
 
     expect_correction("\n")

--- a/spec/rubocop/cop/chef/modernize/conflicts_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/conflicts_metadata_spec.rb
@@ -16,13 +16,13 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Chef::ChefDeprecations::ConflictsMetadata, :config do
+describe RuboCop::Cop::Chef::ChefModernize::ConflictsMetadata, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense when metadata uses "conflicts"' do
     expect_offense(<<~RUBY)
       conflicts 'foo'
-      ^^^^^^^^^^^^^^^ Don't use the deprecated 'conflicts' metadata value
+      ^^^^^^^^^^^^^^^ The conflicts metadata.rb method is not used and is unnecessary in cookbooks.
     RUBY
 
     expect_correction("\n")

--- a/spec/rubocop/cop/chef/modernize/long_description_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/long_description_metadata_spec.rb
@@ -16,16 +16,18 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Chef::ChefDeprecations::ReplacesMetadata, :config do
+describe RuboCop::Cop::Chef::ChefModernize::LongDescriptionMetadata, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when metadata uses "replaces"' do
+  it 'registers an offense when metadata uses "long_description"' do
     expect_offense(<<~RUBY)
-      replaces 'foo'
-      ^^^^^^^^^^^^^^ Don't use the deprecated 'replaces' metadata value
+      description 'foo'
+      long_description 'foo'
+      ^^^^^^^^^^^^^^^^^^^^^^ The long_description metadata.rb method is not used and is unnecessary in cookbooks.
+      version '1.0.0'
     RUBY
 
-    expect_correction("\n")
+    expect_correction("description 'foo'\nversion '1.0.0'\n")
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/modernize/provides_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/provides_metadata_spec.rb
@@ -16,13 +16,13 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Chef::ChefDeprecations::SuggestsMetadata, :config do
+describe RuboCop::Cop::Chef::ChefModernize::ProvidesMetadata, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when metadata uses "suggests"' do
+  it 'registers an offense when metadata uses "provides"' do
     expect_offense(<<~RUBY)
-      suggests 'foo'
-      ^^^^^^^^^^^^^^ Don't use the deprecated 'suggests' metadata value
+      provides 'foo'
+      ^^^^^^^^^^^^^^ The provides metadata.rb method is not used and is unnecessary in cookbooks.
     RUBY
 
     expect_correction("\n")

--- a/spec/rubocop/cop/chef/modernize/recipe_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/recipe_metadata_spec.rb
@@ -16,13 +16,13 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Chef::ChefDeprecations::RecipeMetadata, :config do
+describe RuboCop::Cop::Chef::ChefModernize::RecipeMetadata, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense when metadata uses "recipe"' do
     expect_offense(<<~RUBY)
       recipe 'chef-client::config', 'Configures the client.rb from a template.'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the README.md file instead.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the cookbook's README.md file instead.
     RUBY
 
     expect_correction("\n")

--- a/spec/rubocop/cop/chef/modernize/replaces_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/replaces_metadata_spec.rb
@@ -16,13 +16,13 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Chef::ChefDeprecations::ProvidesMetadata, :config do
+describe RuboCop::Cop::Chef::ChefModernize::ReplacesMetadata, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when metadata uses "provides"' do
+  it 'registers an offense when metadata uses "replaces"' do
     expect_offense(<<~RUBY)
-      provides 'foo'
-      ^^^^^^^^^^^^^^ Don't use the deprecated 'provides' metadata value
+      replaces 'foo'
+      ^^^^^^^^^^^^^^ The replaces metadata.rb method is not used and is unnecessary in cookbooks.
     RUBY
 
     expect_correction("\n")

--- a/spec/rubocop/cop/chef/modernize/suggests_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/suggests_metadata_spec.rb
@@ -16,18 +16,16 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Chef::ChefDeprecations::LongDescriptionMetadata, :config do
+describe RuboCop::Cop::Chef::ChefModernize::SuggestsMetadata, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when metadata uses "long_description"' do
+  it 'registers an offense when metadata uses "suggests"' do
     expect_offense(<<~RUBY)
-      description 'foo'
-      long_description 'foo'
-      ^^^^^^^^^^^^^^^^^^^^^^ The long_description metadata.rb method is not used and is unnecessary in cookbooks
-      version '1.0.0'
+      suggests 'foo'
+      ^^^^^^^^^^^^^^ The suggests metadata.rb method is not used and is unnecessary in cookbooks.
     RUBY
 
-    expect_correction("description 'foo'\nversion '1.0.0'\n")
+    expect_correction("\n")
   end
 
   it "doesn't register an offense on normal metadata" do


### PR DESCRIPTION
These cops really aren't deprecations. They're just not necessary
anymore. We shouldn't be alerting in chef-analyze that every customer
needs to drop everything and remove long_description from their
metadata. It doesn't warrant that, but if they're already in a cookbook
they should def clean it up.

Signed-off-by: Tim Smith <tsmith@chef.io>