### PR TITLE
Handle additional scenarios of platform checks

### DIFF
--- a/lib/rubocop/cop/chef/style/use_platform_helpers.rb
+++ b/lib/rubocop/cop/chef/style/use_platform_helpers.rb
@@ -66,7 +66,8 @@ module RuboCop
               end
 
               platform_include?(node) do |plats, type|
-                corrected_string = "#{type.value}?('#{plats.values.map(&:source).join("', '")}')"
+                platforms = plats.values.map { |x| x.str_type? ? "'#{x.value}'" : x.source }
+                corrected_string = "#{type.value}?(#{platforms.join(', ')})"
                 corrector.replace(node.loc.expression, corrected_string)
               end
             end

--- a/spec/rubocop/cop/chef/style/use_platform_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/style/use_platform_helpers_spec.rb
@@ -70,4 +70,17 @@ describe RuboCop::Cop::Chef::ChefStyle::UsePlatformHelpers do
       end
     RUBY
   end
+
+  it 'registers an offense when checking platform family with include? and a quoted array of values' do
+    expect_offense(<<~RUBY)
+      if ['rhel', some_variable].include?(node['platform_family'])
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use platform? and platform_family? helpers to check a node's platform
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if platform_family?('rhel', some_variable)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
['rhel', some_variable].include?(node['platform_family'] is valid and we
should handle it all correctly without added or double quotes

Signed-off-by: Tim Smith <tsmith@chef.io>