### PR TITLE
Add new ChefCorrectness/OpenSSLPasswordHelpers cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -369,6 +369,14 @@ ChefCorrectness/LazyEvalNodeAttributeDefaults:
     - '**/libraries/*.rb'
     - '**/resources/*.rb'
 
+ChefCorrectness/OpenSSLPasswordHelpers:
+  Description: The secure_password helper from the openssl cookbooks Opscode::OpenSSL::Password class should not be used to generate passwords.
+  Enabled: true
+  VersionAdded: '6.6.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefSharing: Issues that prevent sharing code with other teams or with the Chef community in general
 ###############################

--- a/lib/rubocop/cop/chef/correctness/openssl_password_helpers.rb
+++ b/lib/rubocop/cop/chef/correctness/openssl_password_helpers.rb
@@ -1,0 +1,45 @@
+
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # The openSSL cookbook provides a deprecated `secure_password` helper in the `Opscode::OpenSSL::Password` class, which should not longer be used. This helper would generate a random password that would be used when a data bag or attribute was no present. The practice of generating passwords to be stored on the node is bad security as it exposes the password to anyone that can view the nodes, and deleting a node deletes the password. Passwords should be retrieved from a secure source for use in cookbooks.
+        #
+        #   # bad
+        #   ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
+        #   basic_auth_password = secure_password
+        #
+        class OpenSSLPasswordHelpers < Cop
+          MSG = 'The `secure_password` helper from the openssl cookbooks `Opscode::OpenSSL::Password` class should not be used to generate passwords.'.freeze
+
+          def_node_matcher :openssl_helper?, <<~PATTERN
+            (const
+              (const
+                (const nil? :Opscode) :OpenSSL) :Password)
+          PATTERN
+
+          def on_const(node)
+            openssl_helper?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :warning)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/openssl_password_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/openssl_password_helpers_spec.rb
@@ -1,0 +1,29 @@
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::OpenSSLPasswordHelpers do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when including Opscode::OpenSSL::Password' do
+    expect_offense(<<~RUBY)
+      ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
+                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ The `secure_password` helper from the openssl cookbooks `Opscode::OpenSSL::Password` class should not be used to generate passwords.
+    RUBY
+  end
+end


### PR DESCRIPTION
Detect usage of the old helper that generates a password for users.

Signed-off-by: Tim Smith <tsmith@chef.io>