### PR TITLE
Improve ChefModernize/WhyRunSupportedTrue to detect a common typo

### DIFF
--- a/lib/rubocop/cop/chef/modernize/whyrun_supported_true.rb
+++ b/lib/rubocop/cop/chef/modernize/whyrun_supported_true.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2019, Chef Software Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,8 +35,15 @@ module RuboCop
 
           MSG = 'whyrun_supported? no longer needs to be set to true as it is the default in Chef Infra Client 13+'.freeze
 
+          # match on both whyrun_supported? and the typo form why_run_supported?
+          def_node_matcher :whyrun_true?, <<-PATTERN
+            (def {:whyrun_supported? :why_run_supported?}
+              (args)
+              (true))
+          PATTERN
+
           def on_def(node)
-            if node.method_name == :whyrun_supported? && node.body == s(:true) # rubocop: disable Lint/BooleanSymbol
+            whyrun_true?(node) do
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
           end

--- a/spec/rubocop/cop/chef/modernize/whyrun_supported_true_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/whyrun_supported_true_spec.rb
@@ -1,5 +1,6 @@
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,10 +20,19 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ChefModernize::WhyRunSupportedTrue, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when a resource sets why-run to true' do
+  it 'registers an offense when a resource defines whyrun_supported? to return true' do
     expect_offense(<<~RUBY)
       def whyrun_supported?; true; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ whyrun_supported? no longer needs to be set to true as it is the default in Chef Infra Client 13+
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "registers an offense when a using the typo'd form of the whyrun_supported? method" do
+    expect_offense(<<~RUBY)
+      def why_run_supported?; true; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ whyrun_supported? no longer needs to be set to true as it is the default in Chef Infra Client 13+
     RUBY
 
     expect_correction("\n")


### PR DESCRIPTION
This extends the cop to detect a common typo of the method name

Signed-off-by: Tim Smith <tsmith@chef.io>