### PR TITLE
Add new ChefCorrectness/LazyEvalNodeAttributeDefaults cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -361,6 +361,14 @@ ChefCorrectness/ConditionalRubyShellout:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefCorrectness/LazyEvalNodeAttributeDefaults:
+  Description: When setting a node attribute as a default value for a custom resource property, make sure to wrap the node attribute in `lazy {}` so that the node attribute is available when the resource executes.
+  Enabled: false
+  VersionAdded: '6.6.0'
+  Include:
+    - '**/libraries/*.rb'
+    - '**/resources/*.rb'
+
 ###############################
 # ChefSharing: Issues that prevent sharing code with other teams or with the Chef community in general
 ###############################

--- a/lib/rubocop/cop/chef/correctness/lazy_eval_node_attribute_defaults.rb
+++ b/lib/rubocop/cop/chef/correctness/lazy_eval_node_attribute_defaults.rb
@@ -1,0 +1,56 @@
+#
+# Copyright:: 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # When setting a node attribute as a default value for a custom resource property, make sure to wrap the node attribute in `lazy {}` so that the node attribute is available when the resource executes.
+        #
+        # @example
+        #
+        #   # bad
+        #   property :Something, String, default: node['hostname']
+        #
+        #   # good
+        #   property :Something, String, default: lazy { node['hostname'] }
+        #
+        class LazyEvalNodeAttributeDefaults < Cop
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'When setting a node attribute as a default value for a custom resource property, make sure to wrap the node attribute in `lazy {}` so that the node attribute is available when the resource executes.'.freeze
+
+          def_node_matcher :non_lazy_node_attribute_default?, <<-PATTERN
+           (send nil? :property (sym _) ... (hash <(pair (sym :default) $(send (send _ :node) :[] _) ) ...>))
+          PATTERN
+
+          def on_send(node)
+            non_lazy_node_attribute_default?(node) do |default|
+              add_offense(default, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, "lazy { #{node.loc.expression.source} }")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/lazy_eval_node_attribute_defaults_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/lazy_eval_node_attribute_defaults_spec.rb
@@ -1,0 +1,45 @@
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::LazyEvalNodeAttributeDefaults do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when a property includes a non-lazy attribute as a default' do
+    expect_offense(<<~RUBY)
+      property :Something, String, default: node['hostname']
+                                            ^^^^^^^^^^^^^^^^ When setting a node attribute as a default value for a custom resource property, make sure to wrap the node attribute in `lazy {}` so that the node attribute is available when the resource executes.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      property :Something, String, default: lazy { node['hostname'] }
+    RUBY
+  end
+
+  it 'does not register an offense when a property includes a lazy attribute as a default' do
+    expect_no_offenses("property :Something, String, default: lazy { node['hostname'] }")
+  end
+
+  it 'does not register an offense when a property includes non-attribute default' do
+    expect_no_offenses("property :Something, String, default: 'Some value'")
+  end
+
+  it 'does not register an offense when a property does not have a default' do
+    expect_no_offenses("property :Something, String")
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/lazy_eval_node_attribute_defaults_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/lazy_eval_node_attribute_defaults_spec.rb
@@ -40,6 +40,6 @@ describe RuboCop::Cop::Chef::ChefCorrectness::LazyEvalNodeAttributeDefaults do
   end
 
   it 'does not register an offense when a property does not have a default' do
-    expect_no_offenses("property :Something, String")
+    expect_no_offenses('property :Something, String')
   end
 end


### PR DESCRIPTION
Catch default values in properties that are node attributes

Signed-off-by: Tim Smith <tsmith@chef.io>