### PR TITLE
Match on attributes in TrueClassFalseClassResourceProperties

### DIFF
--- a/lib/rubocop/cop/chef/style/true_false_resource_properties.rb
+++ b/lib/rubocop/cop/chef/style/true_false_resource_properties.rb
@@ -24,28 +24,39 @@ module RuboCop
         #
         #   # bad
         #   property :foo, [TrueClass, FalseClass]
+        #   attribute :foo, kind_of: [TrueClass, FalseClass]
         #
         #   # good
         #   property :foo, [true, false]
+        #   attribute :foo, kind_of: [true, false]
         #
         class TrueClassFalseClassResourceProperties < Cop
           MSG = "When setting the allowed types for a resource to accept either true or false values it's much simpler to use true and false instead of TrueClass and FalseClass.".freeze
 
+          def_node_matcher :trueclass_falseclass_array?, <<-PATTERN
+             (array (const nil? :TrueClass) (const nil? :FalseClass))
+          PATTERN
+
+          def_node_matcher :tf_in_kind_of_hash?, <<-PATTERN
+            (hash (pair (sym :kind_of) #trueclass_falseclass_array? ))
+          PATTERN
+
           def_node_matcher :trueclass_falseclass_property?, <<-PATTERN
-            (send nil? {:property :attribute} (sym _) $(array (const nil? :TrueClass) (const nil? :FalseClass)) ... )
+            (send nil? {:property :attribute} (sym _)
+
+            ${#tf_in_kind_of_hash? #trueclass_falseclass_array? } ... )
           PATTERN
 
           def on_send(node)
-            trueclass_falseclass_property?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            trueclass_falseclass_property?(node) do |tf_match|
+              add_offense(tf_match, location: :expression, message: MSG, severity: :refactor)
             end
           end
 
           def autocorrect(node)
             lambda do |corrector|
-              trueclass_falseclass_property?(node) do |types|
-                corrector.replace(types.loc.expression, '[true, false]')
-              end
+              replacement_text = node.hash_type? ? 'kind_of: [true, false]' : '[true, false]'
+              corrector.replace(node.loc.expression, replacement_text)
             end
           end
         end

--- a/spec/rubocop/cop/chef/style/true_false_resource_properties_spec.rb
+++ b/spec/rubocop/cop/chef/style/true_false_resource_properties_spec.rb
@@ -20,13 +20,22 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ChefStyle::TrueClassFalseClassResourceProperties do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense when a resource specifies the type of TrueClass, FalseClass' do
+  it 'registers an offense when a property specifies the type of TrueClass, FalseClass' do
     expect_offense(<<~RUBY)
       property :foo, [TrueClass, FalseClass]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ When setting the allowed types for a resource to accept either true or false values it's much simpler to use true and false instead of TrueClass and FalseClass.
+                     ^^^^^^^^^^^^^^^^^^^^^^^ When setting the allowed types for a resource to accept either true or false values it's much simpler to use true and false instead of TrueClass and FalseClass.
     RUBY
 
     expect_correction("property :foo, [true, false]\n")
+  end
+
+  it 'registers an offense when an attribute specifies the type of TrueClass, FalseClass' do
+    expect_offense(<<~RUBY)
+      attribute :foo, kind_of: [TrueClass, FalseClass]
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ When setting the allowed types for a resource to accept either true or false values it's much simpler to use true and false instead of TrueClass and FalseClass.
+    RUBY
+
+    expect_correction("attribute :foo, kind_of: [true, false]\n")
   end
 
   it 'does not register an offense when a resource property has a type of true, false' do


### PR DESCRIPTION
We want to fix this in both LWRPs and custom resources. Make sure we catch both. It's a bit tricky due to the kind_of: hash mess.

Signed-off-by: Tim Smith <tsmith@chef.io>