### PR TITLE
Properly cleanup heredoc long_description metadata

### DIFF
--- a/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
@@ -37,7 +37,12 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
+              if node.arguments.first.respond_to?(:heredoc?) && node.arguments.first.heredoc?
+                total_range = range_with_surrounding_space(range: node.loc.expression.join(node.arguments.first.loc.heredoc_end), side: :left)
+                corrector.remove(total_range)
+              else
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
             end
           end
         end

--- a/spec/rubocop/cop/chef/redundant/long_description_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/long_description_metadata_spec.rb
@@ -30,6 +30,25 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::LongDescriptionMetadata, :config
     expect_correction("description 'foo'\nversion '1.0.0'\n")
   end
 
+  it 'properly autocorrects long_description with a heredoc' do
+    expect_offense(<<~RUBY)
+      description 'foo'
+      long_description <<-EOH
+      ^^^^^^^^^^^^^^^^^^^^^^^ The long_description metadata.rb method is not used and is unnecessary in cookbooks.
+      Chef Sugar is a Gem & Chef Recipe that includes series of helpful syntactic
+      sugars on top of the Chef core and other resources to make a cleaner, more lean
+      recipe DSL, enforce DRY principles, and make writing Chef recipes an awesome and
+      fun experience!
+
+      For the most up-to-date information and documentation, please visit the [Chef
+      Sugar project page on GitHub](https://github.com/chef/chef-sugar).
+      EOH
+      version '1.0.0'
+    RUBY
+
+    expect_correction("description 'foo'\nversion '1.0.0'\n")
+  end
+
   it "doesn't register an offense on normal metadata" do
     expect_no_offenses(<<~RUBY)
       depends 'foo'


### PR DESCRIPTION
This is somewhat common and our current autocorrect results in invalid ruby as it leaves behind the heredoc body and anchor.

Signed-off-by: Tim Smith <tsmith@chef.io>