### PR TITLE
Fix target_chef_version support in the new Rubocop 0.88+ format of cops

### DIFF
--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -7,13 +7,13 @@ require 'yaml'
 # ensure the desired target version of RuboCop is gem activated
 gem 'rubocop', "= #{Cookstyle::RUBOCOP_VERSION}"
 require 'rubocop'
-require 'rubocop/monkey_patches/comment_config.rb'
+require_relative 'rubocop/monkey_patches/comment_config.rb'
 
 # monkey patches needed for the TargetChefVersion config option
-require 'rubocop/monkey_patches/config.rb'
-require 'rubocop/monkey_patches/cop.rb'
-require 'rubocop/monkey_patches/team.rb'
-require 'rubocop/monkey_patches/registry_cop.rb'
+require_relative 'rubocop/monkey_patches/config.rb'
+require_relative 'rubocop/monkey_patches/base.rb'
+require_relative 'rubocop/monkey_patches/team.rb'
+require_relative 'rubocop/monkey_patches/registry_cop.rb'
 
 module RuboCop
   class ConfigLoader

--- a/lib/rubocop/monkey_patches/base.rb
+++ b/lib/rubocop/monkey_patches/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module RuboCop
   module Cop
-    class Cop
+    class Base
       # This is a copy of the #target_rails_version method from rubocop-rails
       def target_chef_version
         @config.target_chef_version


### PR DESCRIPTION
This monkeypatch needs to be on the base class not the cop class now. This allows is to work off the new style cops that inherit from base. The test that this works will be the next cop I'm shipping which previously exploded and runs fine with this patch.

Signed-off-by: Tim Smith <tsmith@chef.io>