### PR TITLE
Update ChefModernize/LegacyBerksfileSource to detect REALLY old configs

### DIFF
--- a/lib/rubocop/cop/chef/modernize/berksfile_source.rb
+++ b/lib/rubocop/cop/chef/modernize/berksfile_source.rb
@@ -28,12 +28,17 @@ module RuboCop
         #   source 'http://community.opscode.com/api/v3'
         #   source 'https://supermarket.getchef.com'
         #   source 'https://api.berkshelf.com'
+        #   site :opscode
         #
         #   # good
         #   source 'https://supermarket.chef.io'
         #
         class LegacyBerksfileSource < Cop
           MSG = 'Do not use legacy Berksfile community sources. Use Chef Supermarket instead.'.freeze
+
+          def_node_matcher :berksfile_site?, <<-PATTERN
+            (send nil? :site (:sym _))
+          PATTERN
 
           def_node_matcher :berksfile_source?, <<-PATTERN
             (send nil? :source (str #old_berkshelf_url?))
@@ -45,6 +50,10 @@ module RuboCop
 
           def on_send(node)
             berksfile_source?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+
+            berksfile_site?(node) do
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
           end

--- a/spec/rubocop/cop/chef/modernize/berksfile_source_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/berksfile_source_spec.rb
@@ -52,6 +52,17 @@ describe RuboCop::Cop::Chef::ChefModernize::LegacyBerksfileSource, :config do
     RUBY
   end
 
+  it 'registers an offense when using site :opscode' do
+    expect_offense(<<~RUBY)
+      site :opscode
+      ^^^^^^^^^^^^^ Do not use legacy Berksfile community sources. Use Chef Supermarket instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      source 'https://supermarket.chef.io'
+    RUBY
+  end
+
   it "doesn't register an offense when using supermarket.chef.io" do
     expect_no_offenses(<<~RUBY)
       source 'https://supermarket.chef.io'


### PR DESCRIPTION
This is the original Berksfile syntax that was basically just the Cheffile.

Signed-off-by: Tim Smith <tsmith@chef.io>