### PR TITLE
Better trim metadata.rb whitespace

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1095,7 +1095,7 @@ ChefRedundantCode/ConflictsMetadata:
     - '**/metadata.rb'
 
 ChefRedundantCode/SuggestsMetadata:
-  Description: Don't use the deprecated 'suggests' metadata value
+  Description: The suggests metadata.rb method is not used and is unnecessary in cookbooks.
   Enabled: true
   VersionAdded: '5.1.0'
   VersionChanged: '5.15.0'
@@ -1103,7 +1103,7 @@ ChefRedundantCode/SuggestsMetadata:
     - '**/metadata.rb'
 
 ChefRedundantCode/ProvidesMetadata:
-  Description: Don't use the deprecated 'provides' metadata value
+  Description: The provides metadata.rb method is not used and is unnecessary in cookbooks.
   Enabled: true
   VersionAdded: '5.1.0'
   VersionChanged: '5.15.0'
@@ -1111,7 +1111,7 @@ ChefRedundantCode/ProvidesMetadata:
     - '**/metadata.rb'
 
 ChefRedundantCode/ReplacesMetadata:
-  Description: Don't use the deprecated 'replaces' metadata value
+  Description: The replaces metadata.rb method is not used and is unnecessary in cookbooks.
   Enabled: true
   VersionAdded: '5.1.0'
   VersionChanged: '5.15.0'
@@ -1119,7 +1119,7 @@ ChefRedundantCode/ReplacesMetadata:
     - '**/metadata.rb'
 
 ChefRedundantCode/AttributeMetadata:
-  Description: Don't use the deprecated 'attribute' metadata value
+  Description: The attribute metadata.rb method is not used and is unnecessary in cookbooks.
   Enabled: true
   VersionAdded: '5.1.0'
   VersionChanged: '5.15.0'

--- a/lib/rubocop/cop/chef/redundant/provides_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/provides_metadata.rb
@@ -38,7 +38,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
@@ -38,7 +38,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/replaces_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/replaces_metadata.rb
@@ -38,7 +38,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/suggests_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/suggests_metadata.rb
@@ -38,7 +38,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end
         end

--- a/spec/rubocop/cop/chef/redundant/attribute_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/attribute_metadata_spec.rb
@@ -21,11 +21,16 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::AttributeMetadata, :config do
 
   it 'registers an offense when metadata uses "attribute"' do
     expect_offense(<<~RUBY)
+      name 'foo'
       attribute 'foo'
       ^^^^^^^^^^^^^^^ The attribute metadata.rb method is not used and is unnecessary in cookbooks.
+      depends 'bar'
     RUBY
 
-    expect_correction('')
+    expect_correction(<<~RUBY)
+      name 'foo'
+      depends 'bar'
+    RUBY
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/redundant/conflicts_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/conflicts_metadata_spec.rb
@@ -21,11 +21,16 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::ConflictsMetadata, :config do
 
   it 'registers an offense when metadata uses "conflicts"' do
     expect_offense(<<~RUBY)
+      name 'foo'
       conflicts 'foo'
       ^^^^^^^^^^^^^^^ The conflicts metadata.rb method is not used and is unnecessary in cookbooks.
+      depends 'bar'
     RUBY
 
-    expect_correction('')
+    expect_correction(<<~RUBY)
+      name 'foo'
+      depends 'bar'
+    RUBY
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/redundant/provides_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/provides_metadata_spec.rb
@@ -21,11 +21,16 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::ProvidesMetadata, :config do
 
   it 'registers an offense when metadata uses "provides"' do
     expect_offense(<<~RUBY)
+      name 'foo'
       provides 'foo'
       ^^^^^^^^^^^^^^ The provides metadata.rb method is not used and is unnecessary in cookbooks.
+      depends 'bar'
     RUBY
 
-    expect_correction('')
+    expect_correction(<<~RUBY)
+      name 'foo'
+      depends 'bar'
+    RUBY
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/redundant/recipe_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/recipe_metadata_spec.rb
@@ -21,11 +21,16 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::RecipeMetadata, :config do
 
   it 'registers an offense when metadata uses "recipe"' do
     expect_offense(<<~RUBY)
+      name 'foo'
       recipe 'chef-client::config', 'Configures the client.rb from a template.'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the cookbook's README.md file instead.
+      depends 'bar'
     RUBY
 
-    expect_correction('')
+    expect_correction(<<~RUBY)
+      name 'foo'
+      depends 'bar'
+    RUBY
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/redundant/replaces_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/replaces_metadata_spec.rb
@@ -21,11 +21,16 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::ReplacesMetadata, :config do
 
   it 'registers an offense when metadata uses "replaces"' do
     expect_offense(<<~RUBY)
+      name 'foo'
       replaces 'foo'
       ^^^^^^^^^^^^^^ The replaces metadata.rb method is not used and is unnecessary in cookbooks.
+      depends 'bar'
     RUBY
 
-    expect_correction('')
+    expect_correction(<<~RUBY)
+      name 'foo'
+      depends 'bar'
+    RUBY
   end
 
   it "doesn't register an offense on normal metadata" do

--- a/spec/rubocop/cop/chef/redundant/suggests_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/suggests_metadata_spec.rb
@@ -21,11 +21,16 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::SuggestsMetadata, :config do
 
   it 'registers an offense when metadata uses "suggests"' do
     expect_offense(<<~RUBY)
+      name 'foo'
       suggests 'foo'
       ^^^^^^^^^^^^^^ The suggests metadata.rb method is not used and is unnecessary in cookbooks.
+      depends 'bar'
     RUBY
 
-    expect_correction('')
+    expect_correction(<<~RUBY)
+      name 'foo'
+      depends 'bar'
+    RUBY
   end
 
   it "doesn't register an offense on normal metadata" do


### PR DESCRIPTION
Neither right or left gets it all and :both mangles the world. Left seems to result in better output when the metadata is nested between other metadata which is the most common scenario. I updated the specs to reflect a real metadata.rb file.

Signed-off-by: Tim Smith <tsmith@chef.io>