### PR TITLE
Support checking both notifies and subscribes properties in cops

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -188,7 +188,7 @@ ChefCorrectness/InvalidVersionMetadata:
     - '**/metadata.rb'
 
 ChefCorrectness/NotifiesActionNotSymbol:
-  Description: When notifying an action within a resource the action should always be a symbol. In Chef Infra Client releases before 14.0 this may result in double notification.
+  Description: When notifying or subscribing an action within a resource the action should always be a symbol. In Chef Infra Client releases before 14.0 this may result in double notification.
   Enabled: true
   VersionAdded: '5.10.0'
   Exclude:

--- a/lib/rubocop/chef/cookbook_helpers.rb
+++ b/lib/rubocop/chef/cookbook_helpers.rb
@@ -80,8 +80,7 @@ module RuboCop
       #
       # @return [Array]
       def symbolized_property_types(property)
-        Array(property
-        ).map{|x| x.to_sym}
+        Array(property).map(&:to_sym)
       end
 
       #

--- a/lib/rubocop/chef/cookbook_helpers.rb
+++ b/lib/rubocop/chef/cookbook_helpers.rb
@@ -40,27 +40,28 @@ module RuboCop
       # Match particular properties within a resource
       #
       # @param [String] resource_name The name of the resource to match
-      # @param [String] property_name The name of the property to match (or action)
+      # @param [String] property_names The name of the property to match (or action)
       # @param [RuboCop::AST::Node] node The rubocop ast node to search
       #
       # @yield
       #
-      def match_property_in_resource?(resource_name, property_name, node)
+      def match_property_in_resource?(resource_name, property_names, node)
         return unless looks_like_resource?(node)
         # bail out if we're not in the resource we care about or nil was passed (all resources)
         return unless resource_name.nil? || node.children.first.method?(resource_name.to_sym) # see if we're in the right resource
 
         resource_block = node.children[2] # the 3rd child is the actual block in the resource
         return unless resource_block # nil would be an empty block
+
         if resource_block.begin_type? # if begin_type we need to iterate over the children
           resource_block.children.each do |resource_blk_child|
             extract_send_types(resource_blk_child) do |p|
-              yield(p) if p.method_name == property_name.to_sym
+              yield(p) if symbolized_property_types(property_names).include?(p.method_name)
             end
           end
         else # there's only a single property to check
           extract_send_types(resource_block) do |p|
-            yield(p) if p.method_name == property_name.to_sym
+            yield(p) if symbolized_property_types(property_names).include?(p.method_name)
           end
         end
       end
@@ -74,6 +75,14 @@ module RuboCop
       end
 
       private
+
+      # @param [String, Array] property
+      #
+      # @return [Array]
+      def symbolized_property_types(property)
+        Array(property
+        ).map{|x| x.to_sym}
+      end
 
       #
       # given a node object does it look like a chef resource or not?

--- a/lib/rubocop/cop/chef/correctness/notifies_action_not_symbol.rb
+++ b/lib/rubocop/cop/chef/correctness/notifies_action_not_symbol.rb
@@ -28,9 +28,17 @@ module RuboCop
         #     notifies 'restart', 'service[httpd]', 'delayed'
         #   end
         #
+        #   execute 'some commmand' do
+        #     subscribes 'restart', 'service[httpd]', 'delayed'
+        #   end
+        #
         #   # good
         #   execute 'some commmand' do
         #     notifies :restart, 'service[httpd]', 'delayed'
+        #   end
+        #
+        #   execute 'some commmand' do
+        #     subscribes :restart, 'service[httpd]', 'delayed'
         #   end
         #
         class NotifiesActionNotSymbol < Cop

--- a/lib/rubocop/cop/chef/correctness/notifies_action_not_symbol.rb
+++ b/lib/rubocop/cop/chef/correctness/notifies_action_not_symbol.rb
@@ -19,7 +19,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefCorrectness
-        # When notifying an action within a resource the action should always be a symbol. In Chef Infra Client releases before 14.0 this may result in double notification.
+        # When notifying or subscribing an action within a resource the action should always be a symbol. In Chef Infra Client releases before 14.0 this may result in double notification.
         #
         # @example
         #
@@ -36,10 +36,10 @@ module RuboCop
         class NotifiesActionNotSymbol < Cop
           include RuboCop::Chef::CookbookHelpers
 
-          MSG = 'Resource notifcation actions should be symbols not strings.'.freeze
+          MSG = 'Resource notification and subscription actions should be symbols not strings.'.freeze
 
           def on_block(node)
-            match_property_in_resource?(nil, 'notifies', node) do |notifies_property|
+            match_property_in_resource?(nil, %w(notifies subscribes), node) do |notifies_property|
               add_offense(notifies_property, location: :expression, message: MSG, severity: :refactor) if notifies_property.node_parts[2].str_type?
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -52,7 +52,7 @@ module RuboCop
           MSG = 'Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.'.freeze
 
           def_node_matcher :legacy_notify?, <<-PATTERN
