### PR TITLE
Expand ChefModernize/IncludingMixinShelloutInResources to work in HWRPs

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1115,6 +1115,7 @@ ChefModernize/IncludingMixinShelloutInResources:
   Include:
     - '**/resources/*.rb'
     - '**/providers/*.rb'
+    - '**/libraries/*.rb'
 
 ChefModernize/UseBuildEssentialResource:
   Description: Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+

--- a/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
+++ b/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2019, Chef Software Inc.
+# Copyright:: 2019-2020, Chef Software Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,9 +57,8 @@ module RuboCop
           def check_for_offenses(node)
             containing_dir = File.basename(File.dirname(processed_source.path))
 
-            if containing_dir == 'resources' # resource
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            elsif hwrp_classes?(processed_source.ast) # hwrp
+            # only add offenses when we're in a custom resource or HWRP, but not a plain old library
+            if containing_dir == 'resources' || hwrp_classes?(processed_source.ast)
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
           end

--- a/spec/rubocop/cop/chef/modernize/includes_mixin_shellout_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/includes_mixin_shellout_spec.rb
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Chef::ChefModernize::IncludingMixinShelloutInResources, :
     expect_correction("\n")
   end
 
-  it 'registers an error when requiring "chef/mixin/shell_out" in a non-HWRP library' do
+  it "doesn't register an offense when requiring \"chef/mixin/shell_out\" in a non-HWRP library" do
     allow(File).to receive(:dirname).and_return('/foo/bar/cookbook/libraries/')
     expect_no_offenses(<<~RUBY)
     require 'chef/mixin/shell_out'

--- a/spec/rubocop/cop/chef/modernize/includes_mixin_shellout_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/includes_mixin_shellout_spec.rb
@@ -19,7 +19,8 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ChefModernize::IncludingMixinShelloutInResources, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an error when requiring "chef/mixin/shell_out"' do
+  it 'registers an error when requiring "chef/mixin/shell_out" in a resource' do
+    allow(File).to receive(:dirname).and_return('/foo/bar/cookbook/resources/')
     expect_offense(<<~RUBY)
     require 'chef/mixin/shell_out'
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
@@ -28,7 +29,38 @@ describe RuboCop::Cop::Chef::ChefModernize::IncludingMixinShelloutInResources, :
     expect_correction("\n")
   end
 
-  it 'registers an error when including "Chef::Mixin::ShellOut"' do
+  it 'registers an error when requiring "chef/mixin/shell_out" in a HWRP inheriting from Chef::Provider' do
+    allow(File).to receive(:dirname).and_return('/foo/bar/cookbook/libraries/')
+    expect_offense(<<~RUBY)
+    require 'chef/mixin/shell_out'
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
+
+    class Chef
+      class Provider
+        class LvmVolumeGroup < Chef::Provider
+        end
+      end
+    end
+    RUBY
+  end
+
+  it 'registers an error when requiring "chef/mixin/shell_out" in a HWRP inheriting from Chef::Provider::LWRPBase' do
+    allow(File).to receive(:dirname).and_return('/foo/bar/cookbook/libraries/')
+    expect_offense(<<~RUBY)
+    require 'chef/mixin/shell_out'
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
+
+    class Chef
+      class Provider
+        class LvmVolumeGroup < Chef::Provider::LWRPBase
+        end
+      end
+    end
+    RUBY
+  end
+
+  it 'registers an error when including "Chef::Mixin::ShellOut" in a resource' do
+    allow(File).to receive(:dirname).and_return('/foo/bar/cookbook/resources/')
     expect_offense(<<~RUBY)
     include Chef::Mixin::ShellOut
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
@@ -37,7 +69,8 @@ describe RuboCop::Cop::Chef::ChefModernize::IncludingMixinShelloutInResources, :
     expect_correction("\n")
   end
 
-  it 'registers an error when requiring "chef/mixin/powershell_out"' do
+  it 'registers an error when requiring "chef/mixin/powershell_out" in a resource' do
+    allow(File).to receive(:dirname).and_return('/foo/bar/cookbook/resources/')
     expect_offense(<<~RUBY)
     require 'chef/mixin/powershell_out'
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
@@ -46,13 +79,26 @@ describe RuboCop::Cop::Chef::ChefModernize::IncludingMixinShelloutInResources, :
     expect_correction("\n")
   end
 
-  it 'registers an error when including "Chef::Mixin::PowershellOut"' do
+  it 'registers an error when including "Chef::Mixin::PowershellOut" in a resource' do
+    allow(File).to receive(:dirname).and_return('/foo/bar/cookbook/resources/')
     expect_offense(<<~RUBY)
     include Chef::Mixin::PowershellOut
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.
     RUBY
 
     expect_correction("\n")
+  end
+
+  it 'registers an error when requiring "chef/mixin/shell_out" in a non-HWRP library' do
+    allow(File).to receive(:dirname).and_return('/foo/bar/cookbook/libraries/')
+    expect_no_offenses(<<~RUBY)
+    require 'chef/mixin/shell_out'
+
+    class MyCookbook
+      class Helpers
+      end
+    end
+    RUBY
   end
 
   it "doesn't register an offense when including Chef::Mixin::Foo" do


### PR DESCRIPTION
Let's cleanup the HWRPs as well. This is a bit tricky since we need to make sure we don't remove a shellout helper from any old random ruby library. Just the HWRPs where we know we're in a provider class and we'll have them available to us.

Signed-off-by: Tim Smith <tsmith@chef.io>