### PR TITLE
Fix autocorrection failures in ChefDeprecations/ChefHandlerUsesSupports

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
@@ -46,7 +46,9 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.replace(node.loc.expression, "type #{node.arguments.first.source}")
+              # make sure to delete leading and trailing {}s that would create invalid ruby syntax
+              extracted_val = node.arguments.first.source.gsub(/{|}/, '')
+              corrector.replace(node.loc.expression, "type #{extracted_val}")
             end
           end
         end

--- a/spec/rubocop/cop/chef/deprecation/chef_handler_supports_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_handler_supports_spec.rb
@@ -34,6 +34,21 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ChefHandlerUsesSupports, :config 
     RUBY
   end
 
+  it 'properly autocorrects when chef_handler uses supports(FOO)' do
+    expect_offense(<<~RUBY)
+    chef_handler 'Chef::Handler::ZookeeperHandler' do
+      supports({:exception => true})
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the type property instead of the deprecated supports property in the chef_handler resource. The supports property was removed in chef_handler cookbook version 3.0 (June 2017) and Chef Infra Client 14.0.
+    end
+    RUBY
+
+    expect_correction(<<~RUBY)
+    chef_handler 'Chef::Handler::ZookeeperHandler' do
+      type :exception => true
+    end
+    RUBY
+  end
+
   it "doesn't register an offense when chef_handler uses the type action" do
     expect_no_offenses(<<~RUBY)
     chef_handler 'Chef::Handler::ZookeeperHandler' do


### PR DESCRIPTION
If the hash is surrounded with { } then the autocorrect will produce invalid Ruby code. We now nuke those to autocorrect to the bare hash.

Signed-off-by: Tim Smith <tsmith@chef.io>