### PR TITLE
Fix .start_with? errors on Ruby 2.4

### DIFF
--- a/lib/rubocop/cop/chef/correctness/invalid_platform_metadata.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_metadata.rb
@@ -81,7 +81,7 @@ module RuboCop
             return false unless val
 
             # if the value was previously quoted make sure to quote it again
-            node.source.start_with?(/('|")/) ? "'" + val + "'" : val
+            node.source.match?(/^('|")/) ? "'" + val + "'" : val
           end
         end
       end


### PR DESCRIPTION
start_with? can't take a regex on Ruby 2.4 apparently.

Signed-off-by: Tim Smith <tsmith@chef.io>