### PR TITLE
Rework how we autocorrect allowed actions

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -633,14 +633,6 @@ ChefModernize/CustomResourceWithAttributes:
   Include:
     - '**/resources/*.rb'
 
-ChefModernize/CustomResourceWithAllowedActions:
-  Description: Resources no longer need to define the allowed actions using the allowed_actions / actions helper methods or within an initialize method.
-  Enabled: true
-  VersionAdded: '5.2.0'
-  Include:
-    - '**/resources/*.rb'
-    - '**/libraries/*.rb'
-
 ChefModernize/IncludingAptDefaultRecipe:
   Description: Do not include the Apt default recipe to update package cache. Instead use the apt_update resource, which is built into Chef Infra Client 12.7 and later.
   Enabled: true
@@ -896,6 +888,14 @@ ChefModernize/IncludingOhaiDefaultRecipe:
   Exclude:
     - '**/metadata.rb'
 
+ChefModernize/AllowedActionsFromInitialize:
+  Description: The allowed actions of a resource can be set with the "allowed_actions" helper instead of using the initialize method.
+  Enabled: true
+  VersionAdded: '5.15.0'
+  Include:
+    - '**/resources/*.rb'
+    - '**/libraries/*.rb'
+
 ###############################
 # ChefRedundantCode: Cleanup unncessary code in your cookbooks regardless of chef-client release
 ###############################
@@ -992,6 +992,14 @@ ChefRedundantCode/NamePropertyIsRequired:
   Include:
     - '**/resources/*.rb'
     - '**/libraries/*.rb'
+
+ChefRedundant/CustomResourceWithAllowedActions:
+  Description: It is not necessary to set `actions` or `allowed_actions` in custom resources as Chef Infra Client determines these automatically from the set of all actions defined in the resource.
+  Enabled: true
+  VersionAdded: '5.2.0'
+  VersionChanged: '5.15.0'
+  Include:
+    - '**/resources/*.rb'
 
 ###############################
 # Migrating to new patterns

--- a/lib/rubocop/cop/chef/modernize/allowed_actions_initializer.rb
+++ b/lib/rubocop/cop/chef/modernize/allowed_actions_initializer.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefModernize
-        # The allowed actions can now be specified using the `allowed_actions` helper instead of using the @actions or @allowed_actionsn variables in the resource provider initialize method. In general we recommend against writing HWRPs, but if HWRPs are necessary you should utilize as much of the resource DSL as possible.
+        # The allowed actions can now be specified using the `allowed_actions` helper instead of using the @actions or @allowed_actions variables in the resource's initialize method. In general we recommend against writing HWRPs, but if HWRPs are necessary you should utilize as much of the resource DSL as possible.
         #
         # @example
         #

--- a/lib/rubocop/cop/chef/modernize/allowed_actions_initializer.rb
+++ b/lib/rubocop/cop/chef/modernize/allowed_actions_initializer.rb
@@ -1,0 +1,76 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefModernize
+        # The allowed actions can now be specified using the `allowed_actions` helper instead of using the @actions or @allowed_actionsn variables in the resource provider initialize method. In general we recommend against writing HWRPs, but if HWRPs are necessary you should utilize as much of the resource DSL as possible.
+        #
+        # @example
+        #
+        #   # bad
+        #   def initialize(*args)
+        #     super
+        #     @actions = [ :create, :add ]
+        #   end
+        #
+        #   # also bad
+        #   def initialize(*args)
+        #     super
+        #     @allowed_actions = [ :create, :add ]
+        #   end
+        #
+        #   # good
+        #   allowed_actions [ :create, :add ]
+        #
+        class AllowedActionsFromInitialize < Cop
+          include RangeHelp
+
+          MSG = 'The allowed actions of a resource can be set with the "allowed_actions" helper instead of using the initialize method.'.freeze
+
+          def on_def(node)
+            return unless node.method_name == :initialize
+            return if node.body.nil? # nil body is an empty initialize method
+
+            node.body.each_node do |x|
+              if x.assignment? && !x.node_parts.empty? && %i(@actions @allowed_actions).include?(x.node_parts.first)
+                add_offense(x, location: :expression, message: MSG, severity: :refactor)
+              end
+            end
+          end
+
+          def_node_search :action_methods?, '(send nil? {:actions :allowed_actions} ... )'
+
+          def_node_search :intialize_method, '(def :initialize ... )'
+
+          def autocorrect(node)
+            lambda do |corrector|
+              # insert the new allowed_actions call above the initialize method, but not if one already exists (this is sadly common)
+              unless action_methods?(processed_source.ast)
+                initialize_node = intialize_method(processed_source.ast).first
+                corrector.insert_before(initialize_node.source_range, "allowed_actions #{node.descendants.first.source}\n\n")
+              end
+
+              # remove the variable from the initialize method
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/allowed_actions_initializer_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/allowed_actions_initializer_spec.rb
@@ -1,5 +1,6 @@
 #
 # Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,61 +17,39 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Chef::ChefModernize::CustomResourceWithAllowedActions, :config do
