### PR TITLE
Update to rubocop 0.85.1

### DIFF
--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,4 +1,4 @@
 module Cookstyle
   VERSION = "6.7.4".freeze # rubocop: disable Style/StringLiterals
-  RUBOCOP_VERSION = '0.85.0'.freeze
+  RUBOCOP_VERSION = '0.85.1'.freeze
 end


### PR DESCRIPTION
* [#8083](https://github.com/rubocop-hq/rubocop/issues/8083): Fix an error for `Lint/MixedRegexpCaptureTypes` cop when using a regular expression that cannot be processed by regexp_parser gem.
* [#8081](https://github.com/rubocop-hq/rubocop/issues/8081): Fix a false positive for `Lint/SuppressedException` when empty rescue block in `do` block.
* [#8096](https://github.com/rubocop-hq/rubocop/issues/8096): Fix a false positive for `Lint/SuppressedException` when empty rescue block in defs.
* [#8108](https://github.com/rubocop-hq/rubocop/issues/8108): Fix infinite loop in `Layout/HeredocIndentation` auto-correct.
* [#8042](https://github.com/rubocop-hq/rubocop/pull/8042): Fix raising error in `Lint::FormatParameterMismatch` when it handles invalid format strings and add new offense.

Signed-off-by: Tim Smith <tsmith@chef.io>