### PR TITLE
Allow arrays in match_property_in_resource and fix powershell interp cop

### DIFF
--- a/lib/rubocop/chef/cookbook_helpers.rb
+++ b/lib/rubocop/chef/cookbook_helpers.rb
@@ -39,16 +39,16 @@ module RuboCop
 
       # Match particular properties within a resource
       #
-      # @param [String] resource_name The name of the resource to match
+      # @param [Symbol, Array<Symbol>] resource_names The name of the resources to match
       # @param [String] property_names The name of the property to match (or action)
       # @param [RuboCop::AST::Node] node The rubocop ast node to search
       #
       # @yield
       #
-      def match_property_in_resource?(resource_name, property_names, node)
+      def match_property_in_resource?(resource_names, property_names, node)
         return unless looks_like_resource?(node)
         # bail out if we're not in the resource we care about or nil was passed (all resources)
-        return unless resource_name.nil? || node.children.first.method?(resource_name.to_sym) # see if we're in the right resource
+        return unless resource_names.nil? || Array(resource_names).include?(node.children.first.method_name) # see if we're in the right resource
 
         resource_block = node.children[2] # the 3rd child is the actual block in the resource
         return unless resource_block # nil would be an empty block

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2019-2020, Chef Software, Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ module RuboCop
           MSG = 'Use the type property instead of the deprecated supports property in the chef_handler resource. The supports property was removed in chef_handler cookbook version 3.0 (June 2017) and Chef Infra Client 14.0.'.freeze
 
           def on_block(node)
-            match_property_in_resource?('chef_handler', 'supports', node) do |prop_node|
+            match_property_in_resource?(:chef_handler, 'supports', node) do |prop_node|
               add_offense(prop_node, location: :expression, message: MSG, severity: :refactor)
             end
           end

--- a/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
@@ -18,19 +18,28 @@ module RuboCop
   module Cop
     module Chef
       module ChefModernize
-        # PowerShell is already set as the default guard interpreter for resources in Chef Infra Client 13 and later and does not need to be specified.
+        # PowerShell is already set as the default guard interpreter for `powershell_script` and `batch` resources in Chef Infra Client 13 and later and does not need to be specified.
         #
         # @example
         #
         #   # bad
-        #   powershell_script 'whatever' do
-        #     code "mkdir test_dir"
+        #   powershell_script 'Create Directory' do
+        #     code "New-Item -ItemType Directory -Force -Path C:\mydir"
+        #     guard_interpreter :powershell_script
+        #   end
+        #
+        #   batch 'Create Directory' do
+        #     code "mkdir C:\mydir"
         #     guard_interpreter :powershell_script
         #   end
         #
         #   # good
-        #   powershell_script 'whatever' do
-        #     code "mkdir test_dir"
+        #   powershell_script 'Create Directory' do
+        #     code "New-Item -ItemType Directory -Force -Path C:\mydir"
+        #   end
+        #
+        #   batch 'Create Directory' do
+        #     code "mkdir C:\mydir"
         #   end
         #
         class PowerShellGuardInterpreter < Cop
@@ -40,10 +49,10 @@ module RuboCop
 
           minimum_target_chef_version '13.0'
 
-          MSG = 'PowerShell is already set as the default guard interpreter for powershell_script resources in Chef Infra Client 13 and later and does not need to be specified.'.freeze
+          MSG = 'PowerShell is already set as the default guard interpreter for `powershell_script` and `batch` resources in Chef Infra Client 13 and later and does not need to be specified.'.freeze
 
           def on_block(node)
-            match_property_in_resource?(nil, 'guard_interpreter', node) do |interpreter|
+            match_property_in_resource?(%i(powershell_script batch), 'guard_interpreter', node) do |interpreter|
               if interpreter.arguments.first.source == ':powershell_script'
                 add_offense(interpreter, location: :expression, message: MSG, severity: :refactor)
               end

--- a/lib/rubocop/cop/chef/redundant/apt_repository_distribution_default.rb
+++ b/lib/rubocop/cop/chef/redundant/apt_repository_distribution_default.rb
@@ -47,7 +47,6 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(:apt_repository, 'distribution', node) do |dist|
-              ## require 'pry'; binding.pry
               default_dist?(dist) do
                 add_offense(dist, location: :expression, message: MSG, severity: :refactor)
               end

--- a/spec/rubocop/chef/cookbook_helpers_spec.rb
+++ b/spec/rubocop/chef/cookbook_helpers_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
       it "should yield a single 'running' property ast objects" do
         expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
       end
+
+      it "should yield a single 'running' property ast objects when passed an array" do
+        expect { |b| match_property_in_resource?(%i(service file), 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
+      end
     end
 
     describe 'multiple properties in a resource' do

--- a/spec/rubocop/cop/chef/modernize/powershell_guard_interpreter_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/powershell_guard_interpreter_spec.rb
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Chef::ChefModernize::PowerShellGuardInterpreter, :config 
     powershell_script 'whatever' do
       code "mkdir test_dir"
       guard_interpreter :powershell_script
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PowerShell is already set as the default guard interpreter for powershell_script resources in Chef Infra Client 13 and later and does not need to be specified.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PowerShell is already set as the default guard interpreter for `powershell_script` and `batch` resources in Chef Infra Client 13 and later and does not need to be specified.
     end
     RUBY
 
@@ -35,11 +35,29 @@ describe RuboCop::Cop::Chef::ChefModernize::PowerShellGuardInterpreter, :config 
     RUBY
   end
 
+  it 'registers an offense when using the guard_interpreter is set to :powershell_script in a batch resource' do
+    expect_offense(<<~RUBY)
+    batch 'whatever' do
+      code "mkdir test_dir"
+      guard_interpreter :powershell_script
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PowerShell is already set as the default guard interpreter for `powershell_script` and `batch` resources in Chef Infra Client 13 and later and does not need to be specified.
+    end
+    RUBY
+  end
+
   it "doesn't register an offense when the guard_interpreter is set to something else in powershell_script" do
     expect_no_offenses(<<~RUBY)
     powershell_script 'whatever' do
       code "mkdir test_dir"
       guard_interpreter :foo
+    end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard_interpreter is set to PowerShell on another resource" do
+    expect_no_offenses(<<~RUBY)
+    execute 'mkdir testdir' do
+      guard_interpreter :powershell_script
     end
     RUBY
   end


### PR DESCRIPTION
This fixes the ChefModernize/PowerShellGuardInterpreter cop to detect
the powershell interp being set in powershell_script and batch
resources. Originally we did just powershell_script and then I
incorrectly opened it up all the way (never released). After some
digging it looks like only these 2 resources should have this
removed. That required updates to the helper so we could pass in Arrays
of resource types.

Signed-off-by: Tim Smith <tsmith@chef.io>