### PR TITLE
Add ChefDeprecations/DeprecatedShelloutMethods cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -825,6 +825,15 @@ ChefDeprecations/PowershellCookbookHelpers:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefDeprecations/DeprecatedShelloutMethods:
+  Description: Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.
+  Enabled: true
+  VersionAdded: '6.3.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
@@ -1,0 +1,63 @@
+#
+# Copyright:: 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # The large number of shell_out helper methods in Chef Infra Client has been reduced to just shell_out and shell_out! methods. The legacy methods were removed in Chef Infra Client and cookbooks using these legacy helpers will need to be updated.
+        #
+        # @example
+        #
+        #   # bad
+        #   shell_out_compact('foo')
+        #   shell_out_compact!('foo')
+        #   shell_out_with_timeout('foo')
+        #   shell_out_with_timeout!('foo')
+        #   shell_out_with_systems_locale('foo')
+        #   shell_out_with_systems_locale!('foo')
+        #
+        #   # good
+        #   shell_out('foo')
+        #   shell_out!('foo')
+        #   shell_out!('foo', default_env: false) # replaces shell_out_with_systems_locale
+        #
+        class DeprecatedShelloutMethods < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version '14.3'
+
+          DEPRECATED_SHELLOUT_METHODS = %i( shell_out_compact
+                                            shell_out_compact!
+                                            shell_out_compact_timeout
+                                            shell_out_compact_timeout!
+                                            shell_out_with_timeout
+                                            shell_out_with_timeout!
+                                            shell_out_with_systems_locale
+                                            shell_out_with_systems_locale!
+                                          ).freeze
+
+          MSG = 'Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.'.freeze
+
+          def on_send(node)
+            add_offense(node, location: :expression, message: MSG, severity: :warning) if DEPRECATED_SHELLOUT_METHODS.include?(node.method_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/deprecated_shellout_methods_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/deprecated_shellout_methods_spec.rb
@@ -1,0 +1,72 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::DeprecatedShelloutMethods, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using shell_out_compact' do
+    expect_offense(<<~RUBY)
+      shell_out_compact('foo')
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.
+    RUBY
+  end
+
+  it 'registers an offense when using shell_out_compact!' do
+    expect_offense(<<~RUBY)
+      shell_out_compact!('foo')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.
+    RUBY
+  end
+
+  it 'registers an offense when using shell_out_with_timeout' do
+    expect_offense(<<~RUBY)
+      shell_out_with_timeout('foo')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.
+    RUBY
+  end
+
+  it 'registers an offense when using shell_out_with_timeout!' do
+    expect_offense(<<~RUBY)
+      shell_out_with_timeout!('foo')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.
+    RUBY
+  end
+
+  it 'registers an offense when using shell_out_with_systems_locale' do
+    expect_offense(<<~RUBY)
+      shell_out_with_systems_locale('foo')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.
+    RUBY
+  end
+
+  it 'registers an offense when using shell_out_with_systems_locale!' do
+    expect_offense(<<~RUBY)
+      shell_out_with_systems_locale!('foo')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.
+    RUBY
+  end
+
+  it "doesn't register an offense when using shellout" do
+    expect_no_offenses("shellout('foo')")
+  end
+
+  it "doesn't register an offense when using shellout!" do
+    expect_no_offenses("shellout!('foo')")
+  end
+end


### PR DESCRIPTION
This will need to autocorrect eventually, but we should get this cop out asap to help with upgrades to Infra 15.

Signed-off-by: Tim Smith <tsmith@chef.io>