### PR TITLE
Better exclude the files / vendor directories

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2,8 +2,8 @@ AllCops:
   TargetRubyVersion: 2.4
   TargetChefVersion: ~
   Exclude:
-    - files/**/*
-    - vendor/**/*
+    - '**/files/**/*'
+    - '**/vendor/**/*'
     - Guardfile
   ChefAttributes:
     Patterns:
@@ -1892,7 +1892,7 @@ Lint/BigDecimalNew:
 Lint/UnneededCopEnableDirective:
   Enabled: true
 
-# get people on a much simpler ruby 2.4 way of doing things
+# get people on a much simpler ruby 2.4+ way of doing things
 Style/UnpackFirst:
   Enabled: true
 


### PR DESCRIPTION
This way we exclude them in a mono-repo and in test cookbooks. This not only prevents us from cookstyling people's non-chef ruby code, but it speeds up the cookstyle run since we're touching less.

Signed-off-by: Tim Smith <tsmith@chef.io>