### PR TITLE
Update RuboCop engine to 0.89.1

### DIFF
--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Cookstyle
   VERSION = "6.15.2" # rubocop: disable Style/StringLiterals
-  RUBOCOP_VERSION = '0.89.0'
+  RUBOCOP_VERSION = '0.89.1'
 end


### PR DESCRIPTION
Signed-off-by: Tim Smith <tsmith@chef.io>