### PR TITLE
Add ChefCorrectness/PowershellScriptDeleteFile

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -332,6 +332,15 @@ ChefCorrectness/ChefApplicationFatal:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefCorrectness/PowershellScriptDeleteFile:
+  Description: Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of using Remove-Item in a powershell_script resource
+  Enabled: true
+  VersionAdded: '6.0.0'
+  Exclude:
+    - '**/attributes/*.rb'
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefSharing: Issues that prevent sharing code with other teams or with the Chef community in general
 ###############################

--- a/lib/rubocop/cop/chef/correctness/powershell_delete_file.rb
+++ b/lib/rubocop/cop/chef/correctness/powershell_delete_file.rb
@@ -1,0 +1,53 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of using Remove-Item in a powershell_script resource
+        #
+        # @example
+        #
+        #   # bad
+        #   powershell_script 'Cleanup old files' do
+        #     code 'Remove-Item C:\Windows\foo\bar.txt'
+        #     only_if { ::File.exist?('C:\\Windows\\foo\\bar.txt') }
+        #   end
+        #
+        #  # good
+        #  file 'C:\Windows\foo\bar.txt' do
+        #    action :delete
+        #  end
+        #
+        class PowershellScriptDeleteFile < Cop
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of using Remove-Item in a powershell_script resource'.freeze
+
+          def on_block(node)
+            match_property_in_resource?(:powershell_script, 'code', node) do |code_property|
+              property_data = method_arg_ast_to_string(code_property)
+              if property_data && property_data.match?(/^remove-item/i) && !property_data.include?('*')
+                add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/powershell_delete_file_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/powershell_delete_file_spec.rb
@@ -1,0 +1,43 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::PowershellScriptDeleteFile, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when when using powershell_script to run Remove-File' do
+    expect_offense(<<~RUBY)
+      powershell_script 'Cleanup_Old_Install_File' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of using Remove-Item in a powershell_script resource
+        code 'Remove-Item C:\Windows\foo\installed.txt'
+        action :nothing
+        only_if { ::File.exist?('C:\\Windows\\foo\\installed.txt') }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using powershell_script to run Remove-File with a splat operator' do
+    expect_no_offenses(<<~RUBY)
+      powershell_script 'Cleanup_Old_Install_File' do
+        code 'Remove-Item C:\Windows\foo\installed*.txt'
+        action :nothing
+        only_if { ::File.exist?('C:\\Windows\\foo\\installed.txt') }
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Use file/directory resources to remove files and directories not a
powershell_script. It's slow and not idempotent unless you add your own
conditional.

Signed-off-by: Tim Smith <tsmith@chef.io>