### PR TITLE
Add ChefDeprecations/RubyBlockCreateAction cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -583,6 +583,15 @@ ChefDeprecations/ChefRewind:
     - '**/metadata.rb'
     - '**/attributes/*.rb'
 
+ChefDeprecations/RubyBlockCreateAction:
+  Description: Use the :run action in the ruby_block resource instead of the deprecated :create action
+  Enabled: true
+  VersionAdded: '5.16.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
@@ -1,0 +1,64 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Use the :run action in the ruby_block resource instead of the deprecated :create action
+        #
+        # @example
+        #
+        #   # bad
+        #   ruby_block 'my special ruby block' do
+        #     block do
+        #       puts 'running'
+        #     end
+        #     action :create
+        #   end
+        #
+        #   # good
+        #   ruby_block 'my special ruby block' do
+        #     block do
+        #       puts 'running'
+        #     end
+        #     action :run
+        #   end
+        #
+        class RubyBlockCreateAction < Cop
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'Use the :run action in the ruby_block resource instead of the deprecated :create action'.freeze
+
+          def on_block(node)
+            match_property_in_resource?(:ruby_block, 'action', node) do |ruby_action|
+              ruby_action.arguments.each do |action|
+                add_offense(action, location: :expression, message: MSG, severity: :refactor) if action.source == ':create'
+              end
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, ':run')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/ruby_block_create_action_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/ruby_block_create_action_spec.rb
@@ -1,0 +1,54 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::RubyBlockCreateAction, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when ruby_block uses the :create action' do
+    expect_offense(<<~RUBY)
+      ruby_block 'my special ruby block' do
+        block do
+          puts 'running'
+        end
+        action :create
+               ^^^^^^^ Use the :run action in the ruby_block resource instead of the deprecated :create action
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ruby_block 'my special ruby block' do
+        block do
+          puts 'running'
+        end
+        action :run
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when ruby_block uses the :run action" do
+    expect_no_offenses(<<~RUBY)
+      ruby_block 'my special ruby block' do
+        block do
+          puts 'running'
+        end
+        action :run
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
The :create action has been replaced with the :run action.

Signed-off-by: Tim Smith <tsmith@chef.io>