### PR TITLE
Add clarity to License Strings

### DIFF
--- a/docs/cops_chefsharing.md
+++ b/docs/cops_chefsharing.md
@@ -94,10 +94,13 @@ Enabled | Yes
 metadata.rb license field should include a SPDX compliant string or "all right reserved" (not case sensitive)
 
 list of valid SPDX.org license strings. To build an array run this:
+
+```ruby
 require 'json'
 require 'net/http'
 json_data = JSON.parse(Net::HTTP.get(URI('https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json')))
 licenses = json_data['licenses'].map {|l| l['licenseId'] }.sort
+```
 
 ### Examples
 

--- a/docs/cops_chefsharing.md
+++ b/docs/cops_chefsharing.md
@@ -73,8 +73,8 @@ source_url 'http://www.gitlab.com/something/something'
 source_url 'http://gitlab.com/something/something'
 
 # good
-source_url 'http://github.com/something/something'
-source_url 'http://gitlab.com/something/something'
+source_url 'https://github.com/something/something'
+source_url 'https://gitlab.com/something/something'
 ```
 
 ### Configurable attributes

--- a/lib/rubocop/cop/chef/sharing/invalid_license_string.rb
+++ b/lib/rubocop/cop/chef/sharing/invalid_license_string.rb
@@ -450,6 +450,7 @@ module RuboCop
             'gplv2': 'GPL-2.0',
             'gplv3': 'GPL-3.0',
             'mit license': 'MIT',
+            'UNLICENSED': 'all rights reserved',
           }.freeze
 
           MSG = 'Cookbook metadata.rb does not use a SPDX compliant license string or "all rights reserved". See https://spdx.org/licenses/ for a complete list of license identifiers.'.freeze

--- a/spec/rubocop/cop/chef/sharing/invalid_license_string_spec.rb
+++ b/spec/rubocop/cop/chef/sharing/invalid_license_string_spec.rb
@@ -42,4 +42,10 @@ describe RuboCop::Cop::Chef::ChefSharing::InvalidLicenseString, :config do
       license 'Apache-2.0'
     RUBY
   end
+
+  it "doesn't register an offense when set to the all rights reserved license string" do
+    expect_no_offenses(<<~RUBY)
+      license 'all rights reserved'
+    RUBY
+  end
 end


### PR DESCRIPTION
Add Clarity to License Strings

## Description
This commit adds clarity to the documentation for license strings, it
also adds autocorrection for "UNLICENSED" as the top google result is: https://softwareengineering.stackexchange.com/questions/285885/which-spdx-license-is-equivalent-to-all-rights-reserved

Added tests as well to ensure "all rights reserved" will always pass the
check

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
