### PR TITLE
Update metadata.rb cops to not leave empty lines behind

### DIFF
--- a/lib/rubocop/cop/chef/redundant/attribute_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/attribute_metadata.rb
@@ -33,6 +33,8 @@ module RuboCop
         #              default: '"127.0.0.1:2181"'
         #
         class AttributeMetadata < Cop
+          include RangeHelp
+
           MSG = 'The attribute metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
@@ -41,7 +43,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(node.loc.expression)
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/conflicts_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/conflicts_metadata.rb
@@ -28,6 +28,8 @@ module RuboCop
         #   conflicts "another_cookbook"
         #
         class ConflictsMetadata < Cop
+          include RangeHelp
+
           MSG = 'The conflicts metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
@@ -36,7 +38,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(node.loc.expression)
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/provides_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/provides_metadata.rb
@@ -28,6 +28,8 @@ module RuboCop
         #   provides "some_thing"
         #
         class ProvidesMetadata < Cop
+          include RangeHelp
+
           MSG = 'The provides metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
@@ -36,7 +38,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(node.loc.expression)
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
@@ -28,6 +28,8 @@ module RuboCop
         #
         #
         class RecipeMetadata < Cop
+          include RangeHelp
+
           MSG = "The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the cookbook's README.md file instead.".freeze
 
           def on_send(node)
@@ -36,7 +38,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(node.loc.expression)
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/replaces_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/replaces_metadata.rb
@@ -28,6 +28,8 @@ module RuboCop
         #   replaces "another_cookbook"
         #
         class ReplacesMetadata < Cop
+          include RangeHelp
+
           MSG = 'The replaces metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
@@ -36,7 +38,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(node.loc.expression)
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/suggests_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/suggests_metadata.rb
@@ -28,6 +28,8 @@ module RuboCop
         #   suggests "another_cookbook"
         #
         class SuggestsMetadata < Cop
+          include RangeHelp
+
           MSG = 'The suggests metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
           def on_send(node)
@@ -36,7 +38,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(node.loc.expression)
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
             end
           end
         end

--- a/spec/rubocop/cop/chef/redundant/attribute_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/attribute_metadata_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::AttributeMetadata, :config do
       ^^^^^^^^^^^^^^^ The attribute metadata.rb method is not used and is unnecessary in cookbooks.
     RUBY
 
-    expect_correction("\n")
+    expect_correction('')
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/redundant/conflicts_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/conflicts_metadata_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::ConflictsMetadata, :config do
       ^^^^^^^^^^^^^^^ The conflicts metadata.rb method is not used and is unnecessary in cookbooks.
     RUBY
 
-    expect_correction("\n")
+    expect_correction('')
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/redundant/provides_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/provides_metadata_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::ProvidesMetadata, :config do
       ^^^^^^^^^^^^^^ The provides metadata.rb method is not used and is unnecessary in cookbooks.
     RUBY
 
-    expect_correction("\n")
+    expect_correction('')
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/redundant/recipe_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/recipe_metadata_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::RecipeMetadata, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the cookbook's README.md file instead.
     RUBY
 
-    expect_correction("\n")
+    expect_correction('')
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/redundant/replaces_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/replaces_metadata_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::ReplacesMetadata, :config do
       ^^^^^^^^^^^^^^ The replaces metadata.rb method is not used and is unnecessary in cookbooks.
     RUBY
 
-    expect_correction("\n")
+    expect_correction('')
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/redundant/suggests_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/suggests_metadata_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::SuggestsMetadata, :config do
       ^^^^^^^^^^^^^^ The suggests metadata.rb method is not used and is unnecessary in cookbooks.
     RUBY
 
-    expect_correction("\n")
+    expect_correction('')
   end
 
   it "doesn't register an offense on normal metadata" do


### PR DESCRIPTION
This was already applied to long_description and it works great there. This way we don't end up with funky leftover lines that other cops or humans have to clean up.

example leftover lines:

```







# General Attributes.















# Process related attributes









# Packing related attributes



















# Backup related attributes









# Buildout related attributes

```
Signed-off-by: Tim Smith <tsmith@chef.io>