### PR TITLE
Add a cop for removing legacy Foodcritic comments

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -910,6 +910,11 @@ ChefModernize/AllowedActionsFromInitialize:
     - '**/resources/*.rb'
     - '**/libraries/*.rb'
 
+ChefModernize/FoodcriticComments:
+  Description: Remove legacy code comments that disable Foodcritic rules. These comments are no longer necessary if you've migrated from Foodcritic to Cookstyle for cookbook linting.
+  Enabled: false
+  VersionAdded: '5.16.0'
+
 ###############################
 # ChefRedundantCode: Cleanup unncessary code in your cookbooks regardless of chef-client release
 ###############################

--- a/lib/rubocop/cop/chef/modernize/foodcritic_comments.rb
+++ b/lib/rubocop/cop/chef/modernize/foodcritic_comments.rb
@@ -1,0 +1,51 @@
+#
+# Copyright:: 2016-2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefModernize
+        # Remove legacy code comments that disable Foodcritic rules. These comments are no longer necessary if you've migrated from Foodcritic to Cookstyle for cookbook linting.
+        #
+        # @example
+        #
+        #   # bad
+        #   # ~FC013
+        #
+        class FoodcriticComments < Cop
+          MSG = 'Remove legacy code comments that disable Foodcritic rules'.freeze
+
+          def investigate(processed_source)
+            return unless processed_source.ast
+
+            processed_source.comments.each do |comment|
+              if comment.text.match?(/#\s*~FC\d{3}.*/)
+                add_offense(comment, location: :expression, message: MSG, severity: :refactor)
+              end
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.remove(node.loc.expression)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/foodcritic_comments_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/foodcritic_comments_spec.rb
@@ -1,0 +1,57 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefModernize::FoodcriticComments do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense with a foodcritic inline comment' do
+    expect_offense(<<~RUBY)
+      blah # ~FC013
+           ^^^^^^^^ Remove legacy code comments that disable Foodcritic rules
+    RUBY
+
+    expect_correction("blah \n")
+  end
+
+  it 'registers an offense with a foodcritic comment above code' do
+    expect_offense(<<~RUBY)
+      # ~FC013
+      ^^^^^^^^ Remove legacy code comments that disable Foodcritic rules
+      blah
+    RUBY
+
+    expect_correction("\nblah\n")
+  end
+
+  it 'removes the entire comment if it starts with ~FCXXX' do
+    expect_offense(<<~RUBY)
+      # ~FC013 doesn't make sense here
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Remove legacy code comments that disable Foodcritic rules
+      blah
+    RUBY
+
+    expect_correction("\nblah\n")
+  end
+
+  it "doesn't register an offense when a comment just mentions FCXXX" do
+    expect_no_offenses(<<~RUBY)
+    timezone 'UTC' # no need for ~FC123 here anymore
+    RUBY
+  end
+end


### PR DESCRIPTION
These are no longer necessary when a user has migrated to Cookstyle. This cop will be disabled for now, but sometime in the future we'll probably want to enable it.

Signed-off-by: Tim Smith <tsmith@chef.io>