### PR TITLE
Monkeypatch the Migration/DepartmentName cop to suggest cookstyle

### DIFF
--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -12,6 +12,7 @@ require 'rubocop/monkey_patches/comment_config.rb'
 require 'rubocop/monkey_patches/config.rb'
 require 'rubocop/monkey_patches/cop.rb'
 require 'rubocop/monkey_patches/team.rb'
+require 'rubocop/monkey_patches/registry_cop.rb'
 
 module RuboCop
   class ConfigLoader

--- a/lib/rubocop/monkey_patches/registry_cop.rb
+++ b/lib/rubocop/monkey_patches/registry_cop.rb
@@ -1,0 +1,14 @@
+module RuboCop
+  module Cop
+    class Registry
+      # we monkeypatch this warning to replace rubocop with cookstyle
+      def print_warning(name, path)
+        message = "#{path}: Warning: no department given for #{name}."
+        if path.end_with?('.rb')
+          message += ' Run `cookstyle -a --only Migration/DepartmentName` to fix.'
+        end
+        warn message
+      end
+    end
+  end
+end

--- a/spec/rubocop/monkey_patches/migration_departmentname_spec.rb
+++ b/spec/rubocop/monkey_patches/migration_departmentname_spec.rb
@@ -27,6 +27,6 @@ describe RuboCop::Cop::Migration::DepartmentName, :config do
         node['platform'] # rubocop: disable UnusedMethodArgument
                                             ^^^^^^^^^^^^^^^^^^^^ Department name is missing.
       RUBY
-    end.to output('file.rb: Warning: no department given for UnusedMethodArgument. Run `cookstyle -a --only Migration/DepartmentName` to fix.').to_stderr
+    end.to output("file.rb: Warning: no department given for UnusedMethodArgument. Run `cookstyle -a --only Migration/DepartmentName` to fix.\n").to_stderr
   end
 end

--- a/spec/rubocop/monkey_patches/migration_departmentname_spec.rb
+++ b/spec/rubocop/monkey_patches/migration_departmentname_spec.rb
@@ -1,0 +1,32 @@
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# this tests the monkey patch we do in lib/rubocop/monkey_patches/registry_cop.rb
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Migration::DepartmentName, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'monkeypatches the Migration/DepartmentName message to reference cookstyle not rubocop' do
+    expect do
+      expect_offense(<<~RUBY, 'file.rb')
+        node['platform'] # rubocop: disable UnusedMethodArgument
+                                            ^^^^^^^^^^^^^^^^^^^^ Department name is missing.
+      RUBY
+    end.to output('file.rb: Warning: no department given for UnusedMethodArgument. Run `cookstyle -a --only Migration/DepartmentName` to fix.').to_stderr
+  end
+end


### PR DESCRIPTION
Cookstyle shouldn't suggest people run rubocop directly even if that would work.

Signed-off-by: Tim Smith <tsmith@chef.io>