### PR TITLE
Support an edge case where the supports / manage_home value is a method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,7 @@ ChefStyle/CommentFormat:
 # undefined method `each_value' for #<RuboCop::AST::ArrayNode:0x00007fb285b2c7c8>
 Style/HashEachMethods:
   Enabled: false
+
+# ChefModernize/FoodcriticComments itslef include an example Foocritic comment which alerts
+ChefModernize/FoodcriticComments:
+  Enabled: false

--- a/lib/rubocop/cop/chef/deprecation/user_supports_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/user_supports_property.rb
@@ -54,8 +54,13 @@ module RuboCop
           def autocorrect(node)
             lambda do |corrector|
               new_text = []
+
               node.arguments.first.each_pair do |k, v|
-                new_text << "#{k.value} #{v.source}"
+                # account for a strange edge case where the person incorrectly makes "manage_home a method
+                # the code would be broken, but without this handling cookstyle would explode
+                key_value = (k.send_type? && k.method_name == :manage_home) ? 'manage_home' : k.value
+
+                new_text << "#{key_value} #{v.source}"
               end
 
               corrector.replace(node.loc.expression, new_text.join("\n  "))

--- a/spec/rubocop/cop/chef/deprecation/user_supports_property_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/user_supports_property_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,6 +34,21 @@ describe RuboCop::Cop::Chef::ChefDeprecations::UserDeprecatedSupportsProperty, :
       user "betty" do
         manage_home true
         non_unique true
+      end
+    RUBY
+  end
+
+  it 'properly autocorrects when the value passed to supports is actually a method not a symbols or string' do
+    expect_offense(<<~RUBY)
+      user "betty" do
+        supports manage_home => true
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The supports property was removed in Chef Infra Client 13 in favor of individual 'manage_home' and 'non_unique' properties.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      user "betty" do
+        manage_home true
       end
     RUBY
   end


### PR DESCRIPTION
This was broken chef code, but it blew up cookstyle and we need to not explode when we hit bad code.

Signed-off-by: Tim Smith <tsmith@chef.io>