### PR TITLE
Enable ChefStyle/UnnecessaryOSCheck

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -129,7 +129,7 @@ ChefStyle/ChefWhaaat:
 
 ChefStyle/UnnecessaryOSCheck:
   Description: Use the platform_family?() helpers instead of node['os] == 'foo' for platform_families that match 1:1 with OS values. These helpers are easier to read and can accept multiple platform arguments, which greatly simplifies complex platform logic.
-  Enabled: false
+  Enabled: true
   VersionAdded: '5.21.0'
 
 ###############################


### PR DESCRIPTION
This was a copy/paste error when adding this cop. It should be enabled
by default.

Signed-off-by: Tim Smith <tsmith@chef.io>