### PR TITLE
Add ChefDeprecations/Ruby27KeywordArgumentWarnings cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -834,6 +834,14 @@ ChefDeprecations/DeprecatedShelloutMethods:
     - '**/attributes/*.rb'
     - '**/Berksfile'
 
+ChefDeprecations/Ruby27KeywordArgumentWarnings:
+  Description: Pass options to shell_out helpers without the brackets to avoid Ruby 2.7 deprecation warnings.
+  Enabled: true
+  VersionAdded: '6.5.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/ruby_27_keyword_argument_warnings.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_27_keyword_argument_warnings.rb
@@ -1,0 +1,58 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Pass options to shell_out helpers without the brackets to avoid Ruby 2.7 deprecation warnings.
+        #
+        # @example
+        #
+        #   # bad
+        #   shell_out!('hostnamectl status', { returns: [0, 1] })
+        #   shell_out('hostnamectl status', { returns: [0, 1] })
+        #
+        #   # good
+        #   shell_out!('hostnamectl status', returns: [0, 1])
+        #   shell_out('hostnamectl status', returns: [0, 1])
+        #
+        class Ruby27KeywordArgumentWarnings < Cop
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'Pass options to shell_out helpers without the brackets to avoid Ruby 2.7 deprecation warnings.'.freeze
+
+          def_node_matcher :positional_shellout?, <<-PATTERN
+            (send nil? {:shell_out :shell_out!} ... $(hash ... ))
+          PATTERN
+
+          def on_send(node)
+            positional_shellout?(node) do |h|
+              add_offense(h, location: :expression, message: MSG, severity: :refactor) if h.braces?
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, node.loc.expression.source.delete_prefix('{').delete_suffix('}'))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/deprecation/ruby_27_keyword_argument_warnings.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_27_keyword_argument_warnings.rb
@@ -48,7 +48,8 @@ module RuboCop
 
           def autocorrect(node)
             lambda do |corrector|
-              corrector.replace(node.loc.expression, node.loc.expression.source.delete_prefix('{').delete_suffix('}'))
+              # @todo when we drop ruby 2.4 support we can convert to to just delete_prefix delete_suffix
+              corrector.replace(node.loc.expression, node.loc.expression.source.gsub(/^{/, '').gsub(/}$/, ''))
             end
           end
         end

--- a/spec/rubocop/cop/chef/deprecation/ruby_27_keyword_argument_warnings_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/ruby_27_keyword_argument_warnings_spec.rb
@@ -1,0 +1,48 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::Ruby27KeywordArgumentWarnings, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when passing a hash with backets to shell_out' do
+    expect_offense(<<~RUBY)
+    shell_out('hostnamectl status', {returns: [0, 1]})
+                                    ^^^^^^^^^^^^^^^^^ Pass options to shell_out helpers without the brackets to avoid Ruby 2.7 deprecation warnings.
+    RUBY
+
+    expect_correction(<<~RUBY)
+    shell_out('hostnamectl status', returns: [0, 1])
+    RUBY
+  end
+
+  it 'registers an offense when passing a hash with backets to shell_out!' do
+    expect_offense(<<~RUBY)
+    shell_out!('hostnamectl status', {returns: [0, 1]})
+                                     ^^^^^^^^^^^^^^^^^ Pass options to shell_out helpers without the brackets to avoid Ruby 2.7 deprecation warnings.
+    RUBY
+
+    expect_correction(<<~RUBY)
+    shell_out!('hostnamectl status', returns: [0, 1])
+    RUBY
+  end
+
+  it "doesn't register an offense when properly passing options to the helpers" do
+    expect_no_offenses("shell_out!('hostnamectl status', returns: [0, 1])")
+  end
+end


### PR DESCRIPTION
Avoid a common and easy to fix Ruby 2.7 warning

Signed-off-by: Tim Smith <tsmith@chef.io>