### PR TITLE
Add ChefModernize/WindowsRegistryUAC cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1141,6 +1141,15 @@ ChefModernize/NodeInitPackage:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefModernize/WindowsRegistryUAC:
+  Description: Chef Infra Client 15.0 and later includes a windows_uac resource that should be used to set Windows UAC values instead of setting registry keys directly.
+  Enabled: true
+  VersionAdded: '5.22.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefRedundantCode: Cleanup unnecessary code in your cookbooks regardless of Chef Infra Client release
 ###############################

--- a/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
@@ -1,0 +1,71 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefModernize
+        # Chef Infra Client 15.0 and later includes a windows_uac resource that should be used to set Windows UAC values instead of setting registry keys directly.
+        #
+        #   # bad
+        #   registry_key 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' do
+        #     values [{ name: 'EnableLUA', type: :dword, data: 0 },
+        #             { name: 'PromptOnSecureDesktop', type: :dword, data: 0 },
+        #             { name: 'ConsentPromptBehaviorAdmin', type: :dword, data: 0 },
+        #            ]
+        #     action :create
+        #   end
+        #
+        #  # good
+        #  windows_uac 'Set Windows UAC settings' do
+        #    enable_uac false
+        #    prompt_on_secure_desktop true
+        #    consent_behavior_admins :no_prompt
+        #  end
+        #
+        class WindowsRegistryUAC < Cop
+          include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version '15.0'
+
+          MSG = 'Chef Infra Client 15.0 and later includes a windows_uac resource that should be used to set Windows UAC values instead of setting registry keys directly.'.freeze
+
+          # non block execute resources
+          def on_send(node)
+            return unless node.method_name == :registry_key
+
+            # use source instead of .value in case there's string interpolation which adds a complex dstr type
+            # with a nested string and a begin. Source allows us to avoid a lot of defensive programming here
+            if node&.arguments.first&.source.match?(/HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/i)
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          # block execute resources
+          def on_block(node)
+            match_property_in_resource?(:registry_key, 'key', node) do |key_prop|
+              property_data = method_arg_ast_to_string(key_prop)
+              if property_data && property_data.match?(/HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/i)
+                add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/windows_registry_uac_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/windows_registry_uac_spec.rb
@@ -1,0 +1,65 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefModernize::WindowsRegistryUAC, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a sets UAC config via registry_key' do
+    expect_offense(<<~RUBY)
+      registry_key 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 15.0 and later includes a windows_uac resource that should be used to set Windows UAC values instead of setting registry keys directly.
+        values [{ name: 'EnableLUA', type: :dword, data: 0 }]
+        action :create
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a sets UAC config via registry_key using the key property' do
+    expect_offense(<<~RUBY)
+      registry_key 'Set UAC values' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 15.0 and later includes a windows_uac resource that should be used to set Windows UAC values instead of setting registry keys directly.
+        key 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System'
+        values [{ name: 'EnableLUA', type: :dword, data: 0 }]
+        action :create
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a sets UAC config via registry_key using a lowercase key' do
+    expect_offense(<<~RUBY)
+      registry_key 'hkey_local_machine\\software\\microsoft\\windows\\currentversion\\policies\\system' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 15.0 and later includes a windows_uac resource that should be used to set Windows UAC values instead of setting registry keys directly.
+        values [{ name: 'EnableLUA', type: :dword, data: 0 }]
+        action :create
+      end
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 14' do
+    let(:config) { target_chef_version(14) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        registry_key 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System' do
+          values [{ name: 'EnableLUA', type: :dword, data: 0 }]
+          action :create
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Detect when someone should use the windows_uac resource instead of manually setting registry values.

Signed-off-by: Tim Smith <tsmith@chef.io>