### PR TITLE
Fix IncludingYumDNFCompatRecipe to not break with inline conditionals

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe.rb
@@ -37,6 +37,7 @@ module RuboCop
 
           def on_send(node)
             yum_dnf_compat_recipe_usage?(node) do
+              node = node.parent if node.parent&.conditional? && node.parent&.single_line?
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
           end

--- a/spec/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe_spec.rb
@@ -21,8 +21,25 @@ describe RuboCop::Cop::Chef::ChefDeprecations::IncludingYumDNFCompatRecipe, :con
 
   it 'registers an offense when including the "yum::dnf_yum_compat" recipe' do
     expect_offense(<<~RUBY)
-      include_recipe 'yum::dnf_yum_compat'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not include the deprecated yum::dnf_yum_compat default recipe to install yum on dnf systems. Chef Infra Client now includes built in support for DNF packages.
+      if platform?('fedora')
+        log "on fedora"
+
+        include_recipe 'yum::dnf_yum_compat'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not include the deprecated yum::dnf_yum_compat default recipe to install yum on dnf systems. Chef Infra Client now includes built in support for DNF packages.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if platform?('fedora')
+        log "on fedora"
+      end
+    RUBY
+  end
+
+  it 'autocorrection removes any inline if statements gating the include_recipe' do
+    expect_offense(<<~RUBY)
+      include_recipe 'yum::dnf_yum_compat' if platform?('fedora')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not include the deprecated yum::dnf_yum_compat default recipe to install yum on dnf systems. Chef Infra Client now includes built in support for DNF packages.
     RUBY
 
     expect_correction("\n")


### PR DESCRIPTION
If there's an inline conditional nuke the conditional as well during the autocorrect. If the conditional isn't inline leave it behind. This prevents the autocorrect from resulting in invalid ruby.

Signed-off-by: Tim Smith <tsmith@chef.io>