### PR TITLE
Fix false positives in ChefModernize/AllowedActionsFromInitialize

### DIFF
--- a/lib/rubocop/cop/chef/modernize/allowed_actions_initializer.rb
+++ b/lib/rubocop/cop/chef/modernize/allowed_actions_initializer.rb
@@ -47,7 +47,7 @@ module RuboCop
             return if node.body.nil? # nil body is an empty initialize method
 
             node.body.each_node do |x|
-              if x.assignment? && !x.node_parts.empty? && %i(@actions @allowed_actions).include?(x.node_parts.first)
+              if x.assignment? && !x.parent.op_asgn_type? && !x.node_parts.empty? && %i(@actions @allowed_actions).include?(x.node_parts.first)
                 add_offense(x, location: :expression, message: MSG, severity: :refactor)
               end
             end

--- a/spec/rubocop/cop/chef/modernize/allowed_actions_initializer_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/allowed_actions_initializer_spec.rb
@@ -72,6 +72,20 @@ describe RuboCop::Cop::Chef::ChefModernize::AllowedActionsFromInitialize, :confi
     RUBY
   end
 
+  it 'does not register an offense when adding actions to the parent class' do
+    expect_no_offenses(<<~RUBY)
+    def initialize(name, run_context=nil)
+      super(name, run_context)
+      @action = :install
+      @allowed_actions += [:install]
+      @resource_name = :chef_bundle
+      @compile_time = Chef::Config[:chef_gem_compile_time]
+      @gemfile = nil
+      @options = []
+    end
+    RUBY
+  end
+
   it 'does not register an offense with a resource that does not have an initialize method' do
     expect_no_offenses(<<~RUBY)
       property :something, String


### PR DESCRIPTION
+= usage of @alllowed_actions is valid and can't be replaced with the allowed_actions method call

Signed-off-by: Tim Smith <tsmith@chef.io>