### PR TITLE
Improve the LogResourceNotifications to tell when notify_group was introduced

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/log_resource_notifications.rb
+++ b/lib/rubocop/cop/chef/deprecation/log_resource_notifications.rb
@@ -19,7 +19,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefDeprecations
-        # In Chef Infra Client 16 the log resource no longer notifies when logging so notifications should not be triggered from log resources. See the notify_group functionality for a potential replacement.
+        # In Chef Infra Client 16 the log resource no longer notifies when logging so notifications should not be triggered from log resources. Use the notify_group resource introduced in Chef Infra Client 15.8 instead to aggregate notifications.
         #
         # @example
         #
@@ -45,8 +45,11 @@ module RuboCop
         #
         class LogResourceNotifications < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
 
-          MSG = 'In Chef Infra Client 16 the log resource no longer notifies when logging so notifications should not be triggered from log resources. Use the notify_group resource instead to aggregate notifications.'.freeze
+          minimum_target_chef_version '15.8'
+
+          MSG = 'In Chef Infra Client 16 the log resource no longer notifies when logging so notifications should not be triggered from log resources. Use the notify_group resource introduced in Chef Infra Client 15.8 instead to aggregate notifications.'.freeze
 
           def on_block(node)
             match_property_in_resource?(:log, 'notifies', node) do |prop_node|

--- a/spec/rubocop/cop/chef/deprecation/log_resource_notification_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/log_resource_notification_spec.rb
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::LogResourceNotifications, :config
     expect_offense(<<~RUBY)
     log 'Aggregate notifications using a single log resource' do
       notifies :restart, 'service[foo]', :delayed
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ In Chef Infra Client 16 the log resource no longer notifies when logging so notifications should not be triggered from log resources. Use the notify_group resource instead to aggregate notifications.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ In Chef Infra Client 16 the log resource no longer notifies when logging so notifications should not be triggered from log resources. Use the notify_group resource introduced in Chef Infra Client 15.8 instead to aggregate notifications.
     end
     RUBY
   end


### PR DESCRIPTION
It's important that people know when this became available and to allow users to avoid this notification if they're not targeting a modern chef infra client release.

Signed-off-by: Tim Smith <tsmith@chef.io>