### PR TITLE
Fix chef infra version in PowershellInstallWindowsFeature

### DIFF
--- a/lib/rubocop/cop/chef/modernize/powershell_install_windowsfeature.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_install_windowsfeature.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefModernize
-        # Use the windows_feature resource built into Chef Infra Client 15+ instead of the powershell_script resource
+        # Use the windows_feature resource built into Chef Infra Client 14+ instead of the powershell_script resource
         # to run Install-WindowsFeature or Add-WindowsFeature
         #
         # @example
@@ -38,9 +38,9 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
 
-          minimum_target_chef_version '13.0'
+          minimum_target_chef_version '14.0'
 
-          MSG = 'Use the windows_feature resource built into Chef Infra Client 13+ instead of using Install-WindowsFeature or Add-WindowsFeature in a powershell_script resource'.freeze
+          MSG = 'Use the windows_feature resource built into Chef Infra Client 14+ instead of using Install-WindowsFeature or Add-WindowsFeature in a powershell_script resource'.freeze
 
           def on_block(node)
             match_property_in_resource?(:powershell_script, 'code', node) do |code_property|

--- a/spec/rubocop/cop/chef/modernize/powershell_install_windowsfeature_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/powershell_install_windowsfeature_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Chef::ChefModernize::PowershellInstallWindowsFeature, :co
   it 'registers an offense when using powershell_script to run Install-WindowsFeature' do
     expect_offense(<<~RUBY)
     powershell_script 'Install Feature' do
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the windows_feature resource built into Chef Infra Client 13+ instead of using Install-WindowsFeature or Add-WindowsFeature in a powershell_script resource
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the windows_feature resource built into Chef Infra Client 14+ instead of using Install-WindowsFeature or Add-WindowsFeature in a powershell_script resource
       code 'Install-WindowsFeature -Name "Net-framework-Core"'
     end
     RUBY
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Chef::ChefModernize::PowershellInstallWindowsFeature, :co
   it 'registers an offense when using powershell_script to run Add-WindowsFeature' do
     expect_offense(<<~RUBY)
     powershell_script 'Add Feature' do
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the windows_feature resource built into Chef Infra Client 13+ instead of using Install-WindowsFeature or Add-WindowsFeature in a powershell_script resource
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the windows_feature resource built into Chef Infra Client 14+ instead of using Install-WindowsFeature or Add-WindowsFeature in a powershell_script resource
       code 'Add-WindowsFeature -Name "Net-framework-Core"'
     end
     RUBY
@@ -45,8 +45,8 @@ describe RuboCop::Cop::Chef::ChefModernize::PowershellInstallWindowsFeature, :co
     RUBY
   end
 
-  context 'with TargetChefVersion set to 12' do
-    let(:config) { target_chef_version(12) }
+  context 'with TargetChefVersion set to 13' do
+    let(:config) { target_chef_version(13) }
 
     it "doesn't register an offense" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This feature was introduced in 14.0. The description said 15 and the target_chef_version was set to 13. No clue how that happened, but it's wrong.

Signed-off-by: Tim Smith <tsmith@chef.io>