### PR TITLE
Detect additional ways to shellout to apt-get update

### DIFF
--- a/lib/rubocop/cop/chef/modernize/execute_apt_update.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_apt_update.rb
@@ -45,7 +45,7 @@ module RuboCop
           MSG = 'Use the apt_update resource instead of the execute resource to run an apt-get update package cache update'.freeze
 
           def_node_matcher :execute_apt_update?, <<-PATTERN
-            (send nil? :execute (str "apt-get update"))
+            (send nil? :execute (str { "apt-get update" "apt-get update -y" "apt-get -y update" }))
           PATTERN
 
           def_node_matcher :notification_property?, <<-PATTERN

--- a/spec/rubocop/cop/chef/modernize/execute_apt_update_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/execute_apt_update_spec.rb
@@ -29,6 +29,24 @@ describe RuboCop::Cop::Chef::ChefModernize::ExecuteAptUpdate, :config do
     RUBY
   end
 
+  it 'registers an offense when using execute to run apt-get update -y' do
+    expect_offense(<<~RUBY)
+      execute 'apt-get update -y' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the apt_update resource instead of the execute resource to run an apt-get update package cache update
+        action :nothing
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using execute to run apt-get -y update' do
+    expect_offense(<<~RUBY)
+      execute 'apt-get -y update' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the apt_update resource instead of the execute resource to run an apt-get update package cache update
+        action :nothing
+      end
+    RUBY
+  end
+
   it "registers an offense when a resource notifies 'execute[apt-get update]'" do
     expect_offense(<<~RUBY)
       execute 'some execute resource' do


### PR DESCRIPTION
Turns out some people add -y even though you don't need that for an
update.

Signed-off-by: Tim Smith <tsmith@chef.io>