### PR TITLE
Add Chef version constraints to multiple deprecation cops

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
@@ -26,6 +26,10 @@ module RuboCop
         #   depends 'partial_search'
         #
         class CookbookDependsOnPartialSearch < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version '13.0'
+
           MSG = "Don't depend on the deprecated partial_search cookbook made obsolete by Chef 13".freeze
 
           def_node_matcher :depends_partial_search?, <<-PATTERN

--- a/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_properties.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_properties.rb
@@ -42,6 +42,9 @@ module RuboCop
         #
         class DeprecatedYumRepositoryProperties < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version '12.14'
 
           MSG = 'With the release of Chef Infra Client 12.14 and the yum cookbook 3.0 several properties in the yum_repository resource were renamed. url -> baseurl, keyurl -> gpgkey, and mirrorexpire -> mirror_expire.'.freeze
 

--- a/lib/rubocop/cop/chef/deprecation/launchd_deprecated_hash_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/launchd_deprecated_hash_property.rb
@@ -34,6 +34,9 @@ module RuboCop
         #
         class LaunchdDeprecatedHashProperty < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version '12.19'
 
           MSG = "The launchd resource's hash property was renamed to plist_hash in Chef Infra Client 13+ to avoid conflicts with Ruby's hash class.".freeze
 

--- a/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
+++ b/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
@@ -34,6 +34,9 @@ module RuboCop
         #
         class VerifyPropertyUsesFileExpansion < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version '12.5'
 
           MSG = "Use the 'path' variable in the verify property and not the 'file' variable which was removed in Chef Infra Client 13.".freeze
 

--- a/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
@@ -41,6 +41,9 @@ module RuboCop
         #
         class WindowsTaskChangeAction < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version '13.0'
 
           MSG = 'The :change action in the windows_task resource was removed when windows_task was added to Chef Infra Client 13+. The default action of :create should can now be used to create an update tasks.'.freeze
 


### PR DESCRIPTION
Some deprecations just require behavior changes. Others require you to
use functionality that might not be there depending on what version of
Chef Infra Client you use. These cops will break on older versions of
chef-client and these version gates make the stepped upgrade process
with Cookstyle easier.

Signed-off-by: Tim Smith <tsmith@chef.io>