### PR TITLE
Disable the Naming/PredicateName

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1553,8 +1553,6 @@ Style/PercentQLiterals:
   Enabled: true
 Style/PerlBackrefs:
   Enabled: true
-Naming/PredicateName:
-  Enabled: true
 Style/Proc:
   Enabled: true
 Style/RaiseArgs:


### PR DESCRIPTION
Can't be autocorrected
Doesn't result in a huge amount of value when changed

Signed-off-by: Tim Smith <tsmith@chef.io>