### PR TITLE
Add autocorrection to ChefCorrectness/DnfPackageAllowDowngrades

### DIFF
--- a/lib/rubocop/cop/chef/correctness/dnf_package_allow_downgrades.rb
+++ b/lib/rubocop/cop/chef/correctness/dnf_package_allow_downgrades.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2019, Chef Software Inc.
+# Copyright:: Copyright 2019-2020, Chef Software Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +34,7 @@ module RuboCop
         #   end
         #
         class DnfPackageAllowDowngrades < Cop
+          include RangeHelp
           include RuboCop::Chef::CookbookHelpers
 
           MSG = 'dnf_package does not support the allow_downgrades property'.freeze
@@ -41,6 +42,12 @@ module RuboCop
           def on_block(node)
             match_property_in_resource?(:dnf_package, :allow_downgrades, node) do |prop|
               add_offense(prop, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end
         end

--- a/spec/rubocop/cop/chef/correctness/dnf_package_allow_downgrades_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/dnf_package_allow_downgrades_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2019, Chef Software Inc.
+# Copyright:: Copyright 2019-2020, Chef Software Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,12 @@ describe RuboCop::Cop::Chef::ChefCorrectness::DnfPackageAllowDowngrades do
         version '1.2.3'
         allow_downgrades true
         ^^^^^^^^^^^^^^^^^^^^^ dnf_package does not support the allow_downgrades property
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      dnf_package 'nginx' do
+        version '1.2.3'
       end
     RUBY
   end


### PR DESCRIPTION
The solution here is just to remove the property.

Signed-off-by: Tim Smith <tsmith@chef.io>