### PR TITLE
Add new ChefDeprecations/ChefDKGenerators cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1020,6 +1020,15 @@ ChefDeprecations/ResourceUsesOnlyResourceName:
     - '**/libraries/*.rb'
     - '**/resources/*.rb'
 
+ChefDeprecations/ChefDKGenerators:
+  Description: Chef Workstation 0.8 and later renamed the ChefDK module used when writing custom cookbook generators from ChefDK to ChefCLI. For compatibility with the latest Chef Workstation releases you'll need to reference the new class names.
+  StyleGuide: '#chefdkgenerators'
+  Enabled: true
+  VersionAdded: '6.12.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/chefdk_generators.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefdk_generators.rb
@@ -1,0 +1,59 @@
+#
+# Copyright:: 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Chef Workstation 0.8 and later renamed the ChefDK module used when writing custom cookbook generators from ChefDK to ChefCLI. For compatibility with the latest Chef Workstation releases you'll need to reference the new class names.
+        #
+        # @example
+        #
+        #   # bad
+        #   ChefDK::CLI
+        #   ChefDK::Generator::TemplateHelper
+        #   module ChefDK
+        #     ...
+        #   end
+        #
+        #   # good
+        #   ChefCLI::CLI
+        #   ChefCLI::Generator::TemplateHelper
+        #   module ChefCLI
+        #     ...
+        #   end
+        #
+        class ChefDKGenerators < Cop
+          MSG = 'When writing cookbook generators use the ChefCLI module instead of the ChefDK module which was removed in Chef Workstation 0.8 and later.'.freeze
+
+          def on_const(node)
+            # We want to catch calls like ChefCLI::CLI.whatever or places where classes are defined in the ChefDK module
+            return unless node.const_name == 'ChefDK' && (node.parent&.module_type? || node.parent&.const_type?)
+
+            add_offense(node, location: :expression, message: MSG, severity: :warning)
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, node.source.gsub('ChefDK', 'ChefCLI'))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/chefdk_generators_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chefdk_generators_spec.rb
@@ -1,0 +1,84 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::ChefDKGenerators, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using ChefDK::CLI.new' do
+    expect_offense(<<~RUBY)
+      ChefDK::CLI.new
+      ^^^^^^ When writing cookbook generators use the ChefCLI module instead of the ChefDK module which was removed in Chef Workstation 0.8 and later.
+    RUBY
+
+    expect_correction("ChefCLI::CLI.new\n")
+  end
+
+  it 'registers an offense when using ChefDK::CLI.new' do
+    expect_offense(<<~RUBY)
+      ChefDK::CLI.new
+      ^^^^^^ When writing cookbook generators use the ChefCLI module instead of the ChefDK module which was removed in Chef Workstation 0.8 and later.
+    RUBY
+
+    expect_correction("ChefCLI::CLI.new\n")
+  end
+
+  it 'registers an offense when using a ChefDK Generator class' do
+    expect_offense(<<~RUBY)
+      ChefDK::Generator::TemplateHelper
+      ^^^^^^ When writing cookbook generators use the ChefCLI module instead of the ChefDK module which was removed in Chef Workstation 0.8 and later.
+    RUBY
+
+    expect_correction("ChefCLI::Generator::TemplateHelper\n")
+  end
+
+  it 'registers an offense when defining your own generators' do
+    expect_offense(<<~RUBY)
+      module ChefDK
+             ^^^^^^ When writing cookbook generators use the ChefCLI module instead of the ChefDK module which was removed in Chef Workstation 0.8 and later.
+        module Command
+          module GeneratorCommands
+            class Cookbook < Base
+              def emit_post_create_message
+                msg("my own thing")
+              end
+            end
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module ChefCLI
+        module Command
+          module GeneratorCommands
+            class Cookbook < Base
+              def emit_post_create_message
+                msg("my own thing")
+              end
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense with a bare ChefDK const" do
+    expect_no_offenses('ChefDK')
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/chefdk_generators_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chefdk_generators_spec.rb
@@ -29,15 +29,6 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ChefDKGenerators, :config do
     expect_correction("ChefCLI::CLI.new\n")
   end
 
-  it 'registers an offense when using ChefDK::CLI.new' do
-    expect_offense(<<~RUBY)
-      ChefDK::CLI.new
-      ^^^^^^ When writing cookbook generators use the ChefCLI module instead of the ChefDK module which was removed in Chef Workstation 0.8 and later.
-    RUBY
-
-    expect_correction("ChefCLI::CLI.new\n")
-  end
-
   it 'registers an offense when using a ChefDK Generator class' do
     expect_offense(<<~RUBY)
       ChefDK::Generator::TemplateHelper


### PR DESCRIPTION
Fix legacy cookbook generators to work on Chef Workstation

Signed-off-by: Tim Smith <tsmith@chef.io>