### PR TITLE
Add cookstyle cop to detect using .to_s on ohai attribute

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1734,7 +1734,6 @@ ChefRedundantCode/OhaiAttributeToString:
   VersionAdded: '6.10.0'
   Exclude:
     - '**/metadata.rb'
-    - '**/attributes/*.rb'
     - '**/Berksfile'
 
 ###############################

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1727,6 +1727,16 @@ ChefRedundantCode/UseCreateIfMissing:
     - '**/attributes/*.rb'
     - '**/Berksfile'
 
+ChefRedundantCode/OhaiAttributeToString:
+  Description: Many Ohai node attributes are already strings and don't need to be cast to strings again
+  StyleGuide: '#ohaiattributetostring'
+  Enabled: true
+  VersionAdded: '6.10.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefEffortless: Migrating to new patterns
 ###############################

--- a/lib/rubocop/cop/chef/redundant/ohai_attribute_to_string.rb
+++ b/lib/rubocop/cop/chef/redundant/ohai_attribute_to_string.rb
@@ -1,0 +1,68 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefRedundantCode
+        # Many Ohai node attributes are already strings and don't need to be cast to strings again
+        #
+        # @example
+        #
+        #   # bad
+        #   node['platform'].to_s
+        #   node['platform_family'].to_s
+        #   node['platform_version'].to_s
+        #   node['fqdn'].to_s
+        #   node['hostname'].to_s
+        #   node['os'].to_s
+        #   node['name'].to_s
+        #
+        #   # good
+        #   node['platform']
+        #   node['platform_family']
+        #   node['platform_version']
+        #   node['fqdn']
+        #   node['hostname']
+        #   node['os']
+        #   node['name']
+        #
+        class OhaiAttributeToString < Cop
+          MSG = "Many Ohai node attributes are already strings and don't need to be cast to strings again".freeze
+
+          def_node_matcher :platform_to_s?, <<-PATTERN
+            (send (send (send nil? :node) :[] $(str {"platform" "platform_family" "platform_version" "fqdn" "hostname" "os" "name"}) ) :to_s )
+          PATTERN
+
+          def on_send(node)
+            platform_to_s?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            platform_to_s?(node) do |method|
+              lambda do |corrector|
+                corrector.replace(node.loc.expression, "node['#{method.value}']")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/redundant/ohai_attribute_to_string.rb
+++ b/lib/rubocop/cop/chef/redundant/ohai_attribute_to_string.rb
@@ -42,7 +42,7 @@ module RuboCop
         #   node['name']
         #
         class OhaiAttributeToString < Cop
-          MSG = "Many Ohai node attributes are already strings and don't need to be cast to strings again".freeze
+          MSG = "This Ohai node attribute is already a string and doesn't need to be converted".freeze
 
           def_node_matcher :platform_to_s?, <<-PATTERN
             (send (send (send nil? :node) :[] $(str {"platform" "platform_family" "platform_version" "fqdn" "hostname" "os" "name"}) ) :to_s )

--- a/spec/rubocop/cop/chef/redundant/ohai_attribute_to_string_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/ohai_attribute_to_string_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::OhaiAttributeToString, :config d
   it "registers an offense with node['platform'].to_s" do
     expect_offense(<<~RUBY)
       node['platform'].to_s
-      ^^^^^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+      ^^^^^^^^^^^^^^^^^^^^^ This Ohai node attribute is already a string and doesn't need to be converted
     RUBY
 
     expect_correction(<<~RUBY)
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::OhaiAttributeToString, :config d
   it "registers an offense with node['platform_family'].to_s" do
     expect_offense(<<~RUBY)
       node['platform_family'].to_s
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This Ohai node attribute is already a string and doesn't need to be converted
     RUBY
 
     expect_correction(<<~RUBY)
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::OhaiAttributeToString, :config d
   it "registers an offense with node['platform_version'].to_s" do
     expect_offense(<<~RUBY)
       node['platform_version'].to_s
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This Ohai node attribute is already a string and doesn't need to be converted
     RUBY
 
     expect_correction(<<~RUBY)
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::OhaiAttributeToString, :config d
   it "registers an offense with node['fqdn'].to_s" do
     expect_offense(<<~RUBY)
       node['fqdn'].to_s
-      ^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+      ^^^^^^^^^^^^^^^^^ This Ohai node attribute is already a string and doesn't need to be converted
     RUBY
 
     expect_correction(<<~RUBY)
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::OhaiAttributeToString, :config d
   it "registers an offense with node['os'].to_s" do
     expect_offense(<<~RUBY)
       node['os'].to_s
-      ^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+      ^^^^^^^^^^^^^^^ This Ohai node attribute is already a string and doesn't need to be converted
     RUBY
 
     expect_correction(<<~RUBY)
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::OhaiAttributeToString, :config d
   it "registers an offense with node['hostname'].to_s" do
     expect_offense(<<~RUBY)
       node['hostname'].to_s
-      ^^^^^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+      ^^^^^^^^^^^^^^^^^^^^^ This Ohai node attribute is already a string and doesn't need to be converted
     RUBY
 
     expect_correction(<<~RUBY)
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::OhaiAttributeToString, :config d
   it "registers an offense with node['name'].to_s" do
     expect_offense(<<~RUBY)
       node['name'].to_s
-      ^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+      ^^^^^^^^^^^^^^^^^ This Ohai node attribute is already a string and doesn't need to be converted
     RUBY
 
     expect_correction(<<~RUBY)

--- a/spec/rubocop/cop/chef/redundant/ohai_attribute_to_string_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/ohai_attribute_to_string_spec.rb
@@ -1,0 +1,111 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefRedundantCode::OhaiAttributeToString, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it "registers an offense with node['platform'].to_s" do
+    expect_offense(<<~RUBY)
+      node['platform'].to_s
+      ^^^^^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['platform']
+    RUBY
+  end
+
+  it "registers an offense with node['platform_family'].to_s" do
+    expect_offense(<<~RUBY)
+      node['platform_family'].to_s
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['platform_family']
+    RUBY
+  end
+
+  it "registers an offense with node['platform_version'].to_s" do
+    expect_offense(<<~RUBY)
+      node['platform_version'].to_s
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['platform_version']
+    RUBY
+  end
+
+  it "registers an offense with node['fqdn'].to_s" do
+    expect_offense(<<~RUBY)
+      node['fqdn'].to_s
+      ^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['fqdn']
+    RUBY
+  end
+
+  it "registers an offense with node['os'].to_s" do
+    expect_offense(<<~RUBY)
+      node['os'].to_s
+      ^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['os']
+    RUBY
+  end
+
+  it "registers an offense with node['hostname'].to_s" do
+    expect_offense(<<~RUBY)
+      node['hostname'].to_s
+      ^^^^^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['hostname']
+    RUBY
+  end
+
+  it "registers an offense with node['name'].to_s" do
+    expect_offense(<<~RUBY)
+      node['name'].to_s
+      ^^^^^^^^^^^^^^^^^ Many Ohai node attributes are already strings and don't need to be cast to strings again
+    RUBY
+
+    expect_correction(<<~RUBY)
+      node['name']
+    RUBY
+  end
+
+  it "doesn't register an offense when using a node attribute directly" do
+    expect_no_offenses(<<~RUBY)
+      node['platform']
+    RUBY
+  end
+
+  it "doesn't register an offense when using .to_s on any old attribute" do
+    expect_no_offenses(<<~RUBY)
+      node['platform']['foo'].to_s
+    RUBY
+  end
+end


### PR DESCRIPTION
There's no reason to .to_s objects that are already strings.

Signed-off-by: Tim Smith <tsmith@chef.io>