### PR TITLE
Avoid false positives in ChefModernize/DefaultActionFromInitialize

### DIFF
--- a/spec/rubocop/cop/chef/modernize/default_action_initializer_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/default_action_initializer_spec.rb
@@ -82,4 +82,13 @@ describe RuboCop::Cop::Chef::ChefModernize::DefaultActionFromInitialize, :config
     end
     RUBY
   end
+
+  it 'does not register an offense when using ||= on the @action variable' do
+    expect_no_offenses(<<~RUBY)
+    def initialize(*args)
+      @default_action ||= :create
+      super
+    end
+    RUBY
+  end
 end


### PR DESCRIPTION
Use node matchers here instead of helper methods.

Signed-off-by: Tim Smith <tsmith@chef.io>