### PR TITLE
Add new cops for incorrect platforms / platform families

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -377,6 +377,22 @@ ChefCorrectness/OpenSSLPasswordHelpers:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefCorrectness/InvalidPlatformFamilyInCase:
+  Description: Use valid platform family values in case statements.
+  Enabled: true
+  VersionAdded: '6.6.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
+ChefCorrectness/InvalidPlatformInCase:
+  Description: Use valid platform values in case statements.
+  Enabled: true
+  VersionAdded: '6.6.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefSharing: Issues that prevent sharing code with other teams or with the Chef community in general
 ###############################

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case.rb
@@ -1,0 +1,76 @@
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # Use valid platform family values in case statements.
+        #
+        # @example
+        #
+        #   # bad
+        #   case node['platform_family']
+        #   when 'redhat'
+        #     puts "I'm on a RHEL-like system"
+        #   end
+        #
+        class InvalidPlatformFamilyInCase < Cop
+          include RangeHelp
+          include ::RuboCop::Chef::PlatformHelpers
+
+          MSG = 'Use valid platform family values in case statements.'.freeze
+
+          def_node_matcher :node_platform_family?, <<-PATTERN
+            (send (send nil? :node) :[] (str "platform_family") )
+          PATTERN
+
+          def on_case(node)
+            node_platform_family?(node.condition) do
+              node.each_when do |when_node|
+                when_node.each_condition do |con|
+                  next unless con.str_type? # if the condition isn't a string we can't check so skip
+
+                  if INVALID_PLATFORM_FAMILIES[con.str_content]
+                    add_offense(con, location: :expression, message: MSG, severity: :refactor)
+                  end
+                end
+              end
+            end
+          end
+
+          def autocorrect(node)
+            new_value = INVALID_PLATFORM_FAMILIES[node.str_content]
+
+            if new_value # some invalid platform families have no direct correction value and return nil instead
+              # if the correct value already exists in the when statement then we just want to delete this node
+              if node.parent.conditions.any? { |x| x.str_content == new_value }
+                lambda do |corrector|
+                  range = range_with_surrounding_comma(range_with_surrounding_space(range: node.loc.expression, side: :left), :both)
+                  corrector.remove(range)
+                end
+              else
+                lambda do |corrector|
+                  corrector.replace(node.loc.expression, "'#{new_value}'")
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case.rb
@@ -55,17 +55,18 @@ module RuboCop
           def autocorrect(node)
             new_value = INVALID_PLATFORM_FAMILIES[node.str_content]
 
-            if new_value # some invalid platform families have no direct correction value and return nil instead
-              # if the correct value already exists in the when statement then we just want to delete this node
-              if node.parent.conditions.any? { |x| x.str_content == new_value }
-                lambda do |corrector|
-                  range = range_with_surrounding_comma(range_with_surrounding_space(range: node.loc.expression, side: :left), :both)
-                  corrector.remove(range)
-                end
-              else
-                lambda do |corrector|
-                  corrector.replace(node.loc.expression, "'#{new_value}'")
-                end
+            # some invalid platform families have no direct correction value and return nil instead
+            return unless new_value
+
+            # if the correct value already exists in the when statement then we just want to delete this node
+            if node.parent.conditions.any? { |x| x.str_content == new_value }
+              lambda do |corrector|
+                range = range_with_surrounding_comma(range_with_surrounding_space(range: node.loc.expression, side: :left), :both)
+                corrector.remove(range)
+              end
+            else
+              lambda do |corrector|
+                corrector.replace(node.loc.expression, "'#{new_value}'")
               end
             end
           end

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_values_in_case.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_values_in_case.rb
@@ -1,0 +1,76 @@
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # Use valid platform values in case statements.
+        #
+        # @example
+        #
+        #   # bad
+        #   case node['platform']
+        #   when 'rhel'
+        #     puts "I'm on a Red Hat system!"
+        #   end
+        #
+        class InvalidPlatformInCase < Cop
+          include RangeHelp
+          include ::RuboCop::Chef::PlatformHelpers
+
+          MSG = 'Use valid platform values in case statements.'.freeze
+
+          def_node_matcher :node_platform?, <<-PATTERN
+            (send (send nil? :node) :[] (str "platform") )
+          PATTERN
+
+          def on_case(node)
+            node_platform?(node.condition) do
+              node.each_when do |when_node|
+                when_node.each_condition do |con|
+                  next unless con.str_type? # if the condition isn't a string we can't check so skip
+
+                  if INVALID_PLATFORMS[con.str_content]
+                    add_offense(con, location: :expression, message: MSG, severity: :refactor)
+                  end
+                end
+              end
+            end
+          end
+
+          def autocorrect(node)
+            new_value = INVALID_PLATFORMS[node.str_content]
+
+            if new_value # some invalid platform have no direct correction value and return nil instead
+              # if the correct value already exists in the when statement then we just want to delete this node
+              if node.parent.conditions.any? { |x| x.str_content == new_value }
+                lambda do |corrector|
+                  range = range_with_surrounding_comma(range_with_surrounding_space(range: node.loc.expression, side: :left), :both)
+                  corrector.remove(range)
+                end
+              else
+                lambda do |corrector|
+                  corrector.replace(node.loc.expression, "'#{new_value}'")
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_values_in_case.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_values_in_case.rb
@@ -55,17 +55,18 @@ module RuboCop
           def autocorrect(node)
             new_value = INVALID_PLATFORMS[node.str_content]
 
