### PR TITLE
Cleanup leftover config from rubocop-chef project

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -5,27 +5,6 @@ AllCops:
     - '/**/files/**/*'
     - '/**/vendor/**/*'
     - Guardfile
-  ChefAttributes:
-    Patterns:
-    - attributes/.*\.rb
-  ChefDefinitions:
-    Patterns:
-    - definitions/.*\.rb
-  ChefLibraries:
-    Patterns:
-    - libraries/.*\.rb
-  ChefMetadata:
-    Patterns:
-    - metadata\.rb
-  ChefProviders:
-    Patterns:
-    - providers/.*\.rb
-  ChefRecipes:
-    Patterns:
-    - recipes/.*\.rb
-  ChefResources:
-    Patterns:
-    - resources/.*\.rb
 
 ###############################
 # ChefStyle: Making cookbooks look better


### PR DESCRIPTION
This was never actually used by cookstyle and just came over with rubocop-chef.

Signed-off-by: Tim Smith <tsmith@chef.io>