### PR TITLE
Add ChefSharing/IncludeResourceExamples

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -503,6 +503,14 @@ ChefSharing/IncludeResourceDescriptions:
   Include:
     - '**/resources/*.rb'
 
+ChefSharing/IncludeResourceExamples:
+  Description: Resources should include examples field to allow automated documention. Requires Chef Infra Client 13.9 or later.
+  StyleGuide: '#chefsharingincluderesourceexamples'
+  Enabled: false
+  VersionAdded: '6.10.0'
+  Include:
+    - '**/resources/*.rb'
+
 ###############################
 # ChefDeprecations: Resolving Deprecations that block upgrading Chef Infra Client
 ###############################

--- a/lib/rubocop/cop/chef/sharing/include_resource_examples.rb
+++ b/lib/rubocop/cop/chef/sharing/include_resource_examples.rb
@@ -1,0 +1,59 @@
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefSharing
+        # Resources should include examples field to allow automated documention. Requires Chef Infra Client 13.9 or later.
+        #
+        # @example
+        #
+        #   # good
+        #   examples <<~DOC
+        #     **Specify a global domain value**
+        #
+        #     ```ruby
+        #     macos_userdefaults 'full keyboard access to all controls' do
+        #       key 'AppleKeyboardUIMode'
+        #       value '2'
+        #     end
+        #     ```
+        #   DOC
+        #
+        class IncludeResourceExamples < Cop
+          include RangeHelp
+          extend TargetChefVersion
+
+          minimum_target_chef_version '13.9'
+
+          MSG = 'Resources should include examples field to allow automated documention. Requires Chef Infra Client 13.9 or later.'.freeze
+
+          def investigate(processed_source)
+            return if processed_source.blank?
+
+            # Using range similar to RuboCop::Cop::Naming::Filename (file_name.rb)
+            range = source_range(processed_source.buffer, 1, 0)
+
+            add_offense(nil, location: range, message: MSG, severity: :refactor) unless resource_examples(processed_source.ast).any?
+          end
+
+          def_node_search :resource_examples, '(send nil? :examples dstr ...)'
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/sharing/include_resource_examples_spec.rb
+++ b/spec/rubocop/cop/chef/sharing/include_resource_examples_spec.rb
@@ -1,0 +1,45 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefSharing::IncludeResourceExamples, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a resource does not include examples' do
+    expect_offense(<<~RUBY)
+    provides 'foo'
+    ^ Resources should include examples field to allow automated documention. Requires Chef Infra Client 13.9 or later.
+    RUBY
+  end
+
+  it "doesn't register an offense when a resource contains examples" do
+    expect_no_offenses(<<~RUBY)
+      provides 'foo'
+      examples <<~DOC
+        **Specify a global domain value**
+
+        ```ruby
+        macos_userdefaults 'full keyboard access to all controls' do
+          key 'AppleKeyboardUIMode'
+          value '2'
+        end
+        ```
+      DOC
+    RUBY
+  end
+end


### PR DESCRIPTION
This is so we can fail our desktop cookbook builds if a PR doesn't includes examples. We're already doing this with resource and property description fields, which works great.

Signed-off-by: Tim Smith <tsmith@chef.io>