### PR TITLE
Catch shelling out to sysctl when using the full path

### DIFF
--- a/lib/rubocop/cop/chef/modernize/execute_sysctl.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_sysctl.rb
@@ -58,7 +58,7 @@ module RuboCop
           def on_block(node)
             match_property_in_resource?(:execute, 'command', node) do |code_property|
               property_data = method_arg_ast_to_string(code_property)
-              if property_data && property_data.match?(/^sysctl -p/i)
+              if property_data && property_data.match?(%r{^(/sbin/)?sysctl -p}i)
                 add_offense(node, location: :expression, message: MSG, severity: :refactor)
               end
             end

--- a/spec/rubocop/cop/chef/modernize/execute_sysctl_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/execute_sysctl_spec.rb
@@ -39,6 +39,16 @@ describe RuboCop::Cop::Chef::ChefModernize::ExecuteSysctl, :config do
     RUBY
   end
 
+  it 'registers an offense when loading a sysctl config with an execute resource with a command property using /sbin/sysctl' do
+    expect_offense(<<~RUBY)
+      execute 'Set IPV6 sysctl vals' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 14.0 and later includes a sysctl resource that should be used to idempotently load sysctl values instead of templating files and using execute to load them.
+        command '/sbin/sysctl -p /etc/sysctl.d/ipv6.conf'
+        action :run
+      end
+    RUBY
+  end
+
   it "doesn't register an offense when using the sysctl resource" do
     expect_no_offenses(<<~RUBY)
       sysctl 'net.ipv4.ip_local_port_range' do


### PR DESCRIPTION
I've noticed a good number of folks that are using the full path when
they shell out. We should alert on those as well.

Signed-off-by: Tim Smith <tsmith@chef.io>