### PR TITLE
Detect the short form the of registry key in ChefModernize/WindowsRegistryUAC

### DIFF
--- a/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
@@ -50,7 +50,7 @@ module RuboCop
 
             # use source instead of .value in case there's string interpolation which adds a complex dstr type
             # with a nested string and a begin. Source allows us to avoid a lot of defensive programming here
-            if node&.arguments.first&.source.match?(/(HKLM|HKEY_LOCAL_MACHINE)\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/i)
+            if node&.arguments.first&.source.match?(/(HKLM|HKEY_LOCAL_MACHINE)\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/i) && node.parent&.method_name != :describe
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
           end

--- a/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
@@ -50,7 +50,7 @@ module RuboCop
 
             # use source instead of .value in case there's string interpolation which adds a complex dstr type
             # with a nested string and a begin. Source allows us to avoid a lot of defensive programming here
-            if node&.arguments.first&.source.match?(/HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/i)
+            if node&.arguments.first&.source.match?(/(HKLM|HKEY_LOCAL_MACHINE)\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/i)
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
           end
@@ -59,7 +59,7 @@ module RuboCop
           def on_block(node)
             match_property_in_resource?(:registry_key, 'key', node) do |key_prop|
               property_data = method_arg_ast_to_string(key_prop)
-              if property_data && property_data.match?(/HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/i)
+              if property_data && property_data.match?(/(HKLM|HKEY_LOCAL_MACHINE)\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/i)
                 add_offense(node, location: :expression, message: MSG, severity: :refactor)
               end
             end

--- a/spec/rubocop/cop/chef/modernize/windows_registry_uac_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/windows_registry_uac_spec.rb
@@ -1,5 +1,6 @@
 #
 # Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +30,16 @@ describe RuboCop::Cop::Chef::ChefModernize::WindowsRegistryUAC, :config do
     RUBY
   end
 
+  it 'registers an offense when a sets UAC config via the shortened form of the key' do
+    expect_offense(<<~RUBY)
+      registry_key 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 15.0 and later includes a windows_uac resource that should be used to set Windows UAC values instead of setting registry keys directly.
+        values [{ name: 'EnableLUA', type: :dword, data: 0 }]
+        action :create
+      end
+    RUBY
+  end
+
   it 'registers an offense when a sets UAC config via registry_key using the key property' do
     expect_offense(<<~RUBY)
       registry_key 'Set UAC values' do
@@ -44,6 +55,16 @@ describe RuboCop::Cop::Chef::ChefModernize::WindowsRegistryUAC, :config do
     expect_offense(<<~RUBY)
       registry_key 'hkey_local_machine\\software\\microsoft\\windows\\currentversion\\policies\\system' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 15.0 and later includes a windows_uac resource that should be used to set Windows UAC values instead of setting registry keys directly.
+        values [{ name: 'EnableLUA', type: :dword, data: 0 }]
+        action :create
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a sets UAC config via registry_key using a shortened key' do
+    expect_offense(<<~RUBY)
+      registry_key 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 15.0 and later includes a windows_uac resource that should be used to set Windows UAC values instead of setting registry keys directly.
         values [{ name: 'EnableLUA', type: :dword, data: 0 }]
         action :create
       end

--- a/spec/rubocop/cop/chef/modernize/windows_registry_uac_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/windows_registry_uac_spec.rb
@@ -71,6 +71,19 @@ describe RuboCop::Cop::Chef::ChefModernize::WindowsRegistryUAC, :config do
     RUBY
   end
 
+  it 'does not register on registry_key within an inspec control' do
+    expect_no_offenses(<<~RUBY)
+      control 'windows-cis-2.3.17.8' do
+        impact 1.0
+        title "2.3.17.8 Ensure 'User Account Control: Switch to the secure desktop when prompting for elevation' is set to 'Enabled'"
+        desc "Ensure 'User Account Control: Switch to the secure desktop when prompting for elevation' is set to 'Enabled'"
+        describe registry_key('HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System') do
+          its('PromptOnSecureDesktop') { should eq 1 }
+        end
+      end
+    RUBY
+  end
+
   context 'with TargetChefVersion set to 14' do
     let(:config) { target_chef_version(14) }
 


### PR DESCRIPTION
It can be HKLM which is pretty common.

Signed-off-by: Tim Smith <tsmith@chef.io>