### PR TITLE
Update ChefStyle/FileMode to support files_mode as well

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -46,7 +46,7 @@ ChefStyle/CommentFormat:
     - '**/Berksfile'
 
 ChefStyle/FileMode:
-  Description: Use strings to represent file modes in Chef resources
+  Description: Use strings to represent file modes to avoid confusion between octal and base 10 integer formats.
   StyleGuide: '#chefstylefilemode'
   Enabled: true
   VersionAdded: '5.0.0'

--- a/spec/rubocop/cop/chef/style/file_mode_spec.rb
+++ b/spec/rubocop/cop/chef/style/file_mode_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Chef::ChefStyle::FileMode do
       file '/foo' do
         owner 'root'
         mode 644
-             ^^^ Use strings for file modes
+             ^^^ Use strings to represent file modes to avoid confusion between octal and base 10 integer formats
       end
     RUBY
 
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Chef::ChefStyle::FileMode do
       file '/foo' do
         owner 'root'
         mode 0644
-             ^^^^ Use strings for file modes
+             ^^^^ Use strings to represent file modes to avoid confusion between octal and base 10 integer formats
       end
     RUBY
 
@@ -68,6 +68,23 @@ describe RuboCop::Cop::Chef::ChefStyle::FileMode do
       file '/foo' do
         owner 'root'
         mode '644'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when setting a files_mode as well' do
+    expect_offense(<<~RUBY)
+      file '/foo' do
+        owner 'root'
+        files_mode 644
+                   ^^^ Use strings to represent file modes to avoid confusion between octal and base 10 integer formats
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      file '/foo' do
+        owner 'root'
+        files_mode '644'
       end
     RUBY
   end


### PR DESCRIPTION
files_mode exists in the remote_directory resource and should also be a string. I also converted this cop to the new format, improved the warning text, and improved the examples while I was in here.

Signed-off-by: Tim Smith <tsmith@chef.io>