### PR TITLE
Add ChefModernize/ResourceForcingCompileTime

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1064,6 +1064,15 @@ ChefModernize/DslIncludeInResource:
     - '**/resources/*.rb'
     - '**/providers/*.rb'
 
+ChefModernize/ResourceForcingCompileTime:
+  Description: The hostname, build_essential, chef_gem, and ohai_hint resources include 'compile_time' properties, which should be used to force the resources to run at compile time by setting `compile_time true`.
+  Enabled: true
+  VersionAdded: '5.18.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefRedundantCode: Cleanup unncessary code in your cookbooks regardless of chef-client release
 ###############################

--- a/lib/rubocop/cop/chef/modernize/compile_time_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/compile_time_resources.rb
@@ -1,0 +1,51 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefModernize
+        # The hostname, build_essential, chef_gem, and ohai_hint resources include 'compile_time' properties, which should be used to force the resources to run at compile time by setting `compile_time true`.
+        #
+        # @example
+        #
+        #   # bad
+        #   build_essential 'install build tools' do
+        #    action :nothing
+        #   end.run_action(:install)
+        #
+        #   # good
+        #   build_essential 'install build tools' do
+        #    compile_time true
+        #   end
+        #
+        class ResourceForcingCompileTime < Cop
+          MSG = "Set 'compile_time true' in resources when available instead of forcing resources to run at compile time by setting an action on the block.".freeze
+
+          def_node_matcher :compile_time_resource?, <<-PATTERN
+            (send (block (send nil? {:build_essential :chef_gem :hostname :ohai_hint} (...)) (args) (...)) $:run_action (sym ...))
+          PATTERN
+
+          def on_send(node)
+            compile_time_resource?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/compile_time_resources_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/compile_time_resources_spec.rb
@@ -1,0 +1,67 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefModernize::ResourceForcingCompileTime, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when build_essential resources set an action on the block' do
+    expect_offense(<<~RUBY)
+      build_essential 'install build tools' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Set 'compile_time true' in resources when available instead of forcing resources to run at compile time by setting an action on the block.
+        action :nothing
+      end.run_action(:install)
+    RUBY
+  end
+
+  it 'registers an offense when hostname resources set an action on the block' do
+    expect_offense(<<~RUBY)
+      hostname 'tim.example.com' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Set 'compile_time true' in resources when available instead of forcing resources to run at compile time by setting an action on the block.
+        action :nothing
+      end.run_action(:set)
+    RUBY
+  end
+
+  it 'registers an offense when chef_gem resources set an action on the block' do
+    expect_offense(<<~RUBY)
+      chef_gem 'community_cookbook_releaser' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Set 'compile_time true' in resources when available instead of forcing resources to run at compile time by setting an action on the block.
+        action :nothing
+      end.run_action(:install)
+    RUBY
+  end
+
+  it 'registers an offense when ohai_hint resources set an action on the block' do
+    expect_offense(<<~RUBY)
+      ohai_hint 'pdx_datacenter' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Set 'compile_time true' in resources when available instead of forcing resources to run at compile time by setting an action on the block.
+        content 'true'
+        action :nothing
+      end.run_action(:install)
+    RUBY
+  end
+
+  it 'does not register an offense when a resource sets compile_time true' do
+    expect_no_offenses(<<~RUBY)
+      chef_gem 'community_cookbook_releaser' do
+        compile_time true
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
This detects overly complex logic for forcing certain resources to run at compile_time

Signed-off-by: Tim Smith <tsmith@chef.io>