### PR TITLE
Add 2 new cops for macos_userdefaults changes in 16.3

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -450,6 +450,15 @@ ChefCorrectness/SupportsMustBeFloat:
   Include:
     - '**/metadata.rb'
 
+ChefCorrectness/MacosUserdefaultsInvalidType:
+  Description: The macos_userdefaults resource prior to Chef Infra Client 16.3 would silently continue if invalid types were passed resulting in unexpected behavior. Valid values are 'array', 'bool', 'dict', 'float', 'int', and 'string'.
+  StyleGuide: '#chefcorrectnessmacosuserdefaultsinvalidtype'
+  Enabled: true
+  VersionAdded: '6.14.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefSharing: Issues that prevent sharing code with other teams or with the Chef community in general
 ###############################
@@ -1042,6 +1051,15 @@ ChefDeprecations/UseAutomaticResourceName:
   Include:
     - '**/libraries/*.rb'
     - '**/resources/*.rb'
+
+ChefDeprecations/MacosUserdefaultsGlobalProperty:
+  Description: The `global` property in the macos_userdefaults resource was deprecated in Chef Infra Client 16.3. Omitting the `domain` property will now set global defaults.
+  StyleGuide: '#chefdeprecationsmacosuserdefaultsglobalproperty'
+  Enabled: true
+  VersionAdded: '6.14.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
 
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources

--- a/lib/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type.rb
+++ b/lib/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # The macos_userdefaults resource prior to Chef Infra Client 16.3 would silently continue if invalid types were passed resulting in unexpected behavior. Valid values are: "array", "bool", "dict", "float", "int", and "string".
+        #
+        # @example
+        #
+        #   # bad
+        #   macos_userdefaults 'set a value' do
+        #     global true
+        #     key 'key'
+        #     type 'boolean'
+        #   end
+        #
+        #   # good
+        #   macos_userdefaults 'set a value' do
+        #     global true
+        #     key 'key'
+        #     type 'bool'
+        #   end
+        #
+        class MacosUserdefaultsInvalidType < Base
+          include RuboCop::Chef::CookbookHelpers
+          extend RuboCop::Cop::AutoCorrector
+
+          VALID_VALUES = %w(array bool dict float int string).freeze
+          INVALID_VALUE_MAP = {
+            'boolean' => 'bool',
+            'str' => 'string',
+            'integer' => 'int',
+          }.freeze
+
+          MSG = 'The macos_userdefaults resource prior to Chef Infra Client 16.3 would silently continue if invalid types were passed resulting in unexpected behavior. Valid values are: "array", "bool", "dict", "float", "int", and "string".'
+
+          def on_block(node)
+            match_property_in_resource?(:macos_userdefaults, 'type', node) do |type|
+              type_val = method_arg_ast_to_string(type)
+              return if VALID_VALUES.include?(type_val)
+              add_offense(type.loc.expression, message: MSG, severity: :refactor) do |corrector|
+                return unless INVALID_VALUE_MAP[type_val]
+                corrector.replace(type.loc.expression, "type '#{INVALID_VALUE_MAP[type_val]}'")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type.rb
+++ b/lib/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type.rb
@@ -55,8 +55,9 @@ module RuboCop
               type_val = method_arg_ast_to_string(type)
               return if VALID_VALUES.include?(type_val)
               add_offense(type.loc.expression, message: MSG, severity: :refactor) do |corrector|