+describe RuboCop::Cop::Chef::ChefModernize::AllowedActionsFromInitialize, :config do
   subject(:cop) { described_class.new(config) }
-
-  it 'registers an offense with a resource that uses allowed_actions method' do
-    expect_offense(<<~RUBY)
-      property :something, String
-
-      allowed_actions [:create, :remove]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resources no longer need to define the allowed actions using the allowed_actions / actions helper methods or within an initialize method.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      property :something, String
-    RUBY
-  end
-
-  it 'registers an offense with a resource that uses actions method' do
-    expect_offense(<<~RUBY)
-      property :something, String
-
-      actions [:create, :remove]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Resources no longer need to define the allowed actions using the allowed_actions / actions helper methods or within an initialize method.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      property :something, String
-    RUBY
-  end
 
   it 'registers an offense with a resource that sets the @allowed_actions variable in an initializer' do
     expect_offense(<<~RUBY)
       def initialize(*args)
         super
         @allowed_actions = [:create, :remove]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resources no longer need to define the allowed actions using the allowed_actions / actions helper methods or within an initialize method.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The allowed actions of a resource can be set with the "allowed_actions" helper instead of using the initialize method.
       end
     RUBY
 
     expect_correction(<<~RUBY)
+    allowed_actions [:create, :remove]
+
     def initialize(*args)
       super
     end
     RUBY
   end
 
-  it 'registers an offense with a resource that pushes to the @allowed_actions variable in an initializer' do
+  it 'registers an offense with a resource that sets the @actions variable in an initializer' do
     expect_offense(<<~RUBY)
       def initialize(*args)
         super
-        @allowed_actions.push(:create, :remove)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resources no longer need to define the allowed actions using the allowed_actions / actions helper methods or within an initialize method.
+        @actions = [:create, :remove]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The allowed actions of a resource can be set with the "allowed_actions" helper instead of using the initialize method.
       end
     RUBY
 
     expect_correction(<<~RUBY)
+    allowed_actions [:create, :remove]
+
     def initialize(*args)
       super
     end
@@ -93,7 +72,7 @@ describe RuboCop::Cop::Chef::ChefModernize::CustomResourceWithAllowedActions, :c
     RUBY
   end
 
-  it 'does not register an offense with a resource that does not use allowed_actions or actions methods' do
+  it 'does not register an offense with a resource that does not have an initialize method' do
     expect_no_offenses(<<~RUBY)
       property :something, String
 

--- a/spec/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions_spec.rb
@@ -1,0 +1,60 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefRedundant::CustomResourceWithAllowedActions, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense with a resource that uses allowed_actions method' do
+    expect_offense(<<~RUBY)
+      allowed_actions [:create, :remove]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It is not necessary to set `actions` or `allowed_actions` in custom resources as Chef Infra Client determines these automatically from the set of all actions defined in the resource
+
+      action :foo do
+        # action stuff
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+
+
+      action :foo do
+        # action stuff
+      end
+    RUBY
+  end
+
+  it 'registers an offense with a resource that uses actions method' do
+    expect_offense(<<~RUBY)
+      actions [:create, :remove]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ It is not necessary to set `actions` or `allowed_actions` in custom resources as Chef Infra Client determines these automatically from the set of all actions defined in the resource
+
+      action :foo do
+        # action stuff
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+
+
+      action :foo do
+        # action stuff
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Don't remove them if we're not in a custom resource
Consider the custom resource cop to be ChefRedundant since there has never been a need for this code in a custom resource. It's just leftover redundant junk
Add a new cop ChefModernize/AllowedActionsFromInitialize that pulls the allowed_actions out of initialize methods in HWRPs. This gets folks closer to LWRPs which gets them closer to custom resources

Signed-off-by: Tim Smith <tsmith@chef.io>