-            if new_value # some invalid platform have no direct correction value and return nil instead
-              # if the correct value already exists in the when statement then we just want to delete this node
-              if node.parent.conditions.any? { |x| x.str_content == new_value }
-                lambda do |corrector|
-                  range = range_with_surrounding_comma(range_with_surrounding_space(range: node.loc.expression, side: :left), :both)
-                  corrector.remove(range)
-                end
-              else
-                lambda do |corrector|
-                  corrector.replace(node.loc.expression, "'#{new_value}'")
-                end
+            # some invalid platform have no direct correction value and return nil instead
+            return unless new_value
+
+            # if the correct value already exists in the when statement then we just want to delete this node
+            if node.parent.conditions.any? { |x| x.str_content == new_value }
+              lambda do |corrector|
+                range = range_with_surrounding_comma(range_with_surrounding_space(range: node.loc.expression, side: :left), :both)
+                corrector.remove(range)
+              end
+            else
+              lambda do |corrector|
+                corrector.replace(node.loc.expression, "'#{new_value}'")
               end
             end
           end

--- a/spec/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case_spec.rb
@@ -1,0 +1,82 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::InvalidPlatformFamilyInCase, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it "registers an offense if case node['platform_family'] checks for an invalid platform_family" do
+    expect_offense(<<~RUBY)
+      case node['platform_family']
+      when 'centos'
+           ^^^^^^^^ Use valid platform family values in case statements.
+        puts "I'm on a Red Hat like box!"
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case node['platform_family']
+      when 'rhel'
+        puts "I'm on a Red Hat like box!"
+      end
+    RUBY
+  end
+
+  it 'does not add duplicate corrected values to the when condition' do
+    expect_offense(<<~RUBY)
+      case node['platform_family']
+      when 'centos', 'rhel'
+           ^^^^^^^^ Use valid platform family values in case statements.
+        puts "I'm on a Red Hat like box!"
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case node['platform_family']
+      when 'rhel'
+        puts "I'm on a Red Hat like box!"
+      end
+    RUBY
+  end
+
+  it 'does not leave a trailing comma behind when autocorrecting' do
+    expect_offense(<<~RUBY)
+      case node['platform_family']
+      when 'rhel', 'centos'
+                   ^^^^^^^^ Use valid platform family values in case statements.
+        puts "I'm on a Red Hat box!"
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case node['platform_family']
+      when 'rhel'
+        puts "I'm on a Red Hat box!"
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense if case node['platform_family'] uses 'redhat'" do
+    expect_no_offenses(<<~RUBY)
+      case node['platform_family']
+      when 'rhel'
+        puts "I'm on a Red Hat box!"
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/invalid_platform_values_in_case_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/invalid_platform_values_in_case_spec.rb
@@ -1,0 +1,82 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::InvalidPlatformInCase, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it "registers an offense if case node['platform'] checks for an invalid platform" do
+    expect_offense(<<~RUBY)
+      case node['platform']
+      when 'rhel', 'centos'
+           ^^^^^^ Use valid platform values in case statements.
+        puts "I'm on a Red Hat box!"
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case node['platform']
+      when 'redhat', 'centos'
+        puts "I'm on a Red Hat box!"
+      end
+    RUBY
+  end
+
+  it 'does not add duplicate corrected values to the when condition' do
+    expect_offense(<<~RUBY)
+      case node['platform']
+      when 'rhel', 'redhat'
+           ^^^^^^ Use valid platform values in case statements.
+        puts "I'm on a Red Hat box!"
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case node['platform']
+      when 'redhat'
+        puts "I'm on a Red Hat box!"
+      end
+    RUBY
+  end
+
+  it 'does not leave a trailing comma behind when autocorrecting' do
+    expect_offense(<<~RUBY)
+      case node['platform']
+      when 'redhat', 'rhel'
+                     ^^^^^^ Use valid platform values in case statements.
+        puts "I'm on a Red Hat box!"
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case node['platform']
+      when 'redhat'
+        puts "I'm on a Red Hat box!"
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense if case node['platform'] uses 'redhat'" do
+    expect_no_offenses(<<~RUBY)
+      case node['platform']
+      when 'redhat'
+        puts "I'm on a Red Hat box!"
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
This time let's catch them in case statements. There's some code reuse
in these cops, but it's actually a lot simpler to just write it as two
cops vs. trying to create a unified cop.

Signed-off-by: Tim Smith <tsmith@chef.io>