### PR TITLE
Add ChefDeprecations/PowershellCookbookHelpers

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -791,6 +791,14 @@ ChefDeprecations/WindowsVersionHelpers:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefDeprecations/PowershellCookbookHelpers:
+  Description: Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers helpers.
+  Enabled: true
+  VersionAdded: '6.1.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -792,7 +792,7 @@ ChefDeprecations/WindowsVersionHelpers:
     - '**/Berksfile'
 
 ChefDeprecations/PowershellCookbookHelpers:
-  Description: Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers helpers.
+  Description: Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers.
   Enabled: true
   VersionAdded: '6.1.0'
   Exclude:

--- a/lib/rubocop/cop/chef/deprecation/powershell_cookbook_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/powershell_cookbook_helpers.rb
@@ -1,0 +1,61 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers helpers
+        #
+        # @example
+        #
+        #   # bad
+        #   Powershell::VersionHelper.powershell_version?('4.0')
+        #
+        #   # good
+        #   node['powershell']['version'].to_f == 4.0
+        #
+        #   # good (Chef Infra Client 16+)
+        #   powershell_version == 4.0
+        #
+        class PowershellCookbookHelpers < Cop
+          MSG = "Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers helpers.".freeze
+
+          def_node_matcher :ps_cb_helper?, <<-PATTERN
+          (send
+            (const
+              (const {cbase nil?} :Powershell) :VersionHelper) :powershell_version?
+            $(...))
+          PATTERN
+
+          def on_send(node)
+            ps_cb_helper?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              ps_cb_helper?(node) do |ver|
+                corrector.replace(node.loc.expression, "node['powershell']['version'].to_f == #{ver.source}")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/deprecation/powershell_cookbook_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/powershell_cookbook_helpers.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefDeprecations
-        # Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers helpers
+        # Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers
         #
         # @example
         #
@@ -32,7 +32,7 @@ module RuboCop
         #   powershell_version == 4.0
         #
         class PowershellCookbookHelpers < Cop
-          MSG = "Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers helpers.".freeze
+          MSG = "Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers.".freeze
 
           def_node_matcher :ps_cb_helper?, <<-PATTERN
           (send

--- a/spec/rubocop/cop/chef/deprecation/powershell_cookbook_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/powershell_cookbook_helpers_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::PowershellCookbookHelpers, :confi
   it 'registers an offense with Powershell::VersionHelper.powershell_version?' do
     expect_offense(<<~RUBY)
       Powershell::VersionHelper.powershell_version?('4.0')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers helpers.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers.
     RUBY
 
     expect_correction("node['powershell']['version'].to_f == '4.0'\n")

--- a/spec/rubocop/cop/chef/deprecation/powershell_cookbook_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/powershell_cookbook_helpers_spec.rb
@@ -1,0 +1,31 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::PowershellCookbookHelpers, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense with Powershell::VersionHelper.powershell_version?' do
+    expect_offense(<<~RUBY)
+      Powershell::VersionHelper.powershell_version?('4.0')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 16+ instead of the deprecated PowerShell cookbook helpers helpers.
+    RUBY
+
+    expect_correction("node['powershell']['version'].to_f == '4.0'\n")
+  end
+end


### PR DESCRIPTION
Detect using these deprecated helpers. We can move people to the chef-utils helpers later on.

Signed-off-by: Tim Smith <tsmith@chef.io>