### PR TITLE
Set the target ruby version to 2.3 to support Chef 12

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.3
   TargetChefVersion: ~
   Exclude:
     - '**/files/**/*'


### PR DESCRIPTION
This way people can use Cookstyle as part of the migration off Chef 12
without breaking cookbooks by introducing Ruby 2.3isms too early.

Chef 12.14+ are Ruby 2.3.

Signed-off-by: Tim Smith <tsmith@chef.io>