### PR TITLE
Fix ChefStyle/FileMode to autocorrect single quotes

### DIFF
--- a/lib/rubocop/cop/chef/style/file_mode.rb
+++ b/lib/rubocop/cop/chef/style/file_mode.rb
@@ -47,7 +47,10 @@ module RuboCop
               # If it was an octal literal, make sure we write out the right number.
               replacement_base = octal?(node) ? 8 : 10
               replacement_mode = node.children.first.to_s(replacement_base)
-              corrector.replace(node.loc.expression, replacement_mode.inspect)
+
+              # we build our own escaped string instead of using .inspect because that way
+              # we can use single quotes instead of the double quotes that .inspect adds
+              corrector.replace(node.loc.expression, "\'#{replacement_mode}\'")
             end
           end
 

--- a/spec/rubocop/cop/chef/style/file_mode_spec.rb
+++ b/spec/rubocop/cop/chef/style/file_mode_spec.rb
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Chef::ChefStyle::FileMode do
     expect_correction(<<~RUBY)
       file '/foo' do
         owner 'root'
-        mode "644"
+        mode '644'
       end
     RUBY
   end
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Chef::ChefStyle::FileMode do
     expect_correction(<<~RUBY)
       file '/foo' do
         owner 'root'
-        mode "644"
+        mode '644'
       end
     RUBY
   end
@@ -66,40 +66,40 @@ describe RuboCop::Cop::Chef::ChefStyle::FileMode do
     expect_no_offenses(<<~RUBY)
       file '/foo' do
         owner 'root'
-        mode "644"
+        mode '644'
       end
     RUBY
   end
 
   include_examples 'autocorrect',
                    'mode 644',
-                   'mode "644"'
+                   "mode '644'"
 
   include_examples 'autocorrect',
                    'mode 0644',
-                   'mode "644"'
+                   "mode '644'"
 
   include_examples 'autocorrect',
                    'mode 00644',
-                   'mode "644"'
+                   "mode '644'"
 
   include_examples 'autocorrect',
                    'mode 1644',
-                   'mode "1644"'
+                   "mode '1644'"
 
   include_examples 'autocorrect',
                    'mode 01644',
-                   'mode "1644"'
+                   "mode '1644'"
 
   include_examples 'autocorrect',
                    'mode 0o644',
-                   'mode "644"'
+                   "mode '644'"
 
   include_examples 'autocorrect',
                    'mode 0O644',
-                   'mode "644"'
+                   "mode '644'"
 
   include_examples 'autocorrect',
                    'mode 0x284',
-                   'mode "644"'
+                   "mode '644'"
 end


### PR DESCRIPTION
That way we don't have to rely on the quoting cops fixing it afterward

Signed-off-by: Tim Smith <tsmith@chef.io>