### PR TITLE
Add ChefRedundantCode/DoubleCompileTime cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1820,6 +1820,16 @@ ChefRedundantCode/MultiplePlatformChecks:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefRedundantCode/DoubleCompileTime:
+  Description: If a resource includes the `compile_time` property there's no need to also use `.run_action(:some_action)` on the resource block
+  StyleGuide: '#chefredundantcodedoublecompiletime'
+  Enabled: true
+  VersionAdded: '6.13.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefEffortless: Migrating to new patterns
 ###############################

--- a/lib/rubocop/cop/chef/redundant/double_compile_time.rb
+++ b/lib/rubocop/cop/chef/redundant/double_compile_time.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefRedundantCode
+        # If a resource includes the `compile_time` property there's no need to also use `.run_action(:some_action)` on the resource block
+        #
+        #   # bad
+        #   chef_gem 'deep_merge' do
+        #     action :nothing
+        #     compile_time true
+        #   end.run_action(:install)
+        #
+        #   # good
+        #   chef_gem 'deep_merge' do
+        #     action :install
+        #     compile_time true
+        #   end
+        #
+        class DoubleCompileTime < Base
+          extend RuboCop::Cop::AutoCorrector
+
+          MSG = "If a resource includes the `compile_time` property there's no need to also use `.run_action(:some_action)` on the resource block."
+
+          def_node_matcher :compile_time_and_run_action?, <<-PATTERN
+          (send
+            $(block
+              (send nil? ... )
+              (args)
+              (begin <
+                (send nil? :action (sym $_) )
+                (send nil? :compile_time (true) )
+                ...
+              >)
+            ) :run_action (sym $_) )
+          PATTERN
+
+          def on_send(node)
+            compile_time_and_run_action?(node) do |resource, action, run_action|
+              add_offense(node.loc.selector, message: MSG, severity: :refactor) do |corrector|
+                corrector.replace(node.loc.expression, resource.source.gsub(action.to_s, run_action.to_s))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/redundant/double_compile_time_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/double_compile_time_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefRedundantCode::DoubleCompileTime do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when a resource uses compile_time and run_action' do
+    expect_offense(<<~RUBY)
+      chef_gem 'deep_merge' do
+        action :nothing
+        compile_time true
+      end.run_action(:install)
+          ^^^^^^^^^^ If a resource includes the `compile_time` property there's no need to also use `.run_action(:some_action)` on the resource block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      chef_gem 'deep_merge' do
+        action :install
+        compile_time true
+      end
+    RUBY
+  end
+
+  it 'does not register an offense if compile_time property is not present' do
+    expect_no_offenses(<<~RUBY)
+      chef_gem 'deep_merge' do
+        compile_time true
+      end.run_action(:install)
+  RUBY
+  end
+end


### PR DESCRIPTION
This is a weird case I keep seeing that needs to get cleaned up. We can
move the run_action into the compile_time and make it work as expected.

Signed-off-by: Tim Smith <tsmith@chef.io>