### PR TITLE
Fix IncludePropertyDescriptions to catch all occurrences

### DIFF
--- a/lib/rubocop/cop/chef/sharing/include_property_descriptions.rb
+++ b/lib/rubocop/cop/chef/sharing/include_property_descriptions.rb
@@ -29,7 +29,7 @@ module RuboCop
         #   # good
         #   property :foo, String, description: "Set the important thing to..."
         #
-        class IncludePropertyDescriptions < Cop
+        class IncludePropertyDescriptions < Base
           extend TargetChefVersion
 
           minimum_target_chef_version '13.9'
@@ -40,11 +40,11 @@ module RuboCop
           def_node_matcher :property?, '(send nil? :property (sym _) ...)'
 
           # hash that contains description in any order (that's the <> bit)
-          def_node_search :description_hash, '(hash <(pair (sym :description) ...) ...>)'
+          def_node_search :description_hash?, '(hash <(pair (sym :description) ...) ...>)'
 
           def on_send(node)
             property?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor) unless description_hash(processed_source.ast).any?
+              add_offense(node.loc.expression, message: MSG, severity: :refactor) unless description_hash?(node)
             end
           end
         end

--- a/spec/rubocop/cop/chef/sharing/include_property_descriptions_spec.rb
+++ b/spec/rubocop/cop/chef/sharing/include_property_descriptions_spec.rb
@@ -23,6 +23,7 @@ describe RuboCop::Cop::Chef::ChefSharing::IncludePropertyDescriptions, :config d
 
   it 'registers an offense when a property does not include a description' do
     expect_offense(<<~RUBY)
+    property :different_prop, String, description: 'this one has a description'
     property :foo, String, name_property: true
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resource properties should include description fields to allow automated documentation. Requires Chef Infra Client 13.9 or later.
     RUBY
@@ -37,8 +38,7 @@ describe RuboCop::Cop::Chef::ChefSharing::IncludePropertyDescriptions, :config d
 
   it "doesn't register an offense when a property contains a description" do
     expect_no_offenses(<<~RUBY)
-      resource_name 'foo'
-      description 'foo does a thing'
+      property :foo, String, description: 'foo'
     RUBY
   end
 


### PR DESCRIPTION
By searching processed_source.ast the cop wouldn't fire if *any* property in the resource had a description. Now it properly requires the property it's looking at the have a description.

Signed-off-by: Tim Smith <tsmith@chef.io>