### PR TITLE
Add Powershell mixins to ChefModernize/IncludingMixinShelloutInResources

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -801,7 +801,7 @@ ChefModernize/MinitestHandlerUsage:
     - '**/metadata.rb'
 
 ChefModernize/IncludingMixinShelloutInResources:
-  Description: There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client.
+  Description: There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
   Enabled: true
   VersionAdded: '5.4.0'
   Include:

--- a/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
+++ b/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
@@ -19,23 +19,25 @@ module RuboCop
   module Cop
     module Chef
       module ChefModernize
-        # There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
+        # There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
         #
         # @example
         #
         #   # bad
         #   require 'chef/mixin/shell_out'
         #   include Chef::Mixin::ShellOut
-
+        #   require 'chef/mixin/powershell_out'
+        #   include Chef::Mixin::PowershellOut
+        #
         class IncludingMixinShelloutInResources < Cop
-          MSG = 'There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client 12.4+.'.freeze
+          MSG = 'There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.'.freeze
 
           def_node_matcher :include_shellout?, <<-PATTERN
-            (send nil? :include (const (const (const nil? :Chef) :Mixin) :ShellOut))
+            (send nil? :include (const (const (const nil? :Chef) :Mixin) {:ShellOut :PowershellOut}))
           PATTERN
 
           def_node_matcher :require_shellout?, <<-PATTERN
-            (send nil? :require ( str "chef/mixin/shell_out"))
+            (send nil? :require ( str {"chef/mixin/shell_out" "chef/mixin/powershell_out"} ))
           PATTERN
 
           def on_send(node)

--- a/spec/rubocop/cop/chef/modernize/includes_mixin_shellout_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/includes_mixin_shellout_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Chef::ChefModernize::IncludingMixinShelloutInResources, :
   it 'registers an error when requiring "chef/mixin/shell_out"' do
     expect_offense(<<~RUBY)
     require 'chef/mixin/shell_out'
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
     RUBY
 
     expect_correction("\n")
@@ -31,7 +31,25 @@ describe RuboCop::Cop::Chef::ChefModernize::IncludingMixinShelloutInResources, :
   it 'registers an error when including "Chef::Mixin::ShellOut"' do
     expect_offense(<<~RUBY)
     include Chef::Mixin::ShellOut
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it 'registers an error when requiring "chef/mixin/powershell_out"' do
+    expect_offense(<<~RUBY)
+    require 'chef/mixin/powershell_out'
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it 'registers an error when including "Chef::Mixin::PowershellOut"' do
+    expect_offense(<<~RUBY)
+    include Chef::Mixin::PowershellOut
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
     RUBY
 
     expect_correction("\n")


### PR DESCRIPTION
The PowerShell mixin was also added by default in Chef Infra 12.4

Signed-off-by: Tim Smith <tsmith@chef.io>