### PR TITLE
Add ChefDeprecations/ResourceUsesOnlyResourceName

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -991,6 +991,15 @@ ChefDeprecations/Ruby27KeywordArgumentWarnings:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefDeprecations/ResourceUsesOnlyResourceName:
+  Description: Starting with Chef Infra Client 16 using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the instead and skip the `resource_name` entirely if it matches the name Chef Infra Client automatically assigned based on COOKBOOKNAME_FILENAME.
+  StyleGuide: '#chefdeprecationsresourceusesonlyresourcename'
+  Enabled: true
+  VersionAdded: '6.7.0'
+  Include:
+    - '**/libraries/*.rb'
+    - '**/resources/*.rb'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -992,7 +992,7 @@ ChefDeprecations/Ruby27KeywordArgumentWarnings:
     - '**/Berksfile'
 
 ChefDeprecations/ResourceUsesOnlyResourceName:
-  Description: Starting with Chef Infra Client 16 using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the instead and skip the `resource_name` entirely if it matches the name Chef Infra Client automatically assigned based on COOKBOOKNAME_FILENAME.
+  Description: Starting with Chef Infra Client 16, using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the resource instead and omit `resource_name` entirely if it matches the name Chef Infra Client automatically assigns based on COOKBOOKNAME_FILENAME.
   StyleGuide: '#chefdeprecationsresourceusesonlyresourcename'
   Enabled: true
   VersionAdded: '6.7.0'

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
@@ -30,7 +30,7 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
           include RangeHelp
 
-          MSG = 'Starting with Chef Infra Client 16 using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the instead and skip the `resource_name` entirely if it matches the name Chef Infra Client automatically assigned based on COOKBOOKNAME_FILENAME.'.freeze
+          MSG = 'Starting with Chef Infra Client 16, using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the resource instead and omit `resource_name` entirely if it matches the name Chef Infra Client automatically assigns based on COOKBOOKNAME_FILENAME.'.freeze
 
           def_node_matcher :resource_name?, <<-PATTERN
           (send nil? :resource_name (sym $_ ))

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
@@ -18,7 +18,7 @@ module RuboCop
   module Cop
     module Chef
       module ChefDeprecations
-        # Starting with Chef Infra Client 16 using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the instead and skip the `resource_name` entirely if it matches the name Chef Infra Client automatically assigned based on COOKBOOKNAME_FILENAME.
+        # Starting with Chef Infra Client 16, using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the resource instead and omit `resource_name` entirely if it matches the name Chef Infra Client automatically assigns based on COOKBOOKNAME_FILENAME.
         #
         # @example
         #

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
@@ -1,0 +1,77 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Starting with Chef Infra Client 16 using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the instead and skip the `resource_name` entirely if it matches the name Chef Infra Client automatically assigned based on COOKBOOKNAME_FILENAME.
+        #
+        # @example
+        #
+        #   # bad
+        #   mycookbook/resources/myresource.rb:
+        #   resource_name :mycookbook_myresource
+        #
+        class ResourceUsesOnlyResourceName < Cop
+          include RuboCop::Chef::CookbookHelpers
+          include RangeHelp
+
+          MSG = 'Starting with Chef Infra Client 16 using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the instead and skip the `resource_name` entirely if it matches the name Chef Infra Client automatically assigned based on COOKBOOKNAME_FILENAME.'.freeze
+
+          def_node_matcher :resource_name?, <<-PATTERN
+          (send nil? :resource_name (sym $_ ))
+          PATTERN
+
+          def_node_search :cb_name_match, <<~PATTERN
+          (send nil? :name (str $_))
+          PATTERN
+
+          def_node_search :provides_methods?, '(send nil? {:provides :chef_version_for_provides} ... )'
+
+          def cookbook_name
+            cb_path = File.expand_path(File.join(processed_source.file_path, '../..'))
+
+            if File.exist?(File.join(cb_path, 'metadata.rb'))
+              cb_metadata_ast = ProcessedSource.from_file(File.join(cb_path, 'metadata.rb'), @config.target_ruby_version).ast
+              cb_name_match(cb_metadata_ast).first
+            elsif File.exist?(File.join(cb_path, 'metadata.json')) # this exists only for supermarket files that lack metadata.rb
+              JSON.parse(File.read(File.join(cb_path, 'metadata.json')))['name']
+            end
+          end
+
+          def on_send(node)
+            resource_name?(node) do |_name|
+              add_offense(node, location: :expression, message: MSG, severity: :warning) unless provides_methods?(processed_source.ast)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              resource_name?(node) do |name|
+                if name.to_s == "#{cookbook_name}_#{File.basename(processed_source.path, '.rb')}"
+                  corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+                else
+                  corrector.replace(node.loc.expression, node.source.gsub('resource_name', 'provides'))
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/resource_uses_only_resource_name_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/resource_uses_only_resource_name_spec.rb
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ResourceUsesOnlyResourceName do
   it 'registers an offense when a resource has resource_name and does not use provides' do
     expect_offense(<<~RUBY, '/mydevdir/cookbooks/my_cookbook/resources/foo.rb')
       resource_name :my_cookbook_foo
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Starting with Chef Infra Client 16 using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the instead and skip the `resource_name` entirely if it matches the name Chef Infra Client automatically assigned based on COOKBOOKNAME_FILENAME.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Starting with Chef Infra Client 16, using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the resource instead and omit `resource_name` entirely if it matches the name Chef Infra Client automatically assigns based on COOKBOOKNAME_FILENAME.
     RUBY
   end
 

--- a/spec/rubocop/cop/chef/deprecation/resource_uses_only_resource_name_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/resource_uses_only_resource_name_spec.rb
@@ -20,6 +20,10 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::ChefDeprecations::ResourceUsesOnlyResourceName do
   subject(:cop) { described_class.new }
 
+  before do
+    skip 'Test not currently supported on Windows!' if RuboCop::Platform.windows?
+  end
+
   let(:non_match_json) do
     <<~DATA
     {

--- a/spec/rubocop/cop/chef/deprecation/resource_uses_only_resource_name_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/resource_uses_only_resource_name_spec.rb
@@ -1,0 +1,95 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::ResourceUsesOnlyResourceName do
+  subject(:cop) { described_class.new }
+
+  let(:non_match_json) do
+    <<~DATA
+    {
+    	"name": "default",
+    	"description": "Installs some stuff",
+    	"maintainer": "Bob Boberson",
+    	"maintainer_email": "bob@example.com",
+    	"license": "Apache-2.0",
+    	"platforms": {},
+    	"dependencies": {},
+    	"recommendations": {},
+    	"suggestions": {},
+    	"conflicting": {},
+    	"providing": {},
+    	"replacing": {},
+    	"attributes": {},
+    	"groupings": {},
+    	"recipes": {},
+    	"version": "1.0.0"
+    }
+    DATA
+  end
+
+  let(:match_json) do
+    non_match_json.gsub('default', 'my_cookbook')
+  end
+
+  it 'registers an offense when a resource has resource_name and does not use provides' do
+    expect_offense(<<~RUBY, '/mydevdir/cookbooks/my_cookbook/resources/foo.rb')
+      resource_name :my_cookbook_foo
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Starting with Chef Infra Client 16 using `resource_name` without also using `provides` will result in resource failures. Use `provides` to change the name of the instead and skip the `resource_name` entirely if it matches the name Chef Infra Client automatically assigned based on COOKBOOKNAME_FILENAME.
+    RUBY
+  end
+
+  it 'autocorrect deletes the resource_name if it the default name based on metadata.json data' do
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:read).and_call_original
+    allow(File).to receive(:exist?).with('/mydevdir/cookbooks/my_cookbook/metadata.rb').and_return(false)
+    allow(File).to receive(:exist?).with('/mydevdir/cookbooks/my_cookbook/metadata.json').and_return(true)
+    allow(File).to receive(:read).with('/mydevdir/cookbooks/my_cookbook/metadata.json').and_return(match_json)
+    corrected = autocorrect_source(<<~RUBY, '/mydevdir/cookbooks/my_cookbook/resources/foo.rb')
+      resource_name :my_cookbook_foo
+    RUBY
+
+    expect(corrected).to eq("\n")
+  end
+
+  it 'autocorrect renames resource_name to provides if it is not the default name based on metadata.json data' do
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:read).and_call_original
+    allow(File).to receive(:exist?).with('/mydevdir/cookbooks/my_cookbook/metadata.rb').and_return(false)
+    allow(File).to receive(:exist?).with('/mydevdir/cookbooks/my_cookbook/metadata.json').and_return(true)
+    allow(File).to receive(:read).with('/mydevdir/cookbooks/my_cookbook/metadata.json').and_return(non_match_json)
+    corrected = autocorrect_source(<<~RUBY, '/mydevdir/cookbooks/my_cookbook/resources/foo.rb')
+      resource_name :my_cookbook_foo
+    RUBY
+
+    expect(corrected).to eq("provides :my_cookbook_foo\n")
+  end
+
+  it "doesn't register an offense when a resource has just provides" do
+    expect_no_offenses(<<~RUBY, '/mydevdir/cookbooks/my_cookbook/resources/foo.rb')
+      provides :my_cookbook_foo
+    RUBY
+  end
+
+  it "doesn't register an offense when a resource has resource_name and provides" do
+    expect_no_offenses(<<~RUBY, '/mydevdir/cookbooks/my_cookbook/resources/foo.rb')
+      resource_name :my_cookbook_foo
+      provides :my_cookbook_foo
+    RUBY
+  end
+end


### PR DESCRIPTION
Add the initial part of the detection of resource_name in custom resources
instead of provides.

Signed-off-by: Tim Smith <tsmith@chef.io>
