### PR TITLE
Add new ChefStyle/IncludeRecipeWithParentheses

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -161,6 +161,16 @@ ChefStyle/NegatingOnlyIf:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefStyle/IncludeRecipeWithParentheses:
+  Description: There is no need to wrap the recipe in parentheses when using the include_recipe helper
+  StyleGuide: '#includerecipewithparentheses'
+  VersionAdded: '6.11.0'
+  Enabled: true
+  Exclude:
+    - '**/attributes/*.rb'
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefCorrectness: Avoiding potential problems
 ###############################

--- a/lib/rubocop/cop/chef/style/include_recipe_with_parentheses.rb
+++ b/lib/rubocop/cop/chef/style/include_recipe_with_parentheses.rb
@@ -1,0 +1,57 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefStyle
+        # There is no need to wrap the recipe in parentheses when using the include_recipe helper.
+        #
+        # @example
+        #
+        #   # bad
+        #   include_recipe('foo::bar')
+        #
+        #   # good
+        #   include_recipe 'foo::bar'
+        #
+        class IncludeRecipeWithParentheses < Base
+          extend RuboCop::Cop::AutoCorrector
+
+          MSG = 'There is no need to wrap the recipe in parentheses when using the include_recipe helper'.freeze
+
+          def_node_matcher :include_recipe?, <<-PATTERN
+            (send nil? :include_recipe $(str _))
+          PATTERN
+
+          def on_send(node)
+            include_recipe?(node) do |recipe|
+              return unless node.parenthesized?
+
+              # avoid chefspec: expect(chef_run).to include_recipe('foo')
+              return if node.parent&.send_type?
+
+              add_offense(node.loc.expression, message: MSG, severity: :refactor) do |corrector|
+                corrector.replace(node.loc.expression, "include_recipe #{recipe.source}")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/style/include_recipe_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/chef/style/include_recipe_with_parentheses_spec.rb
@@ -1,0 +1,37 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefStyle::IncludeRecipeWithParentheses do
+  subject(:cop) { described_class.new }
+
+  it "registers an offense with include_recipe('foo')" do
+    expect_offense(<<~RUBY)
+      include_recipe('foo')
+      ^^^^^^^^^^^^^^^^^^^^^ There is no need to wrap the recipe in parentheses when using the include_recipe helper
+    RUBY
+
+    expect_correction(<<~RUBY)
+    include_recipe 'foo'
+    RUBY
+  end
+
+  it "does not register an with include_recipe 'foo'" do
+    expect_no_offenses("include_recipe 'foo'")
+  end
+end


### PR DESCRIPTION
Yes it's just a method, but none of our examples show it being called
like a method and reading this code may confuse others later on. Let's
set the style to be bare.

Signed-off-by: Tim Smith <tsmith@chef.io>