### PR TITLE
Copy over profiling support from RuboCop

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -45,7 +45,7 @@ steps:
 
 - label: run-cookstyle-and-specs-windows
   command:
-    - bundle install --jobs=7 --retry=3 --without docs debug
+    - bundle install --jobs=7 --retry=3 --without docs debug profiling
     - bundle exec rake
   expeditor:
     executor:

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,11 @@ group :docs do
   gem 'yard'
 end
 
+group :profiling do
+  gem 'stackprof'
+  gem 'memory_profiler'
+end
+
 group :development do
   gem 'adamantium'
   gem 'anima'

--- a/bin/cookstyle-profile
+++ b/bin/cookstyle-profile
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+if ARGV.include?('-h') || ARGV.include?('--help')
+  puts 'Usage: same as main `cookstyle` command but gathers profiling info'
+  puts 'Additional option: `--memory` to print memory usage'
+  exit(0)
+end
+with_mem = ARGV.delete('--memory')
+
+require 'stackprof'
+if with_mem
+  require 'memory_profiler'
+  MemoryProfiler.start
+end
+StackProf.start
+start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+begin
+  load "#{__dir__}/cookstyle"
+ensure
+  delta = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+  puts "Finished in #{delta.round(1)} seconds"
+  StackProf.stop
+  if with_mem
+    puts 'Building memory report...'
+    report = MemoryProfiler.stop
+  end
+  Dir.mkdir('tmp') unless File.exist?('tmp')
+  StackProf.results('tmp/stackprof.dump')
+  report&.pretty_print(scale_bytes: true)
+end

--- a/tasks/prof.rake
+++ b/tasks/prof.rake
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+namespace :prof do
+  DUMP_PATH = 'tmp/stackprof.dump'
+
+  desc 'Run Cookstyle on itself with profiling on'
+  task :run, [:path] do |_task, args|
+    path = args.fetch(:path, '.')
+    cmd = "bin/cookstyle-profile #{path}"
+    system cmd
+  end
+
+  task :run_if_needed, [:path] do
+    Rake::Task[:run].run unless File.exist?(DUMP_PATH)
+  end
+
+  desc 'List the slowest cops'
+  task slow_cops: :run_if_needed do
+    method = 'RuboCop::Cop::Commissioner#trigger_responding_cops'
+    cmd = "stackprof #{DUMP_PATH} --text --method '#{method}'"
+    puts cmd
+    output = `#{cmd}`
+    _header, list, _code = *output
+      .lines
+      .grep_v(/RuboCop::Cop::Commissioner/) # ignore internal calls
+      .slice_when { |line| line.match?(/callees.*:|code:/) }
+    puts list.first(40)
+  end
+
+  desc 'Check a particular method by walking through the callstack'
+  task :walk, [:method] => :run_if_needed do |_task, args|
+    method = args.fetch(:method) do
+      warn 'usage: bundle exec rake walk[Class#method]'
+      exit!
+    end
+    cmd = "stackprof #{DUMP_PATH} --walk --method '#{method}'"
+    puts cmd
+    system cmd
+  end
+end


### PR DESCRIPTION
Adds a binary that we don't ship for profiling cookstyle and adds stackprof and memory_profiler as deps in a new profiling gemfile group.

Signed-off-by: Tim Smith <tsmith@chef.io>