### PR TITLE
Disable Lint/ParenthesesAsGroupedExpression

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1881,8 +1881,6 @@ Lint/NextWithoutAccumulator:
   Enabled: true
 Lint/NonLocalExitFromIterator:
   Enabled: true
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: true
 Lint/RandOne:
   Enabled: true
 Lint/RequireParentheses:
@@ -2182,3 +2180,8 @@ Style/MultilineWhenThen:
 # .each_key is a lot more clear that .keys.each
 Style/HashEachMethods:
   Enabled: true
+
+# this is a confusing one to fix when passing variables to templates and often confuses
+# users for a long period of time with little benefit
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: false


### PR DESCRIPTION
This cop alerts when a user is passing variables into a template and
it's confusing on how you need to fix this. Let's avoid all that
confusion by turning it off.

Signed-off-by: Tim Smith <tsmith@chef.io>