-            (send nil? :notifies $(sym _) (send nil? :resources (hash (pair $(sym _) $(...) ) ) ) $... )
+            (send nil? ${:notifies :subscribes} $(sym _) (send nil? :resources (hash (pair $(sym _) $(...) ) ) ) $... )
           PATTERN
 
           def on_send(node)
@@ -63,7 +63,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              legacy_notify?(node) do |action, type, name, timing|
+              legacy_notify?(node) do |notify_type, action, type, name, timing|
                 service_value = case name.type
                                 when :str
                                   "'#{type.source}[#{name.value}]'"
@@ -72,7 +72,7 @@ module RuboCop
                                 else
                                   "\"#{type.source}[\#{#{name.source}}]\""
                                 end
-                new_val = "notifies #{action.source}, #{service_value}"
+                new_val = "#{notify_type} #{action.source}, #{service_value}"
                 new_val << ", #{timing.first.source}" unless timing.empty?
                 corrector.replace(node.loc.expression, new_val)
               end

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -35,6 +35,10 @@ module RuboCop
         #     notifies :restart, resources(service: service_name_variable), :immediately
         #   end
         #
+        #   template '/etc/www/configures-apache.conf' do
+        #     subscribes :restart, resources(service: service_name_variable), :immediately
+        #   end
+        #
         #   # good
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, 'service[apache]'
@@ -46,6 +50,10 @@ module RuboCop
         #
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, "service[#{service_name_variable}]", :immediately
+        #   end
+        #
+        #   template '/etc/www/configures-apache.conf' do
+        #     subscribes :restart, "service[#{service_name_variable}]", :immediately
         #   end
         #
         class LegacyNotifySyntax < Cop

--- a/spec/rubocop/chef/cookbook_helpers_spec.rb
+++ b/spec/rubocop/chef/cookbook_helpers_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
       end
     end
 
-    describe 'matchesd on multiple properties in a resource as an array' do
+    describe 'matches on multiple properties in a resource as an array' do
       let(:resource_source) do
         <<~RUBY
         service 'if statement' do

--- a/spec/rubocop/chef/cookbook_helpers_spec.rb
+++ b/spec/rubocop/chef/cookbook_helpers_spec.rb
@@ -79,6 +79,22 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
       end
     end
 
+    describe 'matchesd on multiple properties in a resource as an array' do
+      let(:resource_source) do
+        <<~RUBY
+        service 'if statement' do
+          if platform?('mac_os_x')
+            running true
+          end
+        end
+        RUBY
+      end
+
+      it "should yield a single 'running' property ast objects" do
+        expect { |b| match_property_in_resource?(:service, %w(running verify), parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
+      end
+    end
+
     describe 'extracts a property from a resource with an if statement' do
       let(:resource_source) do
         <<~RUBY

--- a/spec/rubocop/cop/chef/correctness/notifies_action_not_symbol_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/notifies_action_not_symbol_spec.rb
@@ -24,13 +24,28 @@ describe RuboCop::Cop::Chef::ChefCorrectness::NotifiesActionNotSymbol do
     expect_offense(<<~RUBY)
       execute 'some commmand' do
         notifies 'restart', 'service[httpd]', 'delayed'
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resource notifcation actions should be symbols not strings.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resource notification and subscription actions should be symbols not strings.
       end
     RUBY
 
     expect_correction(<<~RUBY)
       execute 'some commmand' do
         notifies :restart, 'service[httpd]', 'delayed'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a subscribes action is a string' do
+    expect_offense(<<~RUBY)
+      execute 'some commmand' do
+        subscribes 'restart', 'service[httpd]', 'delayed'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resource notification and subscription actions should be symbols not strings.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      execute 'some commmand' do
+        subscribes :restart, 'service[httpd]', 'delayed'
       end
     RUBY
   end

--- a/spec/rubocop/cop/chef/deprecation/legacy_notify_syntax_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/legacy_notify_syntax_spec.rb
@@ -64,6 +64,21 @@ describe RuboCop::Cop::Chef::ChefDeprecations::LegacyNotifySyntax, :config do
     RUBY
   end
 
+  it 'detects and autocorrections legacy subscription syntax' do
+    expect_offense(<<~'RUBY')
+    foo 'bar' do
+      subscribes :enable, resources(service: service_name), :immediately
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.
+    end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+    foo 'bar' do
+      subscribes :enable, "service[#{service_name}]", :immediately
+    end
+    RUBY
+  end
+
   it 'properly autocorrects legacy notification syntax with string interpolation in the resource name' do
     expect_offense(<<~'RUBY')
     foo 'bar' do


### PR DESCRIPTION
Updates our property helper to accept an array of helpers, which allows updating ChefCorrectness/NotifiesActionNotSymbol and ChefDeprecations/LegacyNotifySyntax to work with both notify and subscribes properties.