### PR TITLE
Disable Naming/MethodName and Naming/VariableName

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1507,8 +1507,6 @@ Style/MethodCallParentheses:
   Enabled: true
 Style/MethodDefParentheses:
   Enabled: true
-Naming/MethodName:
-  Enabled: true
 Style/MultilineBlockChain:
   Enabled: true
 Layout/MultilineBlockLayout:
@@ -1658,8 +1656,6 @@ Style/UnneededPercentQ:
 Style/TrailingUnderscoreVariable:
   Enabled: true
 Style/VariableInterpolation:
-  Enabled: true
-Naming/VariableName:
   Enabled: true
 Style/WhenThen:
   Enabled: true

--- a/lib/rubocop/chef/cookbook_only.rb
+++ b/lib/rubocop/chef/cookbook_only.rb
@@ -63,7 +63,7 @@ module RuboCop
       extend ClassMethods
     end
 
-    def self.CookbookOnly(segments) # rubocop: disable Naming/MethodName
+    def self.CookbookOnly(segments)
       Module.new do |mod|
         mod.define_singleton_method(:included) do |klass|
           super(klass)


### PR DESCRIPTION
Neither of these impact how Chef Infra operates and neither can be autocorrected. These alerts require significant cookbook refactor time with little benefit. We have discussed turning this off in the chef-infra slack channel.

Signed-off-by: Tim Smith <tsmith@chef.io>