### PR TITLE
Set PoiseArchive minimum chef version to 15.0

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/poise_archive.rb
+++ b/lib/rubocop/cop/chef/deprecation/poise_archive.rb
@@ -35,6 +35,8 @@ module RuboCop
         #
         class PoiseArchiveUsage < Cop
           include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+          minimum_target_chef_version '15.0'
 
           MSG = 'The poise_archive resource in the deprecated poise-archive should be replaced with the archive_file resource found in Chef Infra Client 15+'
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Set PoiseArchive minimum chef version to 15.0.
The `archive_file` syntax is only available from Chef 15+ so the minimum version of the rule has to be adjusted accordingly.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
