### PR TITLE
Optimize requires for non omnibus installs

### DIFF
--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require_relative 'cookstyle/version'
 
-require 'pathname'
-require 'yaml'
+require 'pathname' unless defined?(Pathname)
+require 'yaml' unless defined?(YAML)
 
 # ensure the desired target version of RuboCop is gem activated
 gem 'rubocop', "= #{Cookstyle::RUBOCOP_VERSION}"


### PR DESCRIPTION
Requires in ruby are very slow. We patch around this in our omnibus
installs of ruby, but for non-omnibus installs we should avoid requiring
things when we don't need to.

Signed-off-by: Tim Smith <tsmith@chef.io>