### PR TITLE
Add ChefDeprecations/ChefWindowsPlatformHelper cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -751,6 +751,14 @@ ChefDeprecations/DeprecatedWindowsVersionCheck:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefDeprecations/ChefWindowsPlatformHelper:
+  Description: Use `platform?('windows')` instead of the legacy `Chef::Platform.windows?` helper.
+  Enabled: true
+  VersionAdded: '6.0.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
@@ -1,0 +1,56 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Use `platform?('windows')` instead of the legacy `Chef::Platform.windows?` helper
+        #
+        # @example
+        #
+        #   # bad
+        #   Chef::Platform.windows?
+        #
+        #   # good
+        #   platform?('windows')
+        #   platform_family?('windows')
+        #
+        class ChefWindowsPlatformHelper < Cop
+          MSG = "Use `platform?('windows')` instead of the legacy `Chef::Platform.windows?` helper.".freeze
+
+          def_node_matcher :chef_platform_windows?, <<-PATTERN
+            (send
+              (const
+                (const nil? :Chef) :Platform) :windows?)
+          PATTERN
+
+          def on_send(node)
+            chef_platform_windows?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, "platform?('windows')")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/chef_windows_platform_helper_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_windows_platform_helper_spec.rb
@@ -1,0 +1,34 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::ChefWindowsPlatformHelper, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a using Chef::Platform.windows?' do
+    expect_offense(<<~RUBY)
+      Chef::Platform.windows?
+      ^^^^^^^^^^^^^^^^^^^^^^^ Use `platform?('windows')` instead of the legacy `Chef::Platform.windows?` helper.
+    RUBY
+
+    expect_correction("platform?('windows')\n")
+  end
+
+  it "doesn't register an offense when calling other Chef::Platform helpers" do
+    expect_no_offenses('Chef::Platform.foo?')
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/chef_windows_platform_helper_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_windows_platform_helper_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ChefDeprecations::ChefWindowsPlatformHelper, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when a using Chef::Platform.windows?' do
+  it 'registers an offense when using Chef::Platform.windows?' do
     expect_offense(<<~RUBY)
       Chef::Platform.windows?
       ^^^^^^^^^^^^^^^^^^^^^^^ Use `platform?('windows')` instead of the legacy `Chef::Platform.windows?` helper.


### PR DESCRIPTION
This gets us off this old windows helper and onto platform? which we can
update to be just windows? sometime later down the line.

Signed-off-by: Tim Smith <tsmith@chef.io>