### PR TITLE
Detect package installs w/o an action in the multipackage cop

### DIFF
--- a/lib/rubocop/cop/chef/modernize/use_multipackage_installs.rb
+++ b/lib/rubocop/cop/chef/modernize/use_multipackage_installs.rb
@@ -47,12 +47,14 @@ module RuboCop
               (send
                 $(array ... ) :each)
               (args ... )
-              (block
+              {(block
                 (send nil? :package
                   (lvar ... ))
                 (args)
                 (send nil? :action
-                  (sym :install)))) nil?)
+                  (sym :install)))
+                (send nil? :package
+                    (lvar _))}) nil?)
           PATTERN
 
           def_node_matcher :package_array_install?, <<-PATTERN
@@ -60,12 +62,14 @@ module RuboCop
             (send
               $(array ... ) :each)
             (args ... )
-            (block
+            {(block
               (send nil? :package
                 (lvar ... ))
               (args)
               (send nil? :action
-                (sym :install))))
+                (sym :install)))
+              (send nil? :package
+                  (lvar _))})
           PATTERN
 
           # see if all platforms in the when condition are multipackage compliant

--- a/spec/rubocop/cop/chef/modernize/use_multipackage_installs_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/use_multipackage_installs_spec.rb
@@ -41,6 +41,42 @@ describe RuboCop::Cop::Chef::ChefModernize::UseMultipackageInstalls, :config do
     RUBY
   end
 
+  it 'registers an offense when iterating over an array of packages in a case statement with a non-block package resource' do
+    expect_offense(<<~RUBY)
+      case node['platform']
+      when 'ubuntu'
+        %w(bmon htop vim curl).each do |pkg|
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pass an array of packages to package resources instead of interating over an array of packages when using multi-package capable package subystem such as apt, yum, chocolatey, dnf, or zypper. Multipackage installs are faster and simplify logs.
+          package pkg
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case node['platform']
+      when 'ubuntu'
+        package %w(bmon htop vim curl)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when iterating over an array of packages in a platform? check with a non-block package resource' do
+    expect_offense(<<~RUBY)
+      if platform?('ubuntu')
+        %w(bmon htop vim curl).each do |pkg|
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pass an array of packages to package resources instead of interating over an array of packages when using multi-package capable package subystem such as apt, yum, chocolatey, dnf, or zypper. Multipackage installs are faster and simplify logs.
+          package pkg
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if platform?('ubuntu')
+        package %w(bmon htop vim curl)
+      end
+    RUBY
+  end
+
   it 'registers an offense when iterating over an array of packages in a platform? check' do
     expect_offense(<<~RUBY)
       if platform?('ubuntu')


### PR DESCRIPTION
The majority of packages were being missed:

The old cop detected this:

```ruby
      case node['platform']
      when 'ubuntu'
        %w(bmon htop vim curl).each do |pkg|
          package pkg do
            action :install
          end
        end
      end
```

But not this:

```ruby
      case node['platform']
      when 'ubuntu'
        %w(bmon htop vim curl).each do |pkg|
          package pkg
        end
      end
```

Signed-off-by: Tim Smith <tsmith@chef.io>