### PR TITLE
Turn off Naming/AccessorMethodName

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2342,14 +2342,10 @@ Metrics/BlockNesting:
 Metrics/ParameterLists:
   Enabled: false
 
-#### COPS FOR THE NEXT MAJOR RELEASE
-
 # This updates how we send helpers into the Chef recipe/resource classes and makes WAY more sense
 # Chef::Recipe.send(:include, ::Apt::Helpers) -> Chef::Recipe.include ::Apt::Helpers
 Lint/SendWithMixinArgument:
   Enabled: true
-
-#### END COPS FOR THE NEXT MAJOR RELEASE
 
 # this migrates old # rubocop: comments to use the latest namespaces, which prevents a ton of spam during cookstyle runs
 Migration/DepartmentName:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2575,3 +2575,7 @@ Style/HashEachMethods:
 # We want to catch this deprecation in cookbooks
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
+
+# This just isn't a big deal in the context of a cookbook
+Naming/AccessorMethodName:
+  Enabled: false


### PR DESCRIPTION
This isn't a thing folks should worry about in cookbooks. There's more
pressing issues.

Signed-off-by: Tim Smith <tsmith@chef.io>