### PR TITLE
Expand NodeInitPackage to catch more bad systemd tests

### DIFF
--- a/spec/rubocop/cop/chef/modernize/node_init_package_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/node_init_package_spec.rb
@@ -108,6 +108,28 @@ describe RuboCop::Cop::Chef::ChefModernize::NodeInitPackage, :config do
     RUBY
   end
 
+  it "registers an offense with only_if 'test -f /bin/systemctl && /bin/systemctl'" do
+    expect_offense(<<~RUBY)
+      only_if 'test -f /bin/systemctl && /bin/systemctl'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      only_if { node['init_package'] == 'systemd' }
+    RUBY
+  end
+
+  it "registers an offense with not_if 'test -f /bin/systemctl && /bin/systemctl'" do
+    expect_offense(<<~RUBY)
+      not_if 'test -f /bin/systemctl && /bin/systemctl'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      not_if { node['init_package'] == 'systemd' }
+    RUBY
+  end
+
   it "does not register an offense when comparing a non-systemd value in '/proc/1/comm'" do
     expect_no_offenses(<<~RUBY)
       ::File.open('/proc/1/comm').gets.chomp == 'foo'


### PR DESCRIPTION
Catch using test in a conditional. There's a small number of these on the supermarket. This also migrates the new 0.87+ corrector API, which allowed me to easily have 2 different kinds of offenses autocorrected. Very cool stuff.

Signed-off-by: Tim Smith <tsmith@chef.io>