### PR TITLE
Don't fail ChefDeprecations/WindowsTaskChangeAction with a non-string action

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
@@ -73,7 +73,9 @@ module RuboCop
           private
 
           def check_action(ast_obj)
-            add_offense(ast_obj, location: :expression, message: MSG, severity: :refactor) if ast_obj.value == :change
+            if ast_obj.respond_to?(:value) && ast_obj.value == :change
+              add_offense(ast_obj, location: :expression, message: MSG, severity: :refactor)
+            end
           end
         end
       end

--- a/spec/rubocop/cop/chef/deprecation/windows_task_change_action_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/windows_task_change_action_spec.rb
@@ -71,4 +71,15 @@ describe RuboCop::Cop::Chef::ChefDeprecations::WindowsTaskChangeAction, :config 
       end
     RUBY
   end
+
+  it "doesn't register an offense when windows_task uses a variable or method for the action" do
+    expect_no_offenses(<<~RUBY)
+      windows_task 'chef ad-join leave start time' do
+        task_name 'chef ad-join leave'
+        start_day '06/09/2016'
+        start_time '01:00'
+        action foo
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Make sure it responds to value before trying to access that.

Fixed #519 

Signed-off-by: Tim Smith <tsmith@chef.io>
