### PR TITLE
Use node['init_package'] to detect systemd

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1115,7 +1115,6 @@ ChefModernize/SimplifyAptPpaSetup:
     - '**/attributes/*.rb'
     - '**/Berksfile'
 
-
 ChefModernize/UseRequireRelative:
   Description: Instead of using require with a File.expand_path and __FILE__ use the simpler require_relative method.
   Enabled: true
@@ -1123,6 +1122,14 @@ ChefModernize/UseRequireRelative:
   Exclude:
     - '**/metadata.rb'
     - '**/attributes/*.rb'
+    - '**/Berksfile'
+
+ChefModernize/NodeInitPackage:
+  Description: Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+  Enabled: true
+  VersionAdded: '5.22.0'
+  Exclude:
+    - '**/metadata.rb'
     - '**/Berksfile'
 
 ###############################

--- a/lib/rubocop/cop/chef/modernize/node_init_package.rb
+++ b/lib/rubocop/cop/chef/modernize/node_init_package.rb
@@ -1,0 +1,79 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefModernize
+        # Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+        #
+        # @example
+        #
+        #   # bad
+        #   ::File.open('/proc/1/comm').gets.chomp == 'systemd'
+        #   ::File.open('/proc/1/comm').chomp == 'systemd'
+        #   File.open('/proc/1/comm').gets.chomp == 'systemd'
+        #   File.open('/proc/1/comm').chomp == 'systemd'
+        #   File.exist?('/proc/1/comm') && File.open('/proc/1/comm').chomp == 'systemd'
+        #
+        #   IO.read('/proc/1/comm').chomp == 'systemd'
+        #   IO.read('/proc/1/comm').gets.chomp == 'systemd'
+        #   ::IO.read('/proc/1/comm').chomp == 'systemd'
+        #   ::IO.read('/proc/1/comm').gets.chomp == 'systemd'
+        #   File.exist?('/proc/1/comm') && File.open('/proc/1/comm').chomp == 'systemd'
+        #
+        #   # good
+        #   node['init_package'] == 'systemd'
+        #
+        class NodeInitPackage < Cop
+          MSG = "Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'".freeze
+
+          def_node_matcher :file_reads_proc_1_comm?, <<-PATTERN
+            (send (const {(cbase) nil?} {:File :IO}) {:open :read} (str "/proc/1/comm"))
+          PATTERN
+
+          def_node_matcher :proc_1_comm_exists?, <<-PATTERN
+            (send
+              (const
+                {(cbase) nil?} :File) :exist?
+              (str "/proc/1/comm"))
+          PATTERN
+
+          def_node_matcher :compare_init_system?, <<-PATTERN
+            (send
+              (send {#file_reads_proc_1_comm? (send #file_reads_proc_1_comm? :gets) } :chomp)
+                :== (str "systemd"))
+          PATTERN
+
+          def on_send(node)
+            compare_init_system?(node) do
+              # if there's a ::File.exist?('/proc/1/comm') check first we want to match that as well
+              node = node.parent if node.parent&.and_type? && proc_1_comm_exists?(node.parent.conditions.first)
+
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, "node['init_package'] == 'systemd'")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/node_init_package_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/node_init_package_spec.rb
@@ -1,0 +1,116 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefModernize::NodeInitPackage, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it "registers an offense with ::File.open('/proc/1/comm').gets.chomp" do
+    expect_offense(<<~RUBY)
+      ::File.open('/proc/1/comm').gets.chomp == 'systemd'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['init_package'] == 'systemd'
+    RUBY
+  end
+
+  it "registers an offense with File.open('/proc/1/comm').gets.chomp" do
+    expect_offense(<<~RUBY)
+      File.open('/proc/1/comm').gets.chomp == 'systemd'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['init_package'] == 'systemd'
+    RUBY
+  end
+
+  it "registers an offense with File.exist?('/proc/1/comm') && File.open('/proc/1/comm').chomp == 'systemd'" do
+    expect_offense(<<~RUBY)
+      File.exist?('/proc/1/comm') && File.open('/proc/1/comm').chomp == 'systemd'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['init_package'] == 'systemd'
+    RUBY
+  end
+
+  it "registers an offense with IO.read('/proc/1/comm').chomp == 'systemd'" do
+    expect_offense(<<~RUBY)
+      IO.read('/proc/1/comm').chomp == 'systemd'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['init_package'] == 'systemd'
+    RUBY
+  end
+
+  it "registers an offense with ::IO.read('/proc/1/comm').chomp == 'systemd'" do
+    expect_offense(<<~RUBY)
+      ::IO.read('/proc/1/comm').chomp == 'systemd'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['init_package'] == 'systemd'
+    RUBY
+  end
+
+  it "registers an offense with ::IO.read('/proc/1/comm').gets.chomp == 'systemd'" do
+    expect_offense(<<~RUBY)
+      ::IO.read('/proc/1/comm').gets.chomp == 'systemd'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['init_package'] == 'systemd'
+    RUBY
+  end
+
+  it "registers an offense with File.exist?('/proc/1/comm') && File.open('/proc/1/comm').chomp == 'systemd'" do
+    expect_offense(<<~RUBY)
+      File.exist?('/proc/1/comm') && File.open('/proc/1/comm').chomp == 'systemd'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['init_package'] == 'systemd'
+    RUBY
+  end
+
+  it "registers an offense with File.open('/proc/1/comm').chomp" do
+    expect_offense(<<~RUBY)
+      File.open('/proc/1/comm').chomp == 'systemd'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['init_package'] == 'systemd'
+    RUBY
+  end
+
+  it "does not register an offense when comparing a non-systemd value in '/proc/1/comm'" do
+    expect_no_offenses(<<~RUBY)
+      ::File.open('/proc/1/comm').gets.chomp == 'foo'
+    RUBY
+  end
+end


### PR DESCRIPTION
This reduces some crazy complex code that hasn't been necessary since
Chef 12.0.

Signed-off-by: Tim Smith <tsmith@chef.io>