### PR TITLE
Update the severity for all deprecation cops to be :warning

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
@@ -40,7 +40,7 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(:chef_handler, 'supports', node) do |prop_node|
-              add_offense(prop_node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(prop_node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/chef_rest.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rest.rb
@@ -40,13 +40,13 @@ module RuboCop
 
           def on_send(node)
             require_rest?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 
           def on_const(node)
             rest_const?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
@@ -62,21 +62,21 @@ module RuboCop
 
           def on_send(node)
             rewind_gem_install?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
 
             require_rewind?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
 
             rewind_resources?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 
           def on_block(node)
             match_property_in_resource?(:chef_gem, 'package_name', node) do |pkg_name|
-              add_offense(node, location: :expression, message: MSG, severity: :refactor) if pkg_name.arguments&.first&.str_content == 'chef-rewind'
+              add_offense(node, location: :expression, message: MSG, severity: :warning) if pkg_name.arguments&.first&.str_content == 'chef-rewind'
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
@@ -40,7 +40,7 @@ module RuboCop
 
           def on_send(node)
             chef_platform_windows?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/cheffile.rb
+++ b/lib/rubocop/cop/chef/deprecation/cheffile.rb
@@ -32,7 +32,7 @@ module RuboCop
             # Using range similar to RuboCop::Cop::Naming::Filename (file_name.rb)
             range = source_range(processed_source.buffer, 1, 0)
 
-            add_offense(nil, location: range, message: MSG, severity: :refactor)
+            add_offense(nil, location: range, message: MSG, severity: :warning)
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
@@ -36,7 +36,7 @@ module RuboCop
 
           def on_block(node)
             coverage_reporter?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
@@ -48,7 +48,7 @@ module RuboCop
 
           def on_const(node)
             chefspec_runner?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action.rb
@@ -41,7 +41,7 @@ module RuboCop
           def on_block(node)
             match_property_in_resource?(:chocolatey_package, 'action', node) do |choco_action|
               choco_action.arguments.each do |action|
-                add_offense(action, location: :expression, message: MSG, severity: :refactor) if action.source == ':uninstall'
+                add_offense(action, location: :expression, message: MSG, severity: :warning) if action.source == ':uninstall'
               end
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
@@ -39,7 +39,7 @@ module RuboCop
 
           def on_send(node)
             depends_compat_resource?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
@@ -34,7 +34,7 @@ module RuboCop
 
           def on_send(node)
             depends_partial_search?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/depends_poise.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_poise.rb
@@ -35,7 +35,7 @@ module RuboCop
 
           def on_send(node)
             depends_method?(node) do |arg|
-              add_offense(node, location: :expression, message: MSG, severity: :refactor) if %w(poise poise-service).include?(arg.value)
+              add_offense(node, location: :expression, message: MSG, severity: :warning) if %w(poise poise-service).include?(arg.value)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_chefspec_platform.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_chefspec_platform.rb
@@ -108,7 +108,7 @@ module RuboCop
 
           def on_send(node)
             chefspec_definition?(node) do |plat, ver|
-              add_offense(node, location: :expression, message: MSG, severity: :refactor) if legacy_chefspec_platform(plat.value, ver.value)
+              add_offense(node, location: :expression, message: MSG, severity: :warning) if legacy_chefspec_platform(plat.value, ver.value)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
@@ -52,15 +52,15 @@ module RuboCop
 
           def on_send(node)
             deprecated_mixin?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
 
             deprecated_dsl?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
 
             dsl_mixin_require?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/deprecated_platform_methods.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_platform_methods.rb
@@ -46,7 +46,7 @@ module RuboCop
 
           def on_send(node)
             platform_method?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_windows_version_check.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_windows_version_check.rb
@@ -31,7 +31,7 @@ module RuboCop
           MSG = "Don't use the deprecated older_than_win_2012_or_8? helper. Windows versions before 2012 and 8 are now end of life and this helper will always return false.".freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :older_than_win_2012_or_8?
+            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :older_than_win_2012_or_8?
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_properties.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_properties.rb
@@ -48,7 +48,7 @@ module RuboCop
           def on_block(node)
             %w(url keyurl mirrorexpire).each do |prop|
               match_property_in_resource?(:yum_repository, prop, node) do |prop_node|
-                add_offense(prop_node, location: :expression, message: MSG, severity: :refactor)
+                add_offense(prop_node, location: :expression, message: MSG, severity: :warning)
               end
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/easy_install.rb
+++ b/lib/rubocop/cop/chef/deprecation/easy_install.rb
@@ -32,7 +32,7 @@ module RuboCop
           MSG = "Don't use the deprecated easy_install resource removed in Chef 13".freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :easy_install
+            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :easy_install
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/eol_audit_mode.rb
+++ b/lib/rubocop/cop/chef/deprecation/eol_audit_mode.rb
@@ -38,7 +38,7 @@ module RuboCop
 
           def on_send(node)
             control_group?(node) do
-              add_offense(node, location: :selector, message: MSG, severity: :refactor)
+              add_offense(node, location: :selector, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/epic_fail.rb
+++ b/lib/rubocop/cop/chef/deprecation/epic_fail.rb
@@ -37,7 +37,7 @@ module RuboCop
           MSG = 'Use ignore_failure method instead of the deprecated epic_fail method'.freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :epic_fail
+            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :epic_fail
           end
 
           def autocorrect(node)

--- a/lib/rubocop/cop/chef/deprecation/erl_call.rb
+++ b/lib/rubocop/cop/chef/deprecation/erl_call.rb
@@ -32,7 +32,7 @@ module RuboCop
           MSG = "Don't use the deprecated erl_call resource removed in Chef 13".freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :erl_call
+            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :erl_call
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
@@ -45,7 +45,7 @@ module RuboCop
 
           def on_class(node)
             inherits_from_compat_resource?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/launchd_deprecated_hash_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/launchd_deprecated_hash_property.rb
@@ -39,7 +39,7 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(:launchd, 'hash', node) do |hash_prop|
-              add_offense(hash_prop, location: :expression, message: MSG, severity: :refactor)
+              add_offense(hash_prop, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -65,7 +65,7 @@ module RuboCop
 
           def on_send(node)
             legacy_notify?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
@@ -41,7 +41,7 @@ module RuboCop
 
           def on_send(node)
             old_yum_recipe?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/locale_lc_all_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/locale_lc_all_property.rb
@@ -35,7 +35,7 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(:locale, 'lc_all', node) do |property|
-              add_offense(property, location: :expression, message: MSG, severity: :refactor)
+              add_offense(property, location: :expression, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/log_resource_notifications.rb
+++ b/lib/rubocop/cop/chef/deprecation/log_resource_notifications.rb
@@ -50,7 +50,7 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(:log, 'notifies', node) do |prop_node|
-              add_offense(prop_node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(prop_node, location: :expression, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
+++ b/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
@@ -44,7 +44,7 @@ module RuboCop
 
           def on_send(node)
             name_property_with_default?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/node_deep_fetch.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_deep_fetch.rb
@@ -48,11 +48,11 @@ module RuboCop
 
           def on_send(node)
             node_deep_fetch?(node) do
-              add_offense(node, location: :selector, message: MSG, severity: :refactor)
+              add_offense(node, location: :selector, message: MSG, severity: :warning)
             end
 
             node_deep_fetch_bang?(node) do
-              add_offense(node, location: :selector, message: MSG2, severity: :refactor)
+              add_offense(node, location: :selector, message: MSG2, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
@@ -45,7 +45,7 @@ module RuboCop
 
           def on_send(node)
             node_ohai_methods?(node) do
-              add_offense(node, location: :selector, message: MSG, severity: :refactor)
+              add_offense(node, location: :selector, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/node_set.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set.rb
@@ -39,7 +39,7 @@ module RuboCop
 
           def on_send(node)
             node_set?(node) do
-              add_offense(node, location: :selector, message: MSG, severity: :refactor)
+              add_offense(node, location: :selector, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
@@ -39,7 +39,7 @@ module RuboCop
 
           def on_send(node)
             node_set_unless?(node) do
-              add_offense(node, location: :selector, message: MSG, severity: :refactor)
+              add_offense(node, location: :selector, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/node_set_without_level.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set_without_level.rb
@@ -54,9 +54,9 @@ module RuboCop
 
           def add_offense_for_bare_assignment(sub_node)
             if sub_node.receiver == s(:send, nil, :node) # node['foo'] scenario
-              add_offense(sub_node.receiver, location: :selector, message: MSG, severity: :refactor)
+              add_offense(sub_node.receiver, location: :selector, message: MSG, severity: :warning)
             elsif sub_node.receiver && sub_node.receiver&.node_parts[0] == s(:send, nil, :node) && sub_node.receiver&.node_parts[1] == :[] # node['foo']['bar'] scenario
-              add_offense(sub_node.receiver.node_parts.first, location: :selector, message: MSG, severity: :refactor)
+              add_offense(sub_node.receiver.node_parts.first, location: :selector, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/partial_search_class_usage.rb
+++ b/lib/rubocop/cop/chef/deprecation/partial_search_class_usage.rb
@@ -55,7 +55,7 @@ module RuboCop
 
           def on_send(node)
             partial_search_class?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/partial_search_helper_usage.rb
+++ b/lib/rubocop/cop/chef/deprecation/partial_search_helper_usage.rb
@@ -50,7 +50,7 @@ module RuboCop
           MSG = 'Legacy partial_search usage should be updated to use :filter_result in the search helper instead'.freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :partial_search
+            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :partial_search
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/poise_archive.rb
+++ b/lib/rubocop/cop/chef/deprecation/poise_archive.rb
@@ -43,13 +43,13 @@ module RuboCop
 
           def on_send(node)
             depends_poise_archive?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 
           def on_block(node)
             match_resource_type?(:poise_archive, node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/require_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/require_recipe.rb
@@ -37,7 +37,7 @@ module RuboCop
           PATTERN
 
           def on_send(node)
-            require_recipe?(node) { add_offense(node, location: :selector, message: MSG, severity: :refactor) }
+            require_recipe?(node) { add_offense(node, location: :selector, message: MSG, severity: :warning) }
           end
 
           def autocorrect(node)

--- a/lib/rubocop/cop/chef/deprecation/resource_overrides_provides_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_overrides_provides_method.rb
@@ -37,7 +37,7 @@ module RuboCop
 
           def on_def(node)
             if node.method_name == :provides?
-              add_offense(node, location: :expression, message: MSG, severity: :refactor) if provides(processed_source.ast).count == 0
+              add_offense(node, location: :expression, message: MSG, severity: :warning) if provides(processed_source.ast).count == 0
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_dsl_name_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_dsl_name_method.rb
@@ -32,7 +32,7 @@ module RuboCop
           MSG = 'Use resource_name instead of the dsl_name method in resources. This will cause failures in Chef Infra Client 13 and later.'.freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :dsl_name
+            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :dsl_name
           end
 
           # potential autocorrect is new_resource.updated_by_last_action true, but we need to actually see what class we were called from

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_provider_base_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_provider_base_method.rb
@@ -29,7 +29,7 @@ module RuboCop
           MSG = "Don't use the deprecated provider_base method in a resource to specify the provider module to use. Instead, the provider should call provides to register itself, or the resource should call provider to specify the provider to use. This will cause failures in Chef Infra Client 13 and later.".freeze
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :provider_base
+            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :provider_base
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_updated_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_updated_method.rb
@@ -37,7 +37,7 @@ module RuboCop
           MSG = "Don't use updated = true/false to update resource state. This will cause failures in Chef Infra Client 13 and later.".freeze
 
           def on_lvasgn(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.node_parts.first == :updated
+            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.node_parts.first == :updated
           end
 
           # potential autocorrect is new_resource.updated_by_last_action true, but we need to actually see what class we were called from

--- a/lib/rubocop/cop/chef/deprecation/resource_without_name_or_provides.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_without_name_or_provides.rb
@@ -71,7 +71,7 @@ module RuboCop
 
           def on_class(node)
             HWRP?(node) do |inherit|
-              add_offense(inherit, location: :expression, message: MSG, severity: :refactor) if provides_or_resource_name?(processed_source.ast).nil?
+              add_offense(inherit, location: :expression, message: MSG, severity: :warning) if provides_or_resource_name?(processed_source.ast).nil?
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
@@ -47,7 +47,7 @@ module RuboCop
           def on_block(node)
             match_property_in_resource?(:ruby_block, 'action', node) do |ruby_action|
               ruby_action.arguments.each do |action|
-                add_offense(action, location: :expression, message: MSG, severity: :refactor) if action.source == ':create'
+                add_offense(action, location: :expression, message: MSG, severity: :warning) if action.source == ':create'
               end
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
@@ -43,15 +43,15 @@ module RuboCop
 
           def on_send(node)
             calls_run_command?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor) unless defines_run_command?(processed_source.ast)
+              add_offense(node, location: :expression, message: MSG, severity: :warning) unless defines_run_command?(processed_source.ast)
             end
 
             require_mixin_command?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
 
             include_mixin_command?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
+++ b/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
@@ -45,7 +45,7 @@ module RuboCop
 
           def on_send(node)
             search_method?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor) if positional_arguments?(node)
+              add_offense(node, location: :expression, message: MSG, severity: :warning) if positional_arguments?(node)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
@@ -43,7 +43,7 @@ module RuboCop
               if node.parent && node.parent.if_type? && %i(defined? respond_to?).include?(node.parent.children.first.method_name)
                 node = node.parent
               end
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/user_supports_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/user_supports_property.rb
@@ -47,7 +47,7 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(:user, 'supports', node) do |property|
-              add_offense(property, location: :expression, message: MSG, severity: :refactor)
+              add_offense(property, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
+++ b/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
@@ -39,7 +39,7 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(nil, 'verify', node) do |verify|
-              add_offense(verify, location: :expression, message: MSG, severity: :refactor) if verify.source.match?(/%{file}/)
+              add_offense(verify, location: :expression, message: MSG, severity: :warning) if verify.source.match?(/%{file}/)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/windows_feature_servermanagercmd.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_feature_servermanagercmd.rb
@@ -47,7 +47,7 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(:windows_feature, :install_method, node) do |prop_node|
-              add_offense(prop_node, location: :expression, message: MSG, severity: :refactor) if prop_node.source.match?(/:servermanagercmd/)
+              add_offense(prop_node, location: :expression, message: MSG, severity: :warning) if prop_node.source.match?(/:servermanagercmd/)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
@@ -74,7 +74,7 @@ module RuboCop
 
           def check_action(ast_obj)
             if ast_obj.respond_to?(:value) && ast_obj.value == :change
-              add_offense(ast_obj, location: :expression, message: MSG, severity: :refactor)
+              add_offense(ast_obj, location: :expression, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
@@ -35,7 +35,7 @@ module RuboCop
 
           def on_send(node)
             xml_ruby_recipe?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe.rb
@@ -38,7 +38,7 @@ module RuboCop
           def on_send(node)
             yum_dnf_compat_recipe_usage?(node) do
               node = node.parent if node.parent&.conditional? && node.parent&.single_line?
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
             end
           end
 


### PR DESCRIPTION
Warning level will make cookstyle exit with a non-zero error code and fail
CI builds. All other cops remain at refactor level, which does not fail.

Signed-off-by: Tim Smith <tsmith@chef.io>