### PR TITLE
Remove double spaces after periods in documentation

### DIFF
--- a/lib/rubocop/cop/chef/correctness/node_normal.rb
+++ b/lib/rubocop/cop/chef/correctness/node_normal.rb
@@ -18,7 +18,7 @@ module RuboCop
     module Chef
       module ChefCorrectness
         # Normal attributes are discouraged since their semantics differ importantly from the
-        # default and override levels.  Their values persist in the node object even after
+        # default and override levels. Their values persist in the node object even after
         # all code referencing them has been deleted, unlike default and override.
         #
         # Code should be updated to use default or override levels, but this will change

--- a/lib/rubocop/cop/chef/correctness/node_normal_unless.rb
+++ b/lib/rubocop/cop/chef/correctness/node_normal_unless.rb
@@ -18,7 +18,7 @@ module RuboCop
     module Chef
       module ChefCorrectness
         # Normal attributes are discouraged since their semantics differ importantly from the
-        # default and override levels.  Their values persist in the node object even after
+        # default and override levels. Their values persist in the node object even after
         # all code referencing them has been deleted, unlike default and override.
         #
         # Code should be updated to use default or override levels, but this will change

--- a/lib/rubocop/cop/chef/style/overly_complex_supports_depends_metadata.rb
+++ b/lib/rubocop/cop/chef/style/overly_complex_supports_depends_metadata.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefStyle
-        # Don't loop over an array to set cookbook dependencies or supported platforms if you have fewer than three values to set.  Setting multiple `supports` or `depends` values is simpler and easier to understand for new users.
+        # Don't loop over an array to set cookbook dependencies or supported platforms if you have fewer than three values to set. Setting multiple `supports` or `depends` values is simpler and easier to understand for new users.
         #
         # @example
         #


### PR DESCRIPTION
MLA says don't do this anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>