### PR TITLE
Don't detect poise resources in CustomResourceWithAllowedActions

### DIFF
--- a/lib/rubocop/cop/chef/modernize/resource_with_allowed_actions.rb
+++ b/lib/rubocop/cop/chef/modernize/resource_with_allowed_actions.rb
@@ -44,7 +44,12 @@ module RuboCop
             (send nil? {:allowed_actions :actions} ... )
           PATTERN
 
+          def_node_search :poise_require, '(send nil? :require (str "poise"))'
+
           def on_send(node)
+            # if the resource requires poise then bail out since we're in a poise resource where @allowed_actions is legit
+            return if poise_require(processed_source.ast).any?
+
             allowed_actions?(node) do
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end

--- a/spec/rubocop/cop/chef/modernize/resource_with_allowed_actions_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/resource_with_allowed_actions_spec.rb
@@ -77,6 +77,22 @@ describe RuboCop::Cop::Chef::ChefModernize::CustomResourceWithAllowedActions, :c
     RUBY
   end
 
+  it 'does not register an offense with a poise resource' do
+    expect_no_offenses(<<~RUBY)
+    require 'poise'
+
+    module MyCookbook
+      module Resource
+        class MyResource < Chef::Resource
+          include Poise(inversion: true)
+          provides(:consul_installation)
+          actions(:create, :remove)
+        end
+      end
+    end
+    RUBY
+  end
+
   it 'does not register an offense with a resource that does not use allowed_actions or actions methods' do
     expect_no_offenses(<<~RUBY)
       property :something, String


### PR DESCRIPTION
Let's not touch poise resources. They have their own syntax

Signed-off-by: Tim Smith <tsmith@chef.io>