### PR TITLE
Expand IncorrectLibraryInjection to detect more types of injection

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -310,8 +310,9 @@ ChefCorrectness/IncorrectLibraryInjection:
   StyleGuide: '#chefcorrectnessincorrectlibraryinjection'
   Enabled: true
   VersionAdded: '5.10.0'
-  Include:
-    - '**/libraries/*.rb'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
 
 ChefCorrectness/InvalidPlatformHelper:
   Description: Pass valid platforms to the platform? helper.

--- a/lib/rubocop/cop/chef/correctness/incorrect_library_injection.rb
+++ b/lib/rubocop/cop/chef/correctness/incorrect_library_injection.rb
@@ -25,6 +25,8 @@ module RuboCop
         #   # bad
         #   ::Chef::Recipe.send(:include, Filebeat::Helpers)
         #   ::Chef::Provider.send(:include, Filebeat::Helpers)
+        #   ::Chef::Recipe.include Filebeat::Helpers
+        #   ::Chef::Provider.include Filebeat::Helpers
         #
         #   # good
         #   ::Chef::DSL::Recipe.send(:include, Filebeat::Helpers) # covers previous Recipe & Provider classes
@@ -36,8 +38,16 @@ module RuboCop
             (send (const (const (cbase) :Chef) {:Recipe :Provider}) :send (sym :include) ... )
           PATTERN
 
+          def_node_matcher :legacy_class_includes?, <<-PATTERN
+            (send (const (const (cbase) :Chef) {:Recipe :Provider}) :include ... )
+          PATTERN
+
           def on_send(node)
             legacy_class_sends?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+
+            legacy_class_includes?(node) do
               add_offense(node, location: :expression, message: MSG, severity: :refactor)
             end
           end

--- a/spec/rubocop/cop/chef/correctness/incorrect_library_injection_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/incorrect_library_injection_spec.rb
@@ -38,6 +38,24 @@ describe RuboCop::Cop::Chef::ChefCorrectness::IncorrectLibraryInjection do
     expect_correction("::Chef::DSL::Recipe.send(:include, Foo::Helpers)\n")
   end
 
+  it 'registers an offense when calling ::Chef::Recipe.include' do
+    expect_offense(<<~RUBY)
+      ::Chef::Recipe.include Foo::Helpers
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Libraries should be injected into the Chef::DSL::Recipe class and not Chef::Recipe or Chef::Provider classes directly.
+    RUBY
+
+    expect_correction("::Chef::DSL::Recipe.include Foo::Helpers\n")
+  end
+
+  it 'registers an offense when calling ::Chef::Provider.include' do
+    expect_offense(<<~RUBY)
+      ::Chef::Provider.include Foo::Helpers
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Libraries should be injected into the Chef::DSL::Recipe class and not Chef::Recipe or Chef::Provider classes directly.
+    RUBY
+
+    expect_correction("::Chef::DSL::Recipe.include Foo::Helpers\n")
+  end
+
   it 'does not register an offense when calling ::Chef::DSL::Recipe.send' do
     expect_no_offenses(<<~RUBY)
       ::Chef::DSL::Recipe.send


### PR DESCRIPTION
1) Detect the .include form of library injection
2) Don't limit this to libraries that injection themselves. There can be library injection anywhere

With this change we detect an additional 230 incorrect library injections on the Supermarket.

Signed-off-by: Tim Smith <tsmith@chef.io>