### PR TITLE
Detect @default_action in the initializer as well

### DIFF
--- a/lib/rubocop/cop/chef/modernize/default_action_initializer.rb
+++ b/lib/rubocop/cop/chef/modernize/default_action_initializer.rb
@@ -28,6 +28,12 @@ module RuboCop
         #     @action = :create
         #   end
         #
+        #   # bad
+        #   def initialize(*args)
+        #     super
+        #     @default_action = :create
+        #   end
+        #
         #  # good
         #  default_action :create
 
@@ -41,7 +47,7 @@ module RuboCop
             return if node.body.nil? # nil body is an empty initialize method
 
             node.body.each_node do |x|
-              if x.assignment? && !x.node_parts.empty? && x.node_parts.first == :@action
+              if x.assignment? && !x.node_parts.empty? && %i(@action @default_action).include?(x.node_parts.first)
                 add_offense(x, location: :expression, message: MSG, severity: :refactor)
               end
             end

--- a/spec/rubocop/cop/chef/modernize/default_action_initializer_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/default_action_initializer_spec.rb
@@ -38,7 +38,6 @@ describe RuboCop::Cop::Chef::ChefModernize::DefaultActionFromInitialize, :config
     RUBY
   end
 
-
   it 'registers an offense with a HWRP specifies @default_action in the initializer' do
     expect_offense(<<~RUBY)
       def initialize(*args)

--- a/spec/rubocop/cop/chef/modernize/default_action_initializer_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/default_action_initializer_spec.rb
@@ -20,12 +20,31 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ChefModernize::DefaultActionFromInitialize, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense with a HWRP specifies the default_action in the initializer' do
+  it 'registers an offense with a HWRP specifies @action in the initializer' do
     expect_offense(<<~RUBY)
       def initialize(*args)
         super
         @action = :create
         ^^^^^^^^^^^^^^^^^ The default action of a resource can be set with the "default_action" helper instead of using the initialize method.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      default_action :create
+
+      def initialize(*args)
+        super
+      end
+    RUBY
+  end
+
+
+  it 'registers an offense with a HWRP specifies @default_action in the initializer' do
+    expect_offense(<<~RUBY)
+      def initialize(*args)
+        super
+        @default_action = :create
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ The default action of a resource can be set with the "default_action" helper instead of using the initialize method.
       end
     RUBY
 


### PR DESCRIPTION
This is actually wrong, but I found at least one cookbook that's doing it. One more reason that HWRPs were terrible.

Signed-off-by: Tim Smith <tsmith@chef.io>