### PR TITLE
Expand ChefStyle/UsePlatformHelpers to also detect node['platform'].eql?

### DIFF
--- a/spec/rubocop/cop/chef/style/use_platform_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/style/use_platform_helpers_spec.rb
@@ -83,4 +83,17 @@ describe RuboCop::Cop::Chef::ChefStyle::UsePlatformHelpers do
       end
     RUBY
   end
+
+  it "registers an offense when checking platform using node['platform'].eql?()" do
+    expect_offense(<<~RUBY)
+      if node['platform'].eql?('ubuntu')
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use platform? and platform_family? helpers to check a node's platform
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if platform?('ubuntu')
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This is another overly complex form of checking platforms that we can convert to use a platform? or platform_family? helpers.

Signed-off-by: Tim Smith <tsmith@chef.io>