### PR TITLE
Add ChefDeprecations/ChefHandlerRecipe cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1029,6 +1029,15 @@ ChefDeprecations/ChefDKGenerators:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefDeprecations/ChefHandlerRecipe:
+  Description: There is no need to include the empty and deprecated chef_handler::default recipe in order to use the chef_handler resource.
+  StyleGuide: '#chefhandlerrecipe'
+  Enabled: true
+  VersionAdded: '6.12.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
@@ -1,0 +1,54 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # There is no need to include the empty and deprecated chef_handler::default recipe in order to use the chef_handler resource
+        #
+        # @example
+        #
+        #   # bad
+        #   include_recipe 'chef_handler'
+        #   include_recipe 'chef_handler::default'
+        #
+        class ChefHandlerRecipe < Cop
+          include RangeHelp
+
+          MSG = 'There is no need to include the empty and deprecated chef_handler::default recipe in order to use the chef_handler resource'.freeze
+
+          def_node_matcher :chef_handler_recipe?, <<-PATTERN
+            (send nil? :include_recipe (str {"chef_handler" "chef_handler::default"}))
+          PATTERN
+
+          def on_send(node)
+            chef_handler_recipe?(node) do
+              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/chef_handler_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_handler_recipe_spec.rb
@@ -1,0 +1,44 @@
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::ChefHandlerRecipe, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using include_recipe "chef_handler::default"' do
+    expect_offense(<<~RUBY)
+    include_recipe "chef_handler::default"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include the empty and deprecated chef_handler::default recipe in order to use the chef_handler resource
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it 'registers an offense when using include_recipe "chef_handler"' do
+    expect_offense(<<~RUBY)
+    include_recipe "chef_handler"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include the empty and deprecated chef_handler::default recipe in order to use the chef_handler resource
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when including a different recipe" do
+    expect_no_offenses("include_recipe 'yum'")
+  end
+end


### PR DESCRIPTION
We already remove the depends in the metadata and then this would break
users.

Signed-off-by: Tim Smith <tsmith@chef.io>