### PR TITLE
Enable ChefModernize/FoodcriticComments by default

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1158,7 +1158,7 @@ ChefModernize/AllowedActionsFromInitialize:
 
 ChefModernize/FoodcriticComments:
   Description: Remove legacy code comments that disable Foodcritic rules. These comments are no longer necessary if you've migrated from Foodcritic to Cookstyle for cookbook linting.
-  Enabled: false
+  Enabled: true
   VersionAdded: '5.16.0'
   Exclude:
     - '**/Berksfile'


### PR DESCRIPTION
Foodcritic is officially EOL at this point. If folks want to continue to
use both they can disable this in a .rubocop.yml file

Signed-off-by: Tim Smith <tsmith@chef.io>