### PR TITLE
Update dead links

### DIFF
--- a/WRITING_RULES.md
+++ b/WRITING_RULES.md
@@ -2,8 +2,8 @@
 
 Parser library's list of node types: https://github.com/marcandre/parser/blob/master/lib/parser/meta.rb
 
-RuboCop's Creating a New Cop documentation (rubocop specific, but useful): https://docs.rubocop.org/en/latest/development/#add-a-new-cop
+RuboCop's Creating a New Cop documentation (RuboCop specific, but useful): https://docs.rubocop.org/rubocop/development.html#create-a-new-cop
 
-RuboCop Node Pattern documentation: https://docs.rubocop.org/en/latest/node_pattern/
+RuboCop Node Pattern documentation: https://docs.rubocop.org/rubocop-ast/node_pattern.html
 
-RuboCop NodePattern class with query examples: https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/node_pattern.rb
+RuboCop NodePattern class with query examples: https://github.com/rubocop-hq/rubocop-ast/blob/master/lib/rubocop/ast/node_pattern.rb


### PR DESCRIPTION
Update dead links in WRITING_RULES.md to working links.

Signed-off-by: Dan Gordon <chef@dangordon.xyz>

## Description
Some of the links in WRITING_RULES.md directed to 404 pages which may make it difficult for users to find helpful information about how to write custom Cookstyle rules.  This commit simply updates the dead links in that file to working ones.

## Related Issue
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
Note: this change is just updating documentation, which is why I did not run through any of the tests.

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
