### PR TITLE
Additional fixes for ChefDeprecations/UserDeprecatedSupportsProperty

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/user_supports_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/user_supports_property.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2019-2020, Chef Software, Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,8 +55,7 @@ module RuboCop
             lambda do |corrector|
               new_text = []
               node.arguments.first.each_pair do |k, v|
-                # make sure we strip out leading :s incase what we started with was a hash rocket supports hash
-                new_text << "#{k.source.gsub(/^:/, '')} #{v.source}"
+                new_text << "#{k.value} #{v.source}"
               end
 
               corrector.replace(node.loc.expression, new_text.join("\n  "))

--- a/spec/rubocop/cop/chef/deprecation/user_supports_property_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/user_supports_property_spec.rb
@@ -38,11 +38,26 @@ describe RuboCop::Cop::Chef::ChefDeprecations::UserDeprecatedSupportsProperty, :
     RUBY
   end
 
-  it 'registers an offense when a user resource includes the supports property with hash rockets' do
+  it 'registers an offense when a user resource includes the supports property with symbol hash rockets' do
     expect_offense(<<~RUBY)
       user "betty" do
         supports :manage_home => true
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The supports property was removed in Chef Infra Client 13 in favor of individual 'manage_home' and 'non_unique' properties.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      user "betty" do
+        manage_home true
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a user resource includes the supports property with string hash rockets' do
+    expect_offense(<<~RUBY)
+      user "betty" do
+        supports 'manage_home' => true
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The supports property was removed in Chef Infra Client 13 in favor of individual 'manage_home' and 'non_unique' properties.
       end
     RUBY
 


### PR DESCRIPTION
Make sure we don't fail if using string-based hash rockets.

Signed-off-by: Tim Smith <tsmith@chef.io>