-                return unless INVALID_VALUE_MAP[type_val]
-                corrector.replace(type.loc.expression, "type '#{INVALID_VALUE_MAP[type_val]}'")
+                if INVALID_VALUE_MAP[type_val]
+                  corrector.replace(type.loc.expression, "type '#{INVALID_VALUE_MAP[type_val]}'")
+                end
               end
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/macos_userdefaults_global_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/macos_userdefaults_global_property.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # The `global` property in the macos_userdefaults resource was deprecated in Chef Infra Client 16.3. This property was never properly implemented and caused failures under many conditions. Omitting the `domain` property will now set global defaults.
+        #
+        # @example
+        #
+        #   # bad
+        #   macos_userdefaults 'set a value' do
+        #     global true
+        #     key 'key'
+        #     value 'value'
+        #   end
+        #
+        #   # good
+        #   macos_userdefaults 'set a value' do
+        #     key 'key'
+        #     value 'value'
+        #   end
+        #
+        class MacosUserdefaultsGlobalProperty < Base
+          extend TargetChefVersion
+          include RangeHelp
+          include RuboCop::Chef::CookbookHelpers
+          extend AutoCorrector
+
+          minimum_target_chef_version '16.3'
+
+          MSG = 'The `global` property in the macos_userdefaults resource was deprecated in Chef Infra Client 16.3. Omitting the `domain` property will now set global defaults.'
+
+          def on_block(node)
+            match_property_in_resource?(:macos_userdefaults, 'global', node) do |global|
+              add_offense(global.loc.expression, message: MSG, severity: :warning) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: global.loc.expression, side: :left))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::MacosUserdefaultsInvalidType do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when an invalid type is set in macos_userdefaults' do
+    expect_offense(<<~RUBY)
+      macos_userdefaults 'set a value' do
+        global true
+        key 'key'
+        type 'boolean'
+        ^^^^^^^^^^^^^^ The macos_userdefaults resource prior to Chef Infra Client 16.3 would silently continue if invalid types were passed resulting in unexpected behavior. Valid values are: "array", "bool", "dict", "float", "int", and "string".
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      macos_userdefaults 'set a value' do
+        global true
+        key 'key'
+        type 'bool'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense with a valid type in macos_userdefaults' do
+    expect_no_offenses(<<~RUBY)
+      macos_userdefaults 'set a value' do
+        global true
+        key 'key'
+        type 'bool'
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type_spec.rb
@@ -40,6 +40,26 @@ describe RuboCop::Cop::Chef::ChefCorrectness::MacosUserdefaultsInvalidType do
     RUBY
   end
 
+  it "registers an offense even if it can't autocorrect it" do
+    expect_offense(<<~RUBY)
+      macos_userdefaults 'set a value' do
+        global true
+        key 'key'
+        type 'total_fake_stuff'
+        ^^^^^^^^^^^^^^^^^^^^^^^ The macos_userdefaults resource prior to Chef Infra Client 16.3 would silently continue if invalid types were passed resulting in unexpected behavior. Valid values are: "array", "bool", "dict", "float", "int", and "string".
+      end
+    RUBY
+
+    # not this is the same aka no autocorrect
+    expect_correction(<<~RUBY)
+      macos_userdefaults 'set a value' do
+        global true
+        key 'key'
+        type 'total_fake_stuff'
+      end
+    RUBY
+  end
+
   it 'does not register an offense with a valid type in macos_userdefaults' do
     expect_no_offenses(<<~RUBY)
       macos_userdefaults 'set a value' do

--- a/spec/rubocop/cop/chef/deprecation/macos_userdefaults_global_property_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/macos_userdefaults_global_property_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::MacosUserdefaultsGlobalProperty, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when macos_userdefaults set the global property' do
+    expect_offense(<<~RUBY)
+      macos_userdefaults 'set a value' do
+        global true
+        ^^^^^^^^^^^ The `global` property in the macos_userdefaults resource was deprecated in Chef Infra Client 16.3. Omitting the `domain` property will now set global defaults.
+        key 'key'
+        value 'value'
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      macos_userdefaults 'set a value' do
+        key 'key'
+        value 'value'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when macos_userdefaults doesn't use the global property" do
+    expect_no_offenses(<<~RUBY)
+      macos_userdefaults 'set a value' do
+        key 'key'
+        value 'value'
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Detect global property which was always broken, but is now deprecated
Detect invalid types which were silently ignored before and now raise

Signed-off-by: Tim Smith <tsmith@chef.io>