### PR TITLE
Make sure metadata cops properly autocorrect heredocs

### DIFF
--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -38,6 +38,7 @@ module Cookstyle
 end
 
 require_relative 'rubocop/chef'
+require_relative 'rubocop/chef/autocorrect_helpers'
 require_relative 'rubocop/chef/cookbook_helpers'
 require_relative 'rubocop/chef/platform_helpers'
 require_relative 'rubocop/chef/cookbook_only'

--- a/lib/rubocop/chef/autocorrect_helpers.rb
+++ b/lib/rubocop/chef/autocorrect_helpers.rb
@@ -1,0 +1,32 @@
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Chef
+    # Helpers for use in autocorrection
+    module AutocorrectHelpers
+      # if the node has a heredoc as an argument you'll only get the start of the heredoc and removing
+      # the node will result in broken ruby. This way we match the node and the entire heredoc for removal
+      def expression_including_heredocs(node)
+        if node.arguments.last.respond_to?(:heredoc?) && node.arguments.last.heredoc?
+          node.loc.expression.join(node.arguments.last.loc.heredoc_end)
+        else
+          node.loc.expression
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/redundant/attribute_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/attribute_metadata.rb
@@ -34,6 +34,7 @@ module RuboCop
         #
         class AttributeMetadata < Cop
           include RangeHelp
+          include RuboCop::Chef::AutocorrectHelpers
 
           MSG = 'The attribute metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
@@ -43,7 +44,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
+              corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/grouping_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/grouping_metadata.rb
@@ -29,6 +29,7 @@ module RuboCop
         #
         class GroupingMetadata < Cop
           include RangeHelp
+          include RuboCop::Chef::AutocorrectHelpers
 
           MSG = 'The grouping metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
@@ -38,7 +39,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
@@ -28,6 +28,7 @@ module RuboCop
         #
         class LongDescriptionMetadata < Cop
           include RangeHelp
+          include RuboCop::Chef::AutocorrectHelpers
 
           MSG = 'The long_description metadata.rb method is not used and is unnecessary in cookbooks.'.freeze
 
@@ -37,12 +38,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              if node.arguments.first.respond_to?(:heredoc?) && node.arguments.first.heredoc?
-                total_range = range_with_surrounding_space(range: node.loc.expression.join(node.arguments.first.loc.heredoc_end), side: :left)
-                corrector.remove(total_range)
-              else
-                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
-              end
+              corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
@@ -29,6 +29,7 @@ module RuboCop
         #
         class RecipeMetadata < Cop
           include RangeHelp
+          include RuboCop::Chef::AutocorrectHelpers
 
           MSG = "The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the cookbook's README.md file instead.".freeze
 
@@ -38,7 +39,7 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end
           end
         end

--- a/spec/rubocop/cop/chef/redundant/grouping_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/grouping_metadata_spec.rb
@@ -34,6 +34,24 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::GroupingMetadata, :config do
     RUBY
   end
 
+  it 'properly autocorrects metadata using "grouping" with a heredoc' do
+    expect_offense(<<~RUBY)
+      name 'foo'
+      grouping 'foo', <<-EOH
+      ^^^^^^^^^^^^^^^^^^^^^^ The grouping metadata.rb method is not used and is unnecessary in cookbooks.
+      Stuff!!
+      More Stuff!!
+      Even More Stuff!!
+      EOH
+      depends 'bar'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      name 'foo'
+      depends 'bar'
+    RUBY
+  end
+
   it "doesn't register an offense on normal metadata" do
     expect_no_offenses(<<~RUBY)
       depends 'foo'

--- a/spec/rubocop/cop/chef/redundant/recipe_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/recipe_metadata_spec.rb
@@ -33,6 +33,24 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::RecipeMetadata, :config do
     RUBY
   end
 
+  it 'properly autocorrects metadata using "recipe" with a heredoc' do
+    expect_offense(<<~RUBY)
+      name 'foo'
+      recipe 'foo::bar', <<-EOH
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the cookbook's README.md file instead.
+      Stuff!!
+      More Stuff!!
+      Even More Stuff!!
+      EOH
+      depends 'bar'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      name 'foo'
+      depends 'bar'
+    RUBY
+  end
+
   it "doesn't register an offense on normal metadata" do
     expect_no_offenses(<<~RUBY)
       depends 'foo'


### PR DESCRIPTION
There's a few of these on the supermarket. We should properly support this by extracting the logic I added to long_description into a helper.

Signed-off-by: Tim Smith <tsmith@chef.io>