### PR TITLE
Add 2 new cops for removing redundant config in apt_repository

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1185,6 +1185,24 @@ ChefRedundantCode/UnnecessaryDesiredState:
     - '**/resources/*.rb'
     - '**/libraries/*.rb'
 
+ChefRedundantCode/AptRepositoryNotifiesAptUpdate:
+  Description: There is no need to notify an apt-get update when an apt_repository is created as this is done automatically by the apt_repository resource.
+  Enabled: true
+  VersionAdded: '5.17.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
+ChefRedundantCode/AptRepositoryDistributionDefault:
+  Description: There is no need to pass `distribution node['lsb']['codename']` to an apt_repository resource as this is done automatically by the apt_repository resource.
+  Enabled: true
+  VersionAdded: '5.17.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 ###############################
 # Migrating to new patterns
 ###############################

--- a/lib/rubocop/cop/chef/redundant/apt_repository_distribution_default.rb
+++ b/lib/rubocop/cop/chef/redundant/apt_repository_distribution_default.rb
@@ -1,0 +1,66 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefRedundantCode
+        # There is no need to pass `distribution node['lsb']['codename']` to an apt_repository resource as this is done automatically by the apt_repository resource.
+        #
+        #   # bad
+        #   apt_repository 'my repo' do
+        #     uri 'http://packages.example.com/debian'
+        #     components %w(stable main)
+        #     deb_src false
+        #     distribution node['lsb']['codename']
+        #   end
+        #
+        #   # good
+        #   apt_repository 'my repo' do
+        #     uri 'http://packages.example.com/debian'
+        #     components %w(stable main)
+        #     deb_src false
+        #   end
+        #
+        class AptRepositoryDistributionDefault < Cop
+          include RuboCop::Chef::CookbookHelpers
+          include RangeHelp
+
+          MSG = "There is no need to pass `distribution node['lsb']['codename']` to an apt_repository resource as this is done automatically by the apt_repository resource.".freeze
+
+          def_node_matcher :default_dist?, <<-PATTERN
+            (send nil? :distribution (send (send (send nil? :node) :[] ({sym str} {:lsb "lsb"})) :[] ({sym str} {:codename "codename"})))
+          PATTERN
+
+          def on_block(node)
+            match_property_in_resource?(:apt_repository, 'distribution', node) do |dist|
+              ## require 'pry'; binding.pry
+              default_dist?(dist) do
+                add_offense(dist, location: :expression, message: MSG, severity: :refactor)
+              end
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/redundant/apt_repository_notifies_apt_update.rb
+++ b/lib/rubocop/cop/chef/redundant/apt_repository_notifies_apt_update.rb
@@ -1,0 +1,59 @@
+#
+# Copyright:: 2019, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefRedundantCode
+        # There is no need to notify an apt-get update when an apt_repository is created as this is done automatically by the apt_repository resource.
+        #
+        #   # bad
+        #   apt_repository 'my repo' do
+        #     uri 'http://packages.example.com/debian'
+        #     components %w(stable main)
+        #     deb_src false
+        #     notifies :run, 'execute[apt-get update]', :immediately
+        #   end
+        #
+        #   # good
+        #   apt_repository 'my repo' do
+        #     uri 'http://packages.example.com/debian'
+        #     components %w(stable main)
+        #     deb_src false
+        #   end
+        #
+        class AptRepositoryNotifiesAptUpdate < Cop
+          include RuboCop::Chef::CookbookHelpers
+          include RangeHelp
+
+          MSG = 'There is no need to notify an apt-get update when an apt_repository is created as this is done automatically by the apt_repository resource.'.freeze
+
+          def on_block(node)
+            match_property_in_resource?(:apt_repository, 'notifies', node) do |notifies|
+              add_offense(notifies, location: :expression, message: MSG, severity: :refactor) if notifies.arguments[1] == s(:str, 'execute[apt-get update]')
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/redundant/apt_repository_distribution_default_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/apt_repository_distribution_default_spec.rb
@@ -1,0 +1,73 @@
+#
+# Copyright:: Copyright 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefRedundantCode::AptRepositoryDistributionDefault do
+  subject(:cop) { described_class.new }
+
+  it "registers an offense when apt_repository sets the distribution to node['lsb']['codename']" do
+    expect_offense(<<~RUBY)
+      apt_repository 'my repo' do
+        uri 'http://packages.example.com/debian'
+        components %w(stable main)
+        deb_src false
+        distribution node['lsb']['codename']
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to pass `distribution node['lsb']['codename']` to an apt_repository resource as this is done automatically by the apt_repository resource.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      apt_repository 'my repo' do
+        uri 'http://packages.example.com/debian'
+        components %w(stable main)
+        deb_src false
+      end
+    RUBY
+  end
+
+  it 'registers an offense when apt_repository sets the distribution to node[:lsb][:codename]' do
+    expect_offense(<<~RUBY)
+      apt_repository 'my repo' do
+        uri 'http://packages.example.com/debian'
+        components %w(stable main)
+        deb_src false
+        distribution node[:lsb][:codename]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to pass `distribution node['lsb']['codename']` to an apt_repository resource as this is done automatically by the apt_repository resource.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      apt_repository 'my repo' do
+        uri 'http://packages.example.com/debian'
+        components %w(stable main)
+        deb_src false
+      end
+    RUBY
+  end
+
+  it 'does not register an offense with a non-default distribution value' do
+    expect_no_offenses(<<~RUBY)
+    apt_repository 'my repo' do
+      uri 'http://packages.example.com/debian'
+      components %w(stable main)
+      deb_src false
+      distribution 'stuff'
+    end
+  RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/redundant/apt_repository_notifies_apt_update_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/apt_repository_notifies_apt_update_spec.rb
@@ -1,0 +1,53 @@
+#
+# Copyright:: Copyright 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefRedundantCode::AptRepositoryNotifiesAptUpdate do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when apt_repository notifies execute[apt-get update]' do
+    expect_offense(<<~RUBY)
+      apt_repository 'my repo' do
+        uri 'http://packages.example.com/debian'
+        components %w(stable main)
+        deb_src false
+        notifies :run, 'execute[apt-get update]', :immediately
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to notify an apt-get update when an apt_repository is created as this is done automatically by the apt_repository resource.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      apt_repository 'my repo' do
+        uri 'http://packages.example.com/debian'
+        components %w(stable main)
+        deb_src false
+      end
+    RUBY
+  end
+
+  it 'does not register an offense with a plain old notification' do
+    expect_no_offenses(<<~RUBY)
+    apt_repository 'my repo' do
+      uri 'http://packages.example.com/debian'
+      components %w(stable main)
+      deb_src false
+      notifies :run, 'execute[foo]', :immediately
+    end
+  RUBY
+  end
+end


### PR DESCRIPTION
Simplify apt_repository usage by removing two complex bits of code that aren't needed.

Signed-off-by: Tim Smith <tsmith@chef.io>