### PR TITLE
Add ChefStyle/OverlyComplexSupportsDependsMetadata

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -115,6 +115,13 @@ ChefStyle/TrueClassFalseClassResourceProperties:
     - '**/libraries/*.rb'
     - '**/resources/*.rb'
 
+ChefStyle/OverlyComplexSupportsDependsMetadata:
+  Description: Don't loop over an array to set cookbook dependencies or supported platforms if you have fewer than three values to set.
+  Enabled: true
+  VersionAdded: '5.19.0'
+  Include:
+    - '**/metadata.rb'
+
 ###############################
 # ChefCorrectness: Avoiding potential problems
 ###############################

--- a/lib/rubocop/cop/chef/style/overly_complex_supports_depends_metadata.rb
+++ b/lib/rubocop/cop/chef/style/overly_complex_supports_depends_metadata.rb
@@ -1,0 +1,73 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefStyle
+        # Don't loop over an array to set cookbook dependencies or supported platforms if you have fewer than three values to set.  Setting multiple `supports` or `depends` values is simpler and easier to understand for new users.
+        #
+        # @example
+        #
+        #   # bad
+        #
+        #   %w( debian ubuntu ).each do |os|
+        #     supports os
+        #   end
+        #
+        #   %w( apt yum ).each do |cb|
+        #     depends cb
+        #   end
+        #
+        #   # good
+        #
+        #   supports 'debian'
+        #   supports 'ubuntu'
+        #
+        #   depends 'apt'
+        #   depends 'yum'
+        #
+        class OverlyComplexSupportsDependsMetadata < Cop
+          MSG = "Don't loop over an array to set cookbook dependencies or supported platforms if you have fewer than three values to set.".freeze
+
+          def_node_matcher :supports_depends_array?, <<-PATTERN
+            (block
+              (send
+                $(array ...) :each)
+              (args
+                (arg _))
+              (send nil? ${:supports :depends} (lvar _)))
+          PATTERN
+
+          def on_block(node)
+            supports_depends_array?(node) do |array, _type|
+              add_offense(node, location: :expression, message: MSG, severity: :refactor) if array.values.count < 3
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              supports_depends_array?(node) do |array, type|
+                corrected_value = array.values.map { |x| "#{type} '#{x.source}'" }
+                corrector.replace(node.loc.expression, corrected_value.join("\n"))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/style/overly_complex_supports_depends_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/style/overly_complex_supports_depends_metadata_spec.rb
@@ -1,0 +1,58 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefStyle::OverlyComplexSupportsDependsMetadata do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when defining two supports in an array' do
+    expect_offense(<<~RUBY)
+      %w( debian ubuntu ).each do |os|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't loop over an array to set cookbook dependencies or supported platforms if you have fewer than three values to set.
+        supports os
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      supports 'debian'
+      supports 'ubuntu'
+    RUBY
+  end
+
+  it 'registers an offense when defining two depends in an array' do
+    expect_offense(<<~RUBY)
+      %w( apt yum ).each do |cb|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't loop over an array to set cookbook dependencies or supported platforms if you have fewer than three values to set.
+        depends cb
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      depends 'apt'
+      depends 'yum'
+    RUBY
+  end
+
+  it 'does not register an offense when defining three depends in an array' do
+    expect_no_offenses(<<~RUBY)
+      %w( apt yum windows ).each do |cb|
+        depends cb
+      end
+  RUBY
+  end
+end


### PR DESCRIPTION
Make Chef a bit easier to read for new users by removing some Ruby where it's not helpful. DRY isn't always better.

Signed-off-by: Tim Smith <tsmith@chef.io>