### PR TITLE
Autocorrect 'apache v2' to 'Apache-2.0'

### DIFF
--- a/lib/rubocop/cop/chef/sharing/invalid_license_string.rb
+++ b/lib/rubocop/cop/chef/sharing/invalid_license_string.rb
@@ -439,6 +439,7 @@ module RuboCop
           COMMON_TYPOS = {
             "all_rights": 'all rights reserved',
             "apache 2.0": 'Apache-2.0',
+            "apache v2": 'Apache-2.0',
             "apache v2.0": 'Apache-2.0',
             "apache license version 2.0": 'Apache-2.0',
             "apache2": 'Apache-2.0',


### PR DESCRIPTION
Another one we should auto correct

Signed-off-by: Tim Smith <tsmith@chef.io>