### PR TITLE
Add new ChefModernize/ShellOutHelper cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1301,6 +1301,15 @@ ChefModernize/RespondToCompileTime:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefModernize/ShellOutHelper:
+  Description: Use the built-in shell_out helper available in Chef Infra Client 12.11+ instead of calling Mixlib::ShellOut.new('foo').run_command.
+  Enabled: true
+  VersionAdded: '6.5.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+    - '**/libraries/*.rb'
+
 ###############################
 # ChefRedundantCode: Cleanup unnecessary code in your cookbooks regardless of Chef Infra Client release
 ###############################

--- a/lib/rubocop/cop/chef/modernize/shell_out_helper.rb
+++ b/lib/rubocop/cop/chef/modernize/shell_out_helper.rb
@@ -1,0 +1,64 @@
+#
+# Copyright:: 2019, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefModernize
+        # Use the built-in `shell_out` helper available in Chef Infra Client 12.11+ instead of calling `Mixlib::ShellOut.new('foo').run_command`.
+        #
+        # @example
+        #
+        #   # bad
+        #   Mixlib::ShellOut.new('foo').run_command
+        #
+        #   # good
+        #   shell_out('foo')
+        #
+        class ShellOutHelper < Cop
+          extend TargetChefVersion
+
+          minimum_target_chef_version '12.11'
+
+          MSG = "Use the built-in `shell_out` helper available in Chef Infra Client 12.11+ instead of calling `Mixlib::ShellOut.new('foo').run_command`.".freeze
+
+          def_node_matcher :mixlib_shellout_run_cmd?, <<-PATTERN
+          (send
+            (send
+              (const
+                (const nil? :Mixlib) :ShellOut) :new
+              $(...)) :run_command)
+          PATTERN
+
+          def on_send(node)
+            mixlib_shellout_run_cmd?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            mixlib_shellout_run_cmd?(node) do |cmd|
+              lambda do |corrector|
+                corrector.replace(node.loc.expression, "shell_out(#{cmd.loc.expression.source})")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/shell_out_helper_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/shell_out_helper_spec.rb
@@ -1,0 +1,37 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefModernize::ShellOutHelper, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it "registers an offense when a resource runs Mixlib::ShellOut.new('foo').run_command" do
+    expect_offense(<<~RUBY)
+      Mixlib::ShellOut.new('foo').run_command
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the built-in `shell_out` helper available in Chef Infra Client 12.11+ instead of calling `Mixlib::ShellOut.new('foo').run_command`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      shell_out('foo')
+    RUBY
+  end
+
+  it 'does not register an offense when just Mixlib::ShellOut is used w/o run_command' do
+    expect_no_offenses("Mixlib::ShellOut.new('foo')")
+  end
+end


### PR DESCRIPTION
Switch people over to the shell_out helper instead of using the more
complex Mixlib::ShellOut

Signed-off-by: Tim Smith <tsmith@chef.io>