### PR TITLE
Add ChefModernize/DatabagHelpers

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1185,6 +1185,14 @@ ChefModernize/ProvidesFromInitialize:
     - '**/providers/*.rb'
     - '**/libraries/*.rb'
 
+ChefModernize/DatabagHelpers:
+  Description: Use the `data_bag_item` helper instead of `Chef::DataBagItem.load` or `Chef::EncryptedDataBagItem.load`.
+  Enabled: true
+  VersionAdded: '6.0.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefRedundantCode: Cleanup unnecessary code in your cookbooks regardless of Chef Infra Client release
 ###############################

--- a/lib/rubocop/cop/chef/modernize/databag_helpers.rb
+++ b/lib/rubocop/cop/chef/modernize/databag_helpers.rb
@@ -1,0 +1,58 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefModernize
+        # Use the `data_bag_item` helper instead of `Chef::DataBagItem.load` or `Chef::EncryptedDataBagItem.load`.
+        #
+        # @example
+        #
+        #   # bad
+        #   plain_text_data = Chef::DataBagItem.load('foo', 'bar')
+        #   encrypted_data = Chef::EncryptedDataBagItem.load('foo2', 'bar2')
+        #
+        #   # good
+        #   plain_text_data = data_bag_item('foo', 'bar')
+        #   encrypted_data = data_bag_item('foo2', 'bar2')
+        #
+        class DatabagHelpers < Cop
+          MSG = 'Use the `data_bag_item` helper instead of `Chef::DataBagItem.load` or `Chef::EncryptedDataBagItem.load`.'.freeze
+
+          def_node_matcher :data_bag_class_load?, <<-PATTERN
+          (send
+            (const
+              (const nil? :Chef) {:DataBagItem :EncryptedDataBagItem}) :load
+              ...)
+          PATTERN
+
+          def on_send(node)
+            data_bag_class_load?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, node.source.gsub(/Chef::(EncryptedDataBagItem|DataBagItem).load/, 'data_bag_item'))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/databag_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/databag_helpers_spec.rb
@@ -1,0 +1,44 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefModernize::DatabagHelpers, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using Chef::DataBagItem.load' do
+    expect_offense(<<~RUBY)
+      Chef::DataBagItem.load('foo', 'bar')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `data_bag_item` helper instead of `Chef::DataBagItem.load` or `Chef::EncryptedDataBagItem.load`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      data_bag_item('foo', 'bar')
+    RUBY
+  end
+
+  it 'registers an offense when using Chef::EncryptedDataBagItem.load' do
+    expect_offense(<<~RUBY)
+      Chef::EncryptedDataBagItem.load('foo', 'bar')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `data_bag_item` helper instead of `Chef::DataBagItem.load` or `Chef::EncryptedDataBagItem.load`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      data_bag_item('foo', 'bar')
+    RUBY
+  end
+end


### PR DESCRIPTION
This is an old Foodcritic rule that didn't make it over to Cookstyle. Super easy to autocorrect and simplifies codebases a lot.

Signed-off-by: Tim Smith <tsmith@chef.io>