### PR TITLE
Improve the cops that check properties / attributes

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -467,7 +467,6 @@ ChefDeprecations/NamePropertyWithDefaultValue:
   VersionAdded: '5.7.0'
   Include:
     - '**/libraries/*.rb'
-    - '**/providers/*.rb'
     - '**/resources/*.rb'
 
 ChefDeprecations/ResourceUsesProviderBaseMethod:

--- a/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
+++ b/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefDeprecations
-        # A resource property (or atttribute) can't be marked as a name_property (or name_attribute) and also have a default value. The name property is a special property that is derived from the name of the resource block in and thus always has a value passed to the resource. For example if you define `my_resource 'foo'` in recipe, then the name property of `my_resource` will automatically be set to `foo`. Setting a property to be both a name_property and have a default value will cause Chef Infra Client failures in 13.0 and later releases.
+        # A resource property (or attribute) can't be marked as a name_property (or name_attribute) and also have a default value. The name property is a special property that is derived from the name of the resource block in and thus always has a value passed to the resource. For example if you define `my_resource 'foo'` in recipe, then the name property of `my_resource` will automatically be set to `foo`. Setting a property to be both a name_property and have a default value will cause Chef Infra Client failures in 13.0 and later releases.
         #
         # @example
         #

--- a/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
+++ b/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
@@ -18,46 +18,42 @@ module RuboCop
   module Cop
     module Chef
       module ChefDeprecations
-        # A custom resource property can't be marked as a name_property and also have a default value. The name property is a special property that is derived from the name of the resource block in and thus always has a value passed to the resource. For example if you define `my_resource 'foo'` in recipe, then the name property of `my_resource` will automatically be set to `foo`. Setting a property to be both a name_property and have a default value will cause Chef Infra Client failures in 13.0 and later releases.
+        # A resource property (or atttribute) can't be marked as a name_property (or name_attribute) and also have a default value. The name property is a special property that is derived from the name of the resource block in and thus always has a value passed to the resource. For example if you define `my_resource 'foo'` in recipe, then the name property of `my_resource` will automatically be set to `foo`. Setting a property to be both a name_property and have a default value will cause Chef Infra Client failures in 13.0 and later releases.
         #
         # @example
         #
         #   # bad
         #   property :config_file, String, default: 'foo', name_property: true
+        #   attribute :config_file, String, default: 'foo', name_attribute: true
         #
         #   # good
         #   property :config_file, String, name_property: true
+        #   attribute :config_file, String, name_attribute: true
         #
         class NamePropertyWithDefaultValue < Cop
+          include RangeHelp
+
           MSG = "A resource property can't be marked as a name_property and also have a default value. This will fail in Chef Infra Client 13 or later.".freeze
 
+          # match on a property or attribute that has any name and any type and a hash that
+          # contains name_property/name_attribute true and any default value. These are wrapped in
+          # <> which means the order doesn't matter in the hash.
+          def_node_matcher :name_property_with_default?, <<-PATTERN
+            (send nil? {:property :attribute} (sym _) ... (hash <(pair (sym {:name_property :name_attribute}) (true)) $(pair (sym :default) ...) ...>))
+          PATTERN
+
           def on_send(node)
-            if default_value?(node) && property_is_name_property?(node)
+            name_property_with_default?(node) do
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
           end
 
-          private
-
-          def property_is_name_property?(node)
-            if node.method_name == :property
-              node.arguments.each do |arg|
-                if arg.type == :hash
-                  return true if arg.source.match?(/name_property:\s*true/)
-                end
+          def autocorrect(node)
+            lambda do |corrector|
+              name_property_with_default?(node) do |default|
+                range = range_with_surrounding_comma(range_with_surrounding_space(range: default.loc.expression, side: :left), :left)
+                corrector.remove(range)
               end
-              false # no required: true found
-            end
-          end
-
-          def default_value?(node)
-            if node.method_name == :property
-              node.arguments.each do |arg|
-                if arg.type == :hash
-                  return true if arg.source.match?(/default:\s/)
-                end
-              end
-              false # no default: found
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/unnecessary_name_property.rb
+++ b/lib/rubocop/cop/chef/redundant/unnecessary_name_property.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefRedundantCode
-        # There is no need to define a property or attribute named :name in a resource as Chef Infra defines this for all resources by default.
+        # There is no need to define a property or attribute named :name in a resource as Chef Infra defines this on all resources by default.
         #
         # @example
         #
@@ -29,7 +29,7 @@ module RuboCop
         #   attribute :name, String, name_attribute: true
         #
         class UnnecessaryNameProperty < Cop
-          MSG = 'There is no need to define a property or attribute named :name in a resource as Chef Infra defines this all resources by default.'.freeze
+          MSG = 'There is no need to define a property or attribute named :name in a resource as Chef Infra defines this on all resources by default.'.freeze
 
           # match on a property/attribute named :name that's a string. The property/attribute optionally
           # set name_property/name_attribute true, but nothing else is allowed. If you're doing that it's

--- a/spec/rubocop/cop/chef/deprecation/name_property_and_default_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/name_property_and_default_spec.rb
@@ -1,5 +1,6 @@
 #
 # Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +24,21 @@ describe RuboCop::Cop::Chef::ChefDeprecations::NamePropertyWithDefaultValue, :co
     expect_offense(<<~RUBY)
       property :foo, String, name_property: true, default: 'foo'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A resource property can't be marked as a name_property and also have a default value. This will fail in Chef Infra Client 13 or later.
+    RUBY
+
+    expect_correction(<<~RUBY)
+    property :foo, String, name_property: true
+    RUBY
+  end
+
+  it 'registers an offense when a resource attribute is both a name_attribute and has a default' do
+    expect_offense(<<~RUBY)
+      attribute :foo, String, name_attribute: true, default: 'foo'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A resource property can't be marked as a name_property and also have a default value. This will fail in Chef Infra Client 13 or later.
+    RUBY
+
+    expect_correction(<<~RUBY)
+    attribute :foo, String, name_attribute: true
     RUBY
   end
 

--- a/spec/rubocop/cop/chef/modernize/property_with_name_attribute_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/property_with_name_attribute_spec.rb
@@ -1,5 +1,6 @@
 #
 # Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +23,7 @@ describe RuboCop::Cop::Chef::ChefModernize::PropertyWithNameAttribute, :config d
   it 'registers an offense when a property has a name_attribute value' do
     expect_offense(<<~RUBY)
       property :foo, String, name_attribute: true
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resource property sets name_attribute not name_property
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resource property sets name_attribute instead of name_property
     RUBY
 
     expect_correction(<<~RUBY)

--- a/spec/rubocop/cop/chef/redundant/unnecessary_name_property_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/unnecessary_name_property_spec.rb
@@ -19,13 +19,19 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ChefRedundantCode::UnnecessaryNameProperty, :config do
   subject(:cop) { described_class.new(config) }
 
-  #   property :name, String
-  #   property :name, String, name_property: true
-
   it 'registers an offense when a resource has a property called name' do
     expect_offense(<<~RUBY)
       property :name, String
-      ^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources by default.
+      ^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this all resources by default.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it 'registers an offense when a resource has an attribute called name' do
+    expect_offense(<<~RUBY)
+      attribute :name, String
+      ^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this all resources by default.
     RUBY
 
     expect_correction("\n")
@@ -34,7 +40,16 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::UnnecessaryNameProperty, :config
   it 'registers an offense when a resource has a property called name that is a name_property' do
     expect_offense(<<~RUBY)
       property :name, String, name_property: true
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property named :name in a resource as Chef Infra defines that property for all resources by default.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this all resources by default.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it 'registers an offense when a resource has a attribute called name that is a name_attribute' do
+    expect_offense(<<~RUBY)
+      attribute :name, String, name_attribute: true
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this all resources by default.
     RUBY
 
     expect_correction("\n")

--- a/spec/rubocop/cop/chef/redundant/unnecessary_name_property_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/unnecessary_name_property_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::UnnecessaryNameProperty, :config
   it 'registers an offense when a resource has a property called name' do
     expect_offense(<<~RUBY)
       property :name, String
-      ^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this all resources by default.
+      ^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this on all resources by default.
     RUBY
 
     expect_correction("\n")
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::UnnecessaryNameProperty, :config
   it 'registers an offense when a resource has an attribute called name' do
     expect_offense(<<~RUBY)
       attribute :name, String
-      ^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this all resources by default.
+      ^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this on all resources by default.
     RUBY
 
     expect_correction("\n")
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::UnnecessaryNameProperty, :config
   it 'registers an offense when a resource has a property called name that is a name_property' do
     expect_offense(<<~RUBY)
       property :name, String, name_property: true
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this all resources by default.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this on all resources by default.
     RUBY
 
     expect_correction("\n")
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::UnnecessaryNameProperty, :config
   it 'registers an offense when a resource has a attribute called name that is a name_attribute' do
     expect_offense(<<~RUBY)
       attribute :name, String, name_attribute: true
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this all resources by default.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this on all resources by default.
     RUBY
 
     expect_correction("\n")


### PR DESCRIPTION
- Greatly simplify these cops by using the node matchers so we don’t have to do a pile of defensive coding to traverse hashes and what not. This also most likely makes these cops much more reliable in funky real-world situations.
- Only match on ruby files in libraries/resources. No need to check methods in providers.
- Add autocorrecting to NamePropertyWithDefaultValue. Just delete the default value since that's what the user will do anyways
- Match on attributes as well in NamePropertyWithDefaultValue. This makes sense to do in the LWRP world as well
- Make UnnecessaryNameProperty also match on attributes. Again this is a valid offense in the LWRP world as well

Signed-off-by: Tim Smith <tsmith@chef.io>