### PR TITLE
Update Deprecations rules to latest RuboCop format

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
@@ -30,6 +30,7 @@ module RuboCop
         #
         class ChefHandlerRecipe < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'There is no need to include the empty and deprecated chef_handler::default recipe in order to use the chef_handler resource'
 
@@ -37,7 +38,6 @@ module RuboCop
             (send nil? :include_recipe (str {"chef_handler" "chef_handler::default"}))
           PATTERN
 
-          extend AutoCorrector
           def on_send(node)
             chef_handler_recipe?(node) do
               add_offense(node, message: MSG, severity: :refactor) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
@@ -28,7 +28,7 @@ module RuboCop
         #   include_recipe 'chef_handler'
         #   include_recipe 'chef_handler::default'
         #
-        class ChefHandlerRecipe < Cop
+        class ChefHandlerRecipe < Base
           include RangeHelp
 
           MSG = 'There is no need to include the empty and deprecated chef_handler::default recipe in order to use the chef_handler resource'
@@ -37,15 +37,12 @@ module RuboCop
             (send nil? :include_recipe (str {"chef_handler" "chef_handler::default"}))
           PATTERN
 
+          extend AutoCorrector
           def on_send(node)
             chef_handler_recipe?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
@@ -34,22 +34,19 @@ module RuboCop
         #     type start: true, report: true, exception: true
         #   end
         #
-        class ChefHandlerUsesSupports < Cop
+        class ChefHandlerUsesSupports < Base
           include RuboCop::Chef::CookbookHelpers
 
           MSG = 'Use the type property instead of the deprecated supports property in the chef_handler resource. The supports property was removed in chef_handler cookbook version 3.0 (June 2017) and Chef Infra Client 14.0.'
 
+          extend AutoCorrector
           def on_block(node)
             match_property_in_resource?(:chef_handler, 'supports', node) do |prop_node|
-              add_offense(prop_node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              # make sure to delete leading and trailing {}s that would create invalid ruby syntax
-              extracted_val = node.arguments.first.source.gsub(/{|}/, '')
-              corrector.replace(node.loc.expression, "type #{extracted_val}")
+              add_offense(prop_node, message: MSG, severity: :warning) do |corrector|
+                # make sure to delete leading and trailing {}s that would create invalid ruby syntax
+                extracted_val = prop_node.arguments.first.source.gsub(/{|}/, '')
+                corrector.replace(prop_node.loc.expression, "type #{extracted_val}")
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
@@ -36,10 +36,10 @@ module RuboCop
         #
         class ChefHandlerUsesSupports < Base
           include RuboCop::Chef::CookbookHelpers
+          extend AutoCorrector
 
           MSG = 'Use the type property instead of the deprecated supports property in the chef_handler resource. The supports property was removed in chef_handler cookbook version 3.0 (June 2017) and Chef Infra Client 14.0.'
 
-          extend AutoCorrector
           def on_block(node)
             match_property_in_resource?(:chef_handler, 'supports', node) do |prop_node|
               add_offense(prop_node, message: MSG, severity: :warning) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/chef_rest.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rest.rb
@@ -28,7 +28,7 @@ module RuboCop
         #   require 'chef/rest'
         #   Chef::REST::RESTRequest.new(:GET, FOO, nil).call
         #
-        class UsesChefRESTHelpers < Cop
+        class UsesChefRESTHelpers < Base
           MSG = "Don't use the helpers in Chef::REST which were removed in Chef Infra Client 13"
 
           def_node_matcher :require_rest?, <<-PATTERN
@@ -41,13 +41,13 @@ module RuboCop
 
           def on_send(node)
             require_rest?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
           end
 
           def on_const(node)
             rest_const?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
@@ -39,6 +39,7 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
           include RangeHelp
           extend TargetChefVersion
+          extend AutoCorrector
 
           minimum_target_chef_version '12.10'
 
@@ -61,54 +62,33 @@ module RuboCop
             (send nil? ${:rewind :unwind} ... )
           PATTERN
 
-          extend AutoCorrector
           def on_send(node)
             rewind_gem_install?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|
-                fixer(node, corrector)
+                node = node.parent if node.parent&.block_type? # make sure we get the whole block not just the method in the block
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
               end
             end
 
             require_rewind?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|
-                fixer(node, corrector)
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
               end
             end
 
-            rewind_resources?(node) do
+            rewind_resources?(node) do |string|
               add_offense(node, message: MSG, severity: :warning) do |corrector|
-                fixer(node, corrector)
+                corrector.replace(node.loc.expression, node.source.gsub(string.to_s, MAPPING[string]))
               end
             end
           end
 
           def on_block(node)
             match_property_in_resource?(:chef_gem, 'package_name', node) do |pkg_name|
+              next unless pkg_name.arguments&.first&.str_content == 'chef-rewind'
               add_offense(node, message: MSG, severity: :warning) do |corrector|
-                fixer(node, corrector)
-              end if pkg_name.arguments&.first&.str_content == 'chef-rewind'
-            end
-          end
-
-          def fixer(node, corrector)
-            rewind_gem_install?(node) do
-              node = node.parent if node.parent&.block_type? # make sure we get the whole block not just the method in the block
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
-              return
-            end
-
-            require_rewind?(node) do
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
-              return
-            end
-
-            match_property_in_resource?(:chef_gem, 'package_name', node) do |pkg_name|
-              corrector.remove(node.loc.expression) if pkg_name.arguments&.first&.str_content == 'chef-rewind'
-              return
-            end
-
-            rewind_resources?(node) do |string|
-              corrector.replace(node.loc.expression, node.source.gsub(string.to_s, MAPPING[string]))
+                corrector.remove(node.loc.expression) if pkg_name.arguments&.first&.str_content == 'chef-rewind'
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
@@ -30,7 +30,7 @@ module RuboCop
         #   platform?('windows')
         #   platform_family?('windows')
         #
-        class ChefWindowsPlatformHelper < Cop
+        class ChefWindowsPlatformHelper < Base
           MSG = "Use `platform?('windows')` instead of the legacy `Chef::Platform.windows?` helper."
 
           def_node_matcher :chef_platform_windows?, <<-PATTERN
@@ -39,15 +39,12 @@ module RuboCop
                 (const nil? :Chef) :Platform) :windows?)
           PATTERN
 
+          extend AutoCorrector
           def on_send(node)
             chef_platform_windows?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, "platform?('windows')")
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(node.loc.expression, "platform?('windows')")
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
@@ -31,6 +31,7 @@ module RuboCop
         #   platform_family?('windows')
         #
         class ChefWindowsPlatformHelper < Base
+          extend AutoCorrector
           MSG = "Use `platform?('windows')` instead of the legacy `Chef::Platform.windows?` helper."
 
           def_node_matcher :chef_platform_windows?, <<-PATTERN
@@ -39,7 +40,6 @@ module RuboCop
                 (const nil? :Chef) :Platform) :windows?)
           PATTERN
 
-          extend AutoCorrector
           def on_send(node)
             chef_platform_windows?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/chefdk_generators.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefdk_generators.rb
@@ -38,18 +38,15 @@ module RuboCop
         #     ...
         #   end
         #
-        class ChefDKGenerators < Cop
+        class ChefDKGenerators < Base
           MSG = 'When writing cookbook generators use the ChefCLI module instead of the ChefDK module which was removed in Chef Workstation 0.8 and later.'
 
+          extend AutoCorrector
           def on_const(node)
             # We want to catch calls like ChefCLI::CLI.whatever or places where classes are defined in the ChefDK module
             return unless node.const_name == 'ChefDK' && (node.parent&.module_type? || node.parent&.const_type?)
 
-            add_offense(node, location: :expression, message: MSG, severity: :warning)
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(node, message: MSG, severity: :warning) do |corrector|
               corrector.replace(node.loc.expression, node.source.gsub('ChefDK', 'ChefCLI'))
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/chefdk_generators.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefdk_generators.rb
@@ -39,9 +39,9 @@ module RuboCop
         #   end
         #
         class ChefDKGenerators < Base
+          extend AutoCorrector
           MSG = 'When writing cookbook generators use the ChefCLI module instead of the ChefDK module which was removed in Chef Workstation 0.8 and later.'
 
-          extend AutoCorrector
           def on_const(node)
             # We want to catch calls like ChefCLI::CLI.whatever or places where classes are defined in the ChefDK module
             return unless node.const_name == 'ChefDK' && (node.parent&.module_type? || node.parent&.const_type?)

--- a/lib/rubocop/cop/chef/deprecation/cheffile.rb
+++ b/lib/rubocop/cop/chef/deprecation/cheffile.rb
@@ -28,9 +28,6 @@ module RuboCop
           MSG = 'The Librarian-Chef depsolving project is no longer maintained and a Cheffile should not be used for cookbook depsolving. Consider using Policyfiles instead.'
 
           def on_new_investigation
-            f_name = processed_source.file_path
-            return if processed_source.blank? && f_name != 'Cheffile'
-
             # Using range similar to RuboCop::Cop::Naming::Filename (file_name.rb)
             range = source_range(processed_source.buffer, 1, 0)
 

--- a/lib/rubocop/cop/chef/deprecation/cheffile.rb
+++ b/lib/rubocop/cop/chef/deprecation/cheffile.rb
@@ -22,18 +22,19 @@ module RuboCop
       # The Librarian-Chef depsolving project is no longer maintained and a Cheffile should not be used for cookbook depsolving. Consider using Policyfiles instead. If the Policyfiles model is not compatible with your workflow you may find Berkshelf offers a more similar, and still supported, experience to Librarian-Chef.
       #
       module ChefDeprecations
-        class Cheffile < Cop
+        class Cheffile < Base
           include RangeHelp
 
           MSG = 'The Librarian-Chef depsolving project is no longer maintained and a Cheffile should not be used for cookbook depsolving. Consider using Policyfiles instead.'
 
-          def investigate(processed_source)
-            return if processed_source.blank?
+          def on_new_investigation
+            f_name = processed_source.file_path
+            return if processed_source.blank? && f_name != 'Cheffile'
 
             # Using range similar to RuboCop::Cop::Naming::Filename (file_name.rb)
             range = source_range(processed_source.buffer, 1, 0)
 
-            add_offense(nil, location: range, message: MSG, severity: :warning)
+            add_offense(range, message: MSG, severity: :warning)
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
@@ -28,22 +28,19 @@ module RuboCop
         #
         #   at_exit { ChefSpec::Coverage.report! }
         #
-        class ChefSpecCoverageReport < Cop
+        class ChefSpecCoverageReport < Base
           MSG = "Don't use the deprecated ChefSpec coverage report functionality in your specs."
 
           def_node_matcher :coverage_reporter?, <<-PATTERN
           (block (send nil? :at_exit ) (args) (send (const (const nil? :ChefSpec) :Coverage) :report!))
           PATTERN
 
+          extend AutoCorrector
           def on_block(node)
             coverage_reporter?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(node.loc.expression)
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.remove(node.loc.expression)
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
@@ -29,13 +29,13 @@ module RuboCop
         #   at_exit { ChefSpec::Coverage.report! }
         #
         class ChefSpecCoverageReport < Base
+          extend AutoCorrector
           MSG = "Don't use the deprecated ChefSpec coverage report functionality in your specs."
 
           def_node_matcher :coverage_reporter?, <<-PATTERN
           (block (send nil? :at_exit ) (args) (send (const (const nil? :ChefSpec) :Coverage) :report!))
           PATTERN
 
-          extend AutoCorrector
           def on_block(node)
             coverage_reporter?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
@@ -41,13 +41,13 @@ module RuboCop
         #   end
         #
         class ChefSpecLegacyRunner < Base
+          extend AutoCorrector
           MSG = 'Use ChefSpec::SoloRunner or ChefSpec::ServerRunner instead of the deprecated ChefSpec::Runner.'
 
           def_node_matcher :chefspec_runner?, <<-PATTERN
           (const (const nil? :ChefSpec) :Runner)
           PATTERN
 
-          extend AutoCorrector
           def on_const(node)
             chefspec_runner?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
@@ -40,22 +40,19 @@ module RuboCop
         #     # some spec code
         #   end
         #
-        class ChefSpecLegacyRunner < Cop
+        class ChefSpecLegacyRunner < Base
           MSG = 'Use ChefSpec::SoloRunner or ChefSpec::ServerRunner instead of the deprecated ChefSpec::Runner.'
 
           def_node_matcher :chefspec_runner?, <<-PATTERN
           (const (const nil? :ChefSpec) :Runner)
           PATTERN
 
+          extend AutoCorrector
           def on_const(node)
             chefspec_runner?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, 'ChefSpec::ServerRunner')
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(node.loc.expression, 'ChefSpec::ServerRunner')
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action.rb
@@ -34,22 +34,19 @@ module RuboCop
         #     action :remove
         #   end
         #
-        class ChocolateyPackageUninstallAction < Cop
+        class ChocolateyPackageUninstallAction < Base
           include RuboCop::Chef::CookbookHelpers
 
           MSG = 'Use the :remove action in the chocolatey_package resource instead of :uninstall which was removed in Chef Infra Client 14+'
 
+          extend AutoCorrector
           def on_block(node)
             match_property_in_resource?(:chocolatey_package, 'action', node) do |choco_action|
               choco_action.arguments.each do |action|
-                add_offense(action, location: :expression, message: MSG, severity: :warning) if action.source == ':uninstall'
+                add_offense(action, message: MSG, severity: :warning) do |corrector|
+                  corrector.replace(action, ':remove')
+                end if action.source == ':uninstall'
               end
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, ':remove')
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action.rb
@@ -36,16 +36,17 @@ module RuboCop
         #
         class ChocolateyPackageUninstallAction < Base
           include RuboCop::Chef::CookbookHelpers
+          extend AutoCorrector
 
           MSG = 'Use the :remove action in the chocolatey_package resource instead of :uninstall which was removed in Chef Infra Client 14+'
 
-          extend AutoCorrector
           def on_block(node)
             match_property_in_resource?(:chocolatey_package, 'action', node) do |choco_action|
               choco_action.arguments.each do |action|
+                next unless action.source == ':uninstall'
                 add_offense(action, message: MSG, severity: :warning) do |corrector|
                   corrector.replace(action, ':remove')
-                end if action.source == ':uninstall'
+                end
               end
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
@@ -26,7 +26,7 @@ module RuboCop
         #   # bad
         #   depends 'compat_resource'
         #
-        class CookbookDependsOnCompatResource < Cop
+        class CookbookDependsOnCompatResource < Base
           include RangeHelp
           extend TargetChefVersion
 
@@ -38,15 +38,12 @@ module RuboCop
             (send nil? :depends (str {"compat_resource"}))
           PATTERN
 
+          extend AutoCorrector
           def on_send(node)
             depends_compat_resource?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
@@ -26,7 +26,7 @@ module RuboCop
         #   # bad
         #   depends 'partial_search'
         #
-        class CookbookDependsOnPartialSearch < Cop
+        class CookbookDependsOnPartialSearch < Base
           extend TargetChefVersion
 
           minimum_target_chef_version '13.0'
@@ -39,7 +39,7 @@ module RuboCop
 
           def on_send(node)
             depends_partial_search?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/depends_poise.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_poise.rb
@@ -27,7 +27,7 @@ module RuboCop
         #   depends 'poise'
         #   depends 'poise-service'
         #
-        class CookbookDependsOnPoise < Cop
+        class CookbookDependsOnPoise < Base
           MSG = 'Cookbooks should not depend on the deprecated Poise framework'
 
           def_node_matcher :depends_method?, <<-PATTERN
@@ -36,7 +36,7 @@ module RuboCop
 
           def on_send(node)
             depends_method?(node) do |arg|
-              add_offense(node, location: :expression, message: MSG, severity: :warning) if %w(poise poise-service).include?(arg.value)
+              add_offense(node, message: MSG, severity: :warning) if %w(poise poise-service).include?(arg.value)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_chefspec_platform.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_chefspec_platform.rb
@@ -26,7 +26,7 @@ module RuboCop
         #
         #   let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04') }
         #
-        class DeprecatedChefSpecPlatform < Cop
+        class DeprecatedChefSpecPlatform < Base
           include RuboCop::Chef::CookbookHelpers
 
           MSG = "Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3"
@@ -114,19 +114,14 @@ module RuboCop
             nil # we don't have a replacement os return nil
           end
 
+          extend AutoCorrector
           def on_send(node)
             chefspec_definition?(node) do |plat, ver|
-              add_offense(node, location: :expression, message: MSG, severity: :warning) if legacy_chefspec_platform(plat.value, ver.value)
-            end
-          end
-
-          def autocorrect(node)
-            chefspec_definition?(node) do |plat, ver|
-              if replacement = replacement_string(plat.value, ver.value) # rubocop: disable Lint/AssignmentInCondition
-                lambda do |corrector|
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                if replacement = replacement_string(plat.value, ver.value) # rubocop: disable Lint/AssignmentInCondition
                   corrector.replace(ver.loc.expression, "'#{replacement}'")
                 end
-              end
+              end if legacy_chefspec_platform(plat.value, ver.value)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_chefspec_platform.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_chefspec_platform.rb
@@ -28,6 +28,7 @@ module RuboCop
         #
         class DeprecatedChefSpecPlatform < Base
           include RuboCop::Chef::CookbookHelpers
+          extend AutoCorrector
 
           MSG = "Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3"
 
@@ -114,14 +115,14 @@ module RuboCop
             nil # we don't have a replacement os return nil
           end
 
-          extend AutoCorrector
           def on_send(node)
             chefspec_definition?(node) do |plat, ver|
+              next unless legacy_chefspec_platform(plat.value, ver.value)
               add_offense(node, message: MSG, severity: :warning) do |corrector|
                 if replacement = replacement_string(plat.value, ver.value) # rubocop: disable Lint/AssignmentInCondition
                   corrector.replace(ver.loc.expression, "'#{replacement}'")
                 end
-              end if legacy_chefspec_platform(plat.value, ver.value)
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
@@ -36,6 +36,7 @@ module RuboCop
         #
         class UsesDeprecatedMixins < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = "Don't use deprecated Mixins no longer included in Chef Infra Client 14 and later."
 
@@ -51,29 +52,24 @@ module RuboCop
             (send nil? :require ( str {"chef/mixin/language" "chef/mixin/language_include_attribute" "chef/mixin/language_include_recipe"}))
           PATTERN
 
-          extend AutoCorrector
           def on_send(node)
             deprecated_mixin?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|
-                fixer(node, corrector)
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
               end
             end
 
             deprecated_dsl?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|
-                fixer(node, corrector)
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
               end
             end
 
             dsl_mixin_require?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|
-                fixer(node, corrector)
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
               end
             end
-          end
-
-          def fixer(node, corrector)
-            corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
@@ -34,7 +34,7 @@ module RuboCop
         #   require 'chef/mixin/language_include_attribute'
         #   require 'chef/mixin/language_include_recipe'
         #
-        class UsesDeprecatedMixins < Cop
+        class UsesDeprecatedMixins < Base
           include RangeHelp
 
           MSG = "Don't use deprecated Mixins no longer included in Chef Infra Client 14 and later."
@@ -51,24 +51,29 @@ module RuboCop
             (send nil? :require ( str {"chef/mixin/language" "chef/mixin/language_include_attribute" "chef/mixin/language_include_recipe"}))
           PATTERN
 
+          extend AutoCorrector
           def on_send(node)
             deprecated_mixin?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                fixer(node, corrector)
+              end
             end
 
             deprecated_dsl?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                fixer(node, corrector)
+              end
             end
 
             dsl_mixin_require?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                fixer(node, corrector)
+              end
             end
           end
 
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
-            end
+          def fixer(node, corrector)
+            corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_platform_methods.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_platform_methods.rb
@@ -38,7 +38,7 @@ module RuboCop
         #   resource = Chef::Resource::File.new("/tmp/foo.xyz", run_context)
         #   provider = resource.provider_for_action(:create)
         #
-        class DeprecatedPlatformMethods < Cop
+        class DeprecatedPlatformMethods < Base
           MSG = 'Use provider_for_action instead of the deprecated Chef::Platform methods in resources, which were removed in Chef Infra Client 13.'
 
           def_node_matcher :platform_method?, <<-PATTERN
@@ -47,7 +47,7 @@ module RuboCop
 
           def on_send(node)
             platform_method?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
@@ -39,7 +39,7 @@ module RuboCop
         #   shell_out!('foo')
         #   shell_out!('foo', default_env: false) # replaces shell_out_with_systems_locale
         #
-        class DeprecatedShelloutMethods < Cop
+        class DeprecatedShelloutMethods < Base
           extend TargetChefVersion
 
           minimum_target_chef_version '14.3'
@@ -57,7 +57,7 @@ module RuboCop
           MSG = 'Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :warning) if DEPRECATED_SHELLOUT_METHODS.include?(node.method_name)
+            add_offense(node, message: MSG, severity: :warning) if DEPRECATED_SHELLOUT_METHODS.include?(node.method_name)
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_windows_version_check.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_windows_version_check.rb
@@ -28,11 +28,11 @@ module RuboCop
         #     # do some legacy things
         #   end
         #
-        class DeprecatedWindowsVersionCheck < Cop
+        class DeprecatedWindowsVersionCheck < Base
           MSG = "Don't use the deprecated older_than_win_2012_or_8? helper. Windows versions before 2012 and 8 are now end of life and this helper will always return false."
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :older_than_win_2012_or_8?
+            add_offense(node, message: MSG, severity: :warning) if node.method_name == :older_than_win_2012_or_8?
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_properties.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_properties.rb
@@ -44,12 +44,12 @@ module RuboCop
         class DeprecatedYumRepositoryProperties < Base
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
+          extend AutoCorrector
 
           minimum_target_chef_version '12.14'
 
           MSG = 'With the release of Chef Infra Client 12.14 and the yum cookbook 3.0 several properties in the yum_repository resource were renamed. url -> baseurl, keyurl -> gpgkey, and mirrorexpire -> mirror_expire.'
 
-          extend AutoCorrector
           def on_block(node)
             %w(url keyurl mirrorexpire).each do |prop|
               match_property_in_resource?(:yum_repository, prop, node) do |prop_node|

--- a/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_properties.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_properties.rb
@@ -41,7 +41,7 @@ module RuboCop
         #     action :create
         #   end
         #
-        class DeprecatedYumRepositoryProperties < Cop
+        class DeprecatedYumRepositoryProperties < Base
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
 
@@ -49,17 +49,17 @@ module RuboCop
 
           MSG = 'With the release of Chef Infra Client 12.14 and the yum cookbook 3.0 several properties in the yum_repository resource were renamed. url -> baseurl, keyurl -> gpgkey, and mirrorexpire -> mirror_expire.'
 
+          extend AutoCorrector
           def on_block(node)
             %w(url keyurl mirrorexpire).each do |prop|
               match_property_in_resource?(:yum_repository, prop, node) do |prop_node|
-                add_offense(prop_node, location: :expression, message: MSG, severity: :warning)
+                add_offense(prop_node, message: MSG, severity: :warning)  do |corrector|
+                  corrector.replace(prop_node.loc.expression, prop_node.loc.expression.source
+                    .gsub(/^url/, 'baseurl')
+                    .gsub(/^keyurl/, 'gpgkey')
+                    .gsub(/^mirrorexpire/, 'mirror_expire'))
+                end
               end
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, node.loc.expression.source.gsub(/^url/, 'baseurl').gsub(/^keyurl/, 'gpgkey').gsub(/^mirrorexpire/, 'mirror_expire'))
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/easy_install.rb
+++ b/lib/rubocop/cop/chef/deprecation/easy_install.rb
@@ -29,11 +29,11 @@ module RuboCop
         #     bar
         #   end
         #
-        class EasyInstallResource < Cop
+        class EasyInstallResource < Base
           MSG = "Don't use the deprecated easy_install resource removed in Chef Infra Client 13"
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :easy_install
+            add_offense(node, message: MSG, severity: :warning) if node.method_name == :easy_install
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/eol_audit_mode.rb
+++ b/lib/rubocop/cop/chef/deprecation/eol_audit_mode.rb
@@ -32,14 +32,14 @@ module RuboCop
         #     end
         #   end
 
-        class EOLAuditModeUsage < Cop
+        class EOLAuditModeUsage < Base
           MSG = 'The beta Audit Mode feature in Chef Infra Client was removed in Chef Infra Client 15.0. Users should instead use InSpec and the audit cookbook. See https://www.inspec.io/ for more information.'
 
           def_node_matcher :control_group?, '(send nil? :control_group ...)'
 
           def on_send(node)
             control_group?(node) do
-              add_offense(node, location: :selector, message: MSG, severity: :warning)
+              add_offense(node.loc.selector, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/epic_fail.rb
+++ b/lib/rubocop/cop/chef/deprecation/epic_fail.rb
@@ -35,13 +35,15 @@ module RuboCop
         #   end
         #
         class EpicFail < Base
+          extend AutoCorrector
+
           MSG = 'Use ignore_failure method instead of the deprecated epic_fail method'
 
-          extend AutoCorrector
           def on_send(node)
+            return unless node.method_name == :epic_fail
             add_offense(node, message: MSG, severity: :warning) do |corrector|
               corrector.replace(node.loc.expression, 'ignore_failure true')
-            end if node.method_name == :epic_fail
+            end
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/epic_fail.rb
+++ b/lib/rubocop/cop/chef/deprecation/epic_fail.rb
@@ -34,17 +34,14 @@ module RuboCop
         #     ignore_failure true
         #   end
         #
-        class EpicFail < Cop
+        class EpicFail < Base
           MSG = 'Use ignore_failure method instead of the deprecated epic_fail method'
 
+          extend AutoCorrector
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :epic_fail
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(node, message: MSG, severity: :warning) do |corrector|
               corrector.replace(node.loc.expression, 'ignore_failure true')
-            end
+            end if node.method_name == :epic_fail
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/erl_call.rb
+++ b/lib/rubocop/cop/chef/deprecation/erl_call.rb
@@ -29,11 +29,11 @@ module RuboCop
         #     bar
         #   end
         #
-        class ErlCallResource < Cop
+        class ErlCallResource < Base
           MSG = "Don't use the deprecated erl_call resource removed in Chef Infra Client 13"
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :erl_call
+            add_offense(node, message: MSG, severity: :warning) if node.method_name == :erl_call
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/hwrp_without_provides.rb
+++ b/lib/rubocop/cop/chef/deprecation/hwrp_without_provides.rb
@@ -83,6 +83,8 @@ module RuboCop
         #  Convert your legacy HWRPs to custom resources
         #
         class HWRPWithoutProvides < Base
+          extend AutoCorrector
+
           MSG = 'In Chef Infra Client 16 and later a legacy HWRP resource must use `provides` to define how the resource is called in recipes or other resources. To maintain compatibility with Chef Infra Client < 16 use both `resource_name` and `provides`.'
 
           def_node_matcher :HWRP?, <<-PATTERN
@@ -101,7 +103,6 @@ module RuboCop
           def_node_search :resource_name_ast, '$(send nil? :resource_name ...)'
           def_node_search :resource_name, '(send nil? :resource_name (sym $_))'
 
-          extend AutoCorrector
           def on_class(node)
             return if has_provides?
             HWRP?(node) do |inherit|

--- a/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
@@ -37,22 +37,19 @@ module RuboCop
         #  # better
         #  Write a custom resource using the custom resource DSL and avoid class based HWRPs entirely
         #
-        class ResourceInheritsFromCompatResource < Cop
+        class ResourceInheritsFromCompatResource < Base
           MSG = "HWRP style resource should inherit from the 'Chef::Resource' class and not the 'ChefCompat::Resource' class from the deprecated compat_resource cookbook."
 
           def_node_matcher :inherits_from_compat_resource?, <<-PATTERN
           (class (const nil? _ ) (const (const nil? :ChefCompat) :Resource) ... )
           PATTERN
 
+          extend AutoCorrector
           def on_class(node)
             inherits_from_compat_resource?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, node.loc.expression.source.gsub('ChefCompat', 'Chef'))
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(node.loc.expression, node.loc.expression.source.gsub('ChefCompat', 'Chef'))
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
@@ -38,13 +38,14 @@ module RuboCop
         #  Write a custom resource using the custom resource DSL and avoid class based HWRPs entirely
         #
         class ResourceInheritsFromCompatResource < Base
+          extend AutoCorrector
+
           MSG = "HWRP style resource should inherit from the 'Chef::Resource' class and not the 'ChefCompat::Resource' class from the deprecated compat_resource cookbook."
 
           def_node_matcher :inherits_from_compat_resource?, <<-PATTERN
           (class (const nil? _ ) (const (const nil? :ChefCompat) :Resource) ... )
           PATTERN
 
-          extend AutoCorrector
           def on_class(node)
             inherits_from_compat_resource?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/launchd_deprecated_hash_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/launchd_deprecated_hash_property.rb
@@ -33,23 +33,20 @@ module RuboCop
         #     plist_hash foo: 'bar'
         #   end
         #
-        class LaunchdDeprecatedHashProperty < Cop
+        class LaunchdDeprecatedHashProperty < Base
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
+          extend AutoCorrector
 
           minimum_target_chef_version '12.19'
 
           MSG = "The launchd resource's hash property was renamed to plist_hash in Chef Infra Client 13+ to avoid conflicts with Ruby's hash class."
 
           def on_block(node)
-            match_property_in_resource?(:launchd, 'hash', node) do |hash_prop|
-              add_offense(hash_prop, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, node.loc.expression.source.gsub(/^hash/, 'plist_hash'))
+            return unless match_property_in_resource?(:launchd, 'hash', node) do |offense|
+              add_offense(offense.loc.expression, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(offense.loc.expression, offense.loc.expression.source.gsub(/^hash/, 'plist_hash'))
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/launchd_deprecated_hash_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/launchd_deprecated_hash_property.rb
@@ -43,7 +43,7 @@ module RuboCop
           MSG = "The launchd resource's hash property was renamed to plist_hash in Chef Infra Client 13+ to avoid conflicts with Ruby's hash class."
 
           def on_block(node)
-            return unless match_property_in_resource?(:launchd, 'hash', node) do |offense|
+            match_property_in_resource?(:launchd, 'hash', node) do |offense|
               add_offense(offense.loc.expression, message: MSG, severity: :warning) do |corrector|
                 corrector.replace(offense.loc.expression, offense.loc.expression.source.gsub(/^hash/, 'plist_hash'))
               end

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -57,33 +57,30 @@ module RuboCop
         #     subscribes :restart, "service[#{service_name_variable}]", :immediately
         #   end
         #
-        class LegacyNotifySyntax < Cop
+        class LegacyNotifySyntax < Base
           MSG = 'Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.'
 
           def_node_matcher :legacy_notify?, <<-PATTERN
             (send nil? ${:notifies :subscribes} $(sym _) (send nil? :resources (hash (pair $(sym _) $(...) ) ) ) $... )
           PATTERN
 
+          extend AutoCorrector
           def on_send(node)
             legacy_notify?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              legacy_notify?(node) do |notify_type, action, type, name, timing|
-                service_value = case name.type
-                                when :str
-                                  "'#{type.source}[#{name.value}]'"
-                                when :dstr
-                                  "\"#{type.source}[#{name.value.source}]\""
-                                else
-                                  "\"#{type.source}[\#{#{name.source}}]\""
-                                end
-                new_val = "#{notify_type} #{action.source}, #{service_value}".dup
-                new_val << ", #{timing.first.source}" unless timing.empty?
-                corrector.replace(node.loc.expression, new_val)
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                legacy_notify?(node) do |notify_type, action, type, name, timing|
+                  service_value = case name.type
+                                  when :str
+                                    "'#{type.source}[#{name.value}]'"
+                                  when :dstr
+                                    "\"#{type.source}[#{name.value.source}]\""
+                                  else
+                                    "\"#{type.source}[\#{#{name.source}}]\""
+                                  end
+                  new_val = "#{notify_type} #{action.source}, #{service_value}".dup
+                  new_val << ", #{timing.first.source}" unless timing.empty?
+                  corrector.replace(node.loc.expression, new_val)
+                end
               end
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
@@ -33,7 +33,7 @@ module RuboCop
         #   include_recipe 'yum::repoforge'
         #   include_recipe 'yum::yum'
         #
-        class LegacyYumCookbookRecipes < Cop
+        class LegacyYumCookbookRecipes < Base
           MSG = 'The elrepo, epel, ius, remi, and repoforge recipes were split into their own cookbooks and the yum recipe was renamed to be default with the release of yum cookbook 3.0 (Dec 2013).'
 
           def_node_matcher :old_yum_recipe?, <<-PATTERN
@@ -42,7 +42,7 @@ module RuboCop
 
           def on_send(node)
             old_yum_recipe?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/locale_lc_all_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/locale_lc_all_property.rb
@@ -29,14 +29,14 @@ module RuboCop
         #     lc_all 'en_gb.utf-8'
         #   end
         #
-        class LocaleDeprecatedLcAllProperty < Cop
+        class LocaleDeprecatedLcAllProperty < Base
           include RuboCop::Chef::CookbookHelpers
 
           MSG = "The local resource's lc_all property has been deprecated and will be removed in Chef Infra Client 17"
 
           def on_block(node)
             match_property_in_resource?(:locale, 'lc_all', node) do |property|
-              add_offense(property, location: :expression, message: MSG, severity: :warning)
+              add_offense(property, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
+++ b/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
@@ -31,8 +31,9 @@ module RuboCop
         #   property :config_file, String, name_property: true
         #   attribute :config_file, String, name_attribute: true
         #
-        class NamePropertyWithDefaultValue < Cop
+        class NamePropertyWithDefaultValue < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = "A resource property can't be marked as a name_property and also have a default value. This will fail in Chef Infra Client 13 or later."
 
@@ -45,15 +46,11 @@ module RuboCop
 
           def on_send(node)
             name_property_with_default?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              name_property_with_default?(node) do |default|
-                range = range_with_surrounding_comma(range_with_surrounding_space(range: default.loc.expression, side: :left), :left)
-                corrector.remove(range)
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                name_property_with_default?(node) do |default|
+                  range = range_with_surrounding_comma(range_with_surrounding_space(range: default.loc.expression, side: :left), :left)
+                  corrector.remove(range)
+                end
               end
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
+++ b/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
@@ -45,12 +45,10 @@ module RuboCop
           PATTERN
 
           def on_send(node)
-            name_property_with_default?(node) do
+            name_property_with_default?(node) do |default|
               add_offense(node, message: MSG, severity: :warning) do |corrector|
-                name_property_with_default?(node) do |default|
-                  range = range_with_surrounding_comma(range_with_surrounding_space(range: default.loc.expression, side: :left), :left)
-                  corrector.remove(range)
-                end
+                range = range_with_surrounding_comma(range_with_surrounding_space(range: default.loc.expression, side: :left), :left)
+                corrector.remove(range)
               end
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
@@ -39,7 +39,7 @@ module RuboCop
         #
         class NodeMethodsInsteadofAttributes < Base
           extend AutoCorrector
-          
+
           MSG = 'Use node attributes to access Ohai data instead of node methods, which were deprecated in Chef Infra Client 13.'
 
           def_node_matcher :node_ohai_methods?, <<-PATTERN

--- a/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
@@ -37,7 +37,9 @@ module RuboCop
         #   node['platform_version']
         #   node['hostname']
         #
-        class NodeMethodsInsteadofAttributes < Cop
+        class NodeMethodsInsteadofAttributes < Base
+          extend AutoCorrector
+          
           MSG = 'Use node attributes to access Ohai data instead of node methods, which were deprecated in Chef Infra Client 13.'
 
           def_node_matcher :node_ohai_methods?, <<-PATTERN
@@ -46,13 +48,9 @@ module RuboCop
 
           def on_send(node)
             node_ohai_methods?(node) do
-              add_offense(node, location: :selector, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, "node['#{node.method_name}']")
+              add_offense(node.loc.selector, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(node.loc.expression, "node['#{node.method_name}']")
+              end
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/node_set.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set.rb
@@ -32,7 +32,7 @@ module RuboCop
         #
         class NodeSet < Base
           extend AutoCorrector
-          
+
           MSG = 'Do not use node.set. Replace with node.normal to keep identical behavior.'
 
           def_node_matcher :node_set?, <<-PATTERN

--- a/lib/rubocop/cop/chef/deprecation/node_set.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set.rb
@@ -30,22 +30,19 @@ module RuboCop
         #   # good
         #   node.normal['foo'] = true
         #
-        class NodeSet < Cop
+        class NodeSet < Base
           MSG = 'Do not use node.set. Replace with node.normal to keep identical behavior.'
 
           def_node_matcher :node_set?, <<-PATTERN
             (send (send _ :node) $:set)
           PATTERN
 
+          extend AutoCorrector
           def on_send(node)
             node_set?(node) do
-              add_offense(node, location: :selector, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.selector, 'normal')
+              add_offense(node.loc.selector, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(node.loc.selector, 'normal')
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/node_set.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set.rb
@@ -31,13 +31,14 @@ module RuboCop
         #   node.normal['foo'] = true
         #
         class NodeSet < Base
+          extend AutoCorrector
+          
           MSG = 'Do not use node.set. Replace with node.normal to keep identical behavior.'
 
           def_node_matcher :node_set?, <<-PATTERN
             (send (send _ :node) $:set)
           PATTERN
 
-          extend AutoCorrector
           def on_send(node)
             node_set?(node) do
               add_offense(node.loc.selector, message: MSG, severity: :warning) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
@@ -32,7 +32,7 @@ module RuboCop
         #
         class NodeSetUnless < Base
           extend AutoCorrector
-          
+
           MSG = 'Do not use node.set_unless. Replace with node.normal_unless to keep identical behavior.'
 
           def_node_matcher :node_set_unless?, <<-PATTERN

--- a/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
@@ -32,6 +32,7 @@ module RuboCop
         #
         class NodeSetUnless < Base
           extend AutoCorrector
+          
           MSG = 'Do not use node.set_unless. Replace with node.normal_unless to keep identical behavior.'
 
           def_node_matcher :node_set_unless?, <<-PATTERN

--- a/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
@@ -30,7 +30,8 @@ module RuboCop
         #   # good
         #   node.normal_unless['foo'] = true
         #
-        class NodeSetUnless < Cop
+        class NodeSetUnless < Base
+          extend AutoCorrector
           MSG = 'Do not use node.set_unless. Replace with node.normal_unless to keep identical behavior.'
 
           def_node_matcher :node_set_unless?, <<-PATTERN
@@ -39,13 +40,9 @@ module RuboCop
 
           def on_send(node)
             node_set_unless?(node) do
-              add_offense(node, location: :selector, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.selector, 'normal_unless')
+              add_offense(node.loc.selector, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(node.loc.selector, 'normal_unless')
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/node_set_without_level.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set_without_level.rb
@@ -34,7 +34,7 @@ module RuboCop
         #   node.default['foo']['bar'] += 1
         #   node.default['foo']['bar'] -= 1
         #
-        class NodeSetWithoutLevel < Cop
+        class NodeSetWithoutLevel < Base
           MSG = 'When setting a node attribute in Chef Infra Client 11 and later you must specify the precedence level.'
 
           def on_op_asgn(node)
@@ -55,9 +55,9 @@ module RuboCop
 
           def add_offense_for_bare_assignment(sub_node)
             if sub_node.receiver == s(:send, nil, :node) # node['foo'] scenario
-              add_offense(sub_node.receiver, location: :selector, message: MSG, severity: :warning)
+              add_offense(sub_node.receiver.loc.selector, message: MSG, severity: :warning)
             elsif sub_node.receiver && sub_node.receiver&.node_parts[0] == s(:send, nil, :node) && sub_node.receiver&.node_parts[1] == :[] # node['foo']['bar'] scenario
-              add_offense(sub_node.receiver.node_parts.first, location: :selector, message: MSG, severity: :warning)
+              add_offense(sub_node.receiver.node_parts.first.loc.selector, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/node_set_without_level.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set_without_level.rb
@@ -56,7 +56,9 @@ module RuboCop
           def add_offense_for_bare_assignment(sub_node)
             if sub_node.receiver == s(:send, nil, :node) # node['foo'] scenario
               add_offense(sub_node.receiver.loc.selector, message: MSG, severity: :warning)
-            elsif sub_node.receiver && sub_node.receiver&.node_parts[0] == s(:send, nil, :node) && sub_node.receiver&.node_parts[1] == :[] # node['foo']['bar'] scenario
+            elsif sub_node.receiver &&
+                  sub_node.receiver&.node_parts[0] == s(:send, nil, :node) &&
+                  sub_node.receiver&.node_parts[1] == :[] # node['foo']['bar'] scenario
               add_offense(sub_node.receiver.node_parts.first.loc.selector, message: MSG, severity: :warning)
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/partial_search_class_usage.rb
+++ b/lib/rubocop/cop/chef/deprecation/partial_search_class_usage.rb
@@ -47,7 +47,7 @@ module RuboCop
         #     puts result['kernel_version']
         #   end
         #
-        class PartialSearchClassUsage < Cop
+        class PartialSearchClassUsage < Base
           MSG = 'Legacy Chef::PartialSearch class usage should be updated to use the search helper instead with the filter_result key.'
 
           def_node_matcher :partial_search_class?, <<-PATTERN
@@ -56,7 +56,7 @@ module RuboCop
 
           def on_send(node)
             partial_search_class?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/partial_search_helper_usage.rb
+++ b/lib/rubocop/cop/chef/deprecation/partial_search_helper_usage.rb
@@ -47,11 +47,11 @@ module RuboCop
         #     puts result['kernel_version']
         #   end
         #
-        class PartialSearchHelperUsage < Cop
+        class PartialSearchHelperUsage < Base
           MSG = 'Legacy partial_search usage should be updated to use :filter_result in the search helper instead'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :partial_search
+            add_offense(node, message: MSG, severity: :warning) if node.method_name == :partial_search
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/poise_archive.rb
+++ b/lib/rubocop/cop/chef/deprecation/poise_archive.rb
@@ -33,7 +33,7 @@ module RuboCop
         #     destination '/opt/my_app'
         #   end
         #
-        class PoiseArchiveUsage < Cop
+        class PoiseArchiveUsage < Base
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
           minimum_target_chef_version '15.0'
@@ -46,13 +46,13 @@ module RuboCop
 
           def on_send(node)
             depends_poise_archive?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
           end
 
           def on_block(node)
             match_resource_type?(:poise_archive, node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/powershell_cookbook_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/powershell_cookbook_helpers.rb
@@ -33,6 +33,8 @@ module RuboCop
         #   powershell_version == 4.0
         #
         class PowershellCookbookHelpers < Base
+          extend AutoCorrector
+
           MSG = "Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 15.8+ instead of the deprecated PowerShell cookbook helpers."
 
           def_node_matcher :ps_cb_helper?, <<-PATTERN
@@ -42,7 +44,6 @@ module RuboCop
             $(...))
           PATTERN
 
-          extend AutoCorrector
           def on_send(node)
             ps_cb_helper?(node) do |ver|
               add_offense(node, message: MSG, severity: :warning) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/powershell_cookbook_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/powershell_cookbook_helpers.rb
@@ -32,7 +32,7 @@ module RuboCop
         #   # better (Chef Infra Client 15.8+)
         #   powershell_version == 4.0
         #
-        class PowershellCookbookHelpers < Cop
+        class PowershellCookbookHelpers < Base
           MSG = "Use node['powershell']['version'] or the new powershell_version helper available in Chef Infra Client 15.8+ instead of the deprecated PowerShell cookbook helpers."
 
           def_node_matcher :ps_cb_helper?, <<-PATTERN
@@ -42,15 +42,10 @@ module RuboCop
             $(...))
           PATTERN
 
+          extend AutoCorrector
           def on_send(node)
-            ps_cb_helper?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              ps_cb_helper?(node) do |ver|
+            ps_cb_helper?(node) do |ver|
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
                 corrector.replace(node.loc.expression, "node['powershell']['version'].to_f == #{ver.source}")
               end
             end

--- a/lib/rubocop/cop/chef/deprecation/require_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/require_recipe.rb
@@ -31,13 +31,14 @@ module RuboCop
         #   include_recipe 'foo'
         #
         class RequireRecipe < Base
+          extend AutoCorrector
+          
           MSG = 'Use include_recipe instead of the require_recipe method'
 
           def_node_matcher :require_recipe?, <<-PATTERN
             (send nil? :require_recipe $str)
           PATTERN
 
-          extend AutoCorrector
           def on_send(node)
             require_recipe?(node) do 
               add_offense(node.loc.selector, message: MSG, severity: :warning) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/require_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/require_recipe.rb
@@ -30,20 +30,19 @@ module RuboCop
         #   # good
         #   include_recipe 'foo'
         #
-        class RequireRecipe < Cop
+        class RequireRecipe < Base
           MSG = 'Use include_recipe instead of the require_recipe method'
 
           def_node_matcher :require_recipe?, <<-PATTERN
             (send nil? :require_recipe $str)
           PATTERN
 
+          extend AutoCorrector
           def on_send(node)
-            require_recipe?(node) { add_offense(node, location: :selector, message: MSG, severity: :warning) }
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.selector, 'include_recipe')
+            require_recipe?(node) do 
+              add_offense(node.loc.selector, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(node.loc.selector, 'include_recipe')
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/require_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/require_recipe.rb
@@ -32,7 +32,7 @@ module RuboCop
         #
         class RequireRecipe < Base
           extend AutoCorrector
-          
+
           MSG = 'Use include_recipe instead of the require_recipe method'
 
           def_node_matcher :require_recipe?, <<-PATTERN
@@ -40,7 +40,7 @@ module RuboCop
           PATTERN
 
           def on_send(node)
-            require_recipe?(node) do 
+            require_recipe?(node) do
               add_offense(node.loc.selector, message: MSG, severity: :warning) do |corrector|
                 corrector.replace(node.loc.selector, 'include_recipe')
               end

--- a/lib/rubocop/cop/chef/deprecation/resource_overrides_provides_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_overrides_provides_method.rb
@@ -31,14 +31,14 @@ module RuboCop
         #   # good
         #   provides :SOME_PROVIDER_NAME
         #
-        class ResourceOverridesProvidesMethod < Cop
+        class ResourceOverridesProvidesMethod < Base
           MSG = "Don't override the provides? method in a resource provider. Use provides :SOME_PROVIDER_NAME instead. This will cause failures in Chef Infra Client 13 and later."
 
           def_node_search :provides, '(send nil? :provides ...)'
 
           def on_def(node)
             if node.method_name == :provides?
-              add_offense(node, location: :expression, message: MSG, severity: :warning) if provides(processed_source.ast).count == 0
+              add_offense(node, message: MSG, severity: :warning) if provides(processed_source.ast).count == 0
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_dsl_name_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_dsl_name_method.rb
@@ -29,11 +29,11 @@ module RuboCop
         #   # good
         #   my_resource = MyResource.resource_name
         #
-        class ResourceUsesDslNameMethod < Cop
+        class ResourceUsesDslNameMethod < Base
           MSG = 'Use resource_name instead of the dsl_name method in resources. This will cause failures in Chef Infra Client 13 and later.'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :dsl_name
+            add_offense(node, message: MSG, severity: :warning) if node.method_name == :dsl_name
           end
 
           # potential autocorrect is new_resource.updated_by_last_action true, but we need to actually see what class we were called from

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_provider_base_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_provider_base_method.rb
@@ -26,11 +26,11 @@ module RuboCop
         #   # bad
         #   provider_base ::Chef::Provider::SomethingSomething
         #
-        class ResourceUsesProviderBaseMethod < Cop
+        class ResourceUsesProviderBaseMethod < Base
           MSG = "Don't use the deprecated provider_base method in a resource to specify the provider module to use. Instead, the provider should call provides to register itself, or the resource should call provider to specify the provider to use. This will cause failures in Chef Infra Client 13 and later."
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.method_name == :provider_base
+            add_offense(node, message: MSG, severity: :warning) if node.method_name == :provider_base
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_updated_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_updated_method.rb
@@ -34,11 +34,11 @@ module RuboCop
         #       # code that causes the resource to converge
         #     end
         #
-        class ResourceUsesUpdatedMethod < Cop
+        class ResourceUsesUpdatedMethod < Base
           MSG = "Don't use updated = true/false to update resource state. This will cause failures in Chef Infra Client 13 and later."
 
           def on_lvasgn(node)
-            add_offense(node, location: :expression, message: MSG, severity: :warning) if node.node_parts.first == :updated
+            add_offense(node, message: MSG, severity: :warning) if node.node_parts.first == :updated
           end
 
           # potential autocorrect is new_resource.updated_by_last_action true, but we need to actually see what class we were called from

--- a/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
@@ -40,22 +40,19 @@ module RuboCop
         #     action :run
         #   end
         #
-        class RubyBlockCreateAction < Cop
+        class RubyBlockCreateAction < Base
           include RuboCop::Chef::CookbookHelpers
+          extend AutoCorrector
 
           MSG = 'Use the :run action in the ruby_block resource instead of the deprecated :create action'
 
           def on_block(node)
             match_property_in_resource?(:ruby_block, 'action', node) do |ruby_action|
               ruby_action.arguments.each do |action|
-                add_offense(action, location: :expression, message: MSG, severity: :warning) if action.source == ':create'
+                add_offense(action, message: MSG, severity: :warning) do |corrector|
+                  corrector.replace(action.loc.expression, ':run')
+                end if action.source == ':create'
               end
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, ':run')
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
@@ -50,7 +50,6 @@ module RuboCop
             match_property_in_resource?(:ruby_block, 'action', node) do |ruby_action|
               ruby_action.arguments.each do |action|
                 next unless action.source == ':create'
-                puts action.source
                 add_offense(action.loc.expression, message: MSG, severity: :warning) do |corrector|
                   corrector.replace(action.loc.expression, ':run')
                 end

--- a/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
@@ -49,9 +49,11 @@ module RuboCop
           def on_block(node)
             match_property_in_resource?(:ruby_block, 'action', node) do |ruby_action|
               ruby_action.arguments.each do |action|
-                add_offense(action, message: MSG, severity: :warning) do |corrector|
+                next unless action.source == ':create'
+                puts action.source
+                add_offense(action.loc.expression, message: MSG, severity: :warning) do |corrector|
                   corrector.replace(action.loc.expression, ':run')
-                end if action.source == ':create'
+                end
               end
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
@@ -33,7 +33,7 @@ module RuboCop
         #   # good
         #   shell_out!('/bin/foo')
         #
-        class UsesRunCommandHelper < Cop
+        class UsesRunCommandHelper < Base
           MSG = "Use 'shell_out!' instead of the legacy 'run_command' or 'run_command_with_systems_locale' helpers for shelling out. The run_command helper was removed in Chef Infra Client 13."
 
           def_node_matcher :calls_run_command?, '(send nil? {:run_command :run_command_with_systems_locale} ...)'
@@ -44,15 +44,15 @@ module RuboCop
 
           def on_send(node)
             calls_run_command?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning) unless defines_run_command?(processed_source.ast)
+              add_offense(node, message: MSG, severity: :warning) unless defines_run_command?(processed_source.ast)
             end
 
             require_mixin_command?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
 
             include_mixin_command?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
+++ b/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
@@ -35,7 +35,7 @@ module RuboCop
         #  search(:node, '*:*', start: 0, rows: 1000)
         #  search(:node, '*:*', start: 0)
         #
-        class SearchUsesPositionalParameters < Cop
+        class SearchUsesPositionalParameters < Base
           MSG = "Don't use deprecated positional parameters in cookbook search queries."
 
           NAMED_PARAM_LOOKUP_TABLE = [nil, nil, 'start', 'rows', 'filter_result'].freeze
@@ -44,15 +44,12 @@ module RuboCop
             (send nil? :search ... )
           PATTERN
 
+          extend AutoCorrector
           def on_send(node)
             search_method?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning) if positional_arguments?(node)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, corrected_string(node))
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(node.loc.expression, corrected_string(node))
+              end if positional_arguments?(node)
             end
           end
 

--- a/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
+++ b/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
@@ -36,6 +36,8 @@ module RuboCop
         #  search(:node, '*:*', start: 0)
         #
         class SearchUsesPositionalParameters < Base
+          extend AutoCorrector
+
           MSG = "Don't use deprecated positional parameters in cookbook search queries."
 
           NAMED_PARAM_LOOKUP_TABLE = [nil, nil, 'start', 'rows', 'filter_result'].freeze
@@ -44,7 +46,6 @@ module RuboCop
             (send nil? :search ... )
           PATTERN
 
-          extend AutoCorrector
           def on_send(node)
             search_method?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
@@ -45,6 +45,7 @@ module RuboCop
               if node.parent && node.parent.if_type? && %i(defined? respond_to?).include?(node.parent.children.first.method_name)
                 node = node.parent
               end
+              
               add_offense(node, message: MSG, severity: :warning) do |corrector|
                 corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
               end

--- a/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
@@ -29,8 +29,9 @@ module RuboCop
         #   use_inline_resources if defined?(use_inline_resources)
         #   use_inline_resources if respond_to?(:use_inline_resources)
         #
-        class UseInlineResourcesDefined < Cop
+        class UseInlineResourcesDefined < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'use_inline_resources is now the default for resources in Chef Infra Client 13+ and does not need to be specified.'
 
@@ -44,13 +45,9 @@ module RuboCop
               if node.parent && node.parent.if_type? && %i(defined? respond_to?).include?(node.parent.children.first.method_name)
                 node = node.parent
               end
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
@@ -45,7 +45,7 @@ module RuboCop
               if node.parent && node.parent.if_type? && %i(defined? respond_to?).include?(node.parent.children.first.method_name)
                 node = node.parent
               end
-              
+
               add_offense(node, message: MSG, severity: :warning) do |corrector|
                 corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
               end

--- a/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
+++ b/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
@@ -33,9 +33,10 @@ module RuboCop
         #     verify 'nginx -t -c %{path}'
         #   end
         #
-        class VerifyPropertyUsesFileExpansion < Cop
+        class VerifyPropertyUsesFileExpansion < Base
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
+          extend AutoCorrector
 
           minimum_target_chef_version '12.5'
 
@@ -43,13 +44,9 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(nil, 'verify', node) do |verify|
-              add_offense(verify, location: :expression, message: MSG, severity: :warning) if verify.source.match?(/%{file}/)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, node.loc.expression.source.gsub('%{file}', '%{path}'))
+              add_offense(verify, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(verify.loc.expression, verify.loc.expression.source.gsub('%{file}', '%{path}'))
+              end if verify.source.match?(/%{file}/)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
+++ b/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
@@ -44,9 +44,10 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(nil, 'verify', node) do |verify|
+              return unless verify.source.match?(/%{file}/)
               add_offense(verify, message: MSG, severity: :warning) do |corrector|
                 corrector.replace(verify.loc.expression, verify.loc.expression.source.gsub('%{file}', '%{path}'))
-              end if verify.source.match?(/%{file}/)
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/windows_feature_servermanagercmd.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_feature_servermanagercmd.rb
@@ -41,14 +41,14 @@ module RuboCop
         #
         #   windows_feature_powershell 'DHCP'
         #
-        class WindowsFeatureServermanagercmd < Cop
+        class WindowsFeatureServermanagercmd < Base
           include RuboCop::Chef::CookbookHelpers
 
           MSG = 'The `windows_feature` resource no longer supports setting the `install_method` to `:servermanagercmd`. `:windows_feature_dism` or `:windows_feature_powershell` should be used instead.'
 
           def on_block(node)
             match_property_in_resource?(:windows_feature, :install_method, node) do |prop_node|
-              add_offense(prop_node, location: :expression, message: MSG, severity: :warning) if prop_node.source.match?(/:servermanagercmd/)
+              add_offense(prop_node, message: MSG, severity: :warning) if prop_node.source.match?(/:servermanagercmd/)
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
@@ -61,22 +61,18 @@ module RuboCop
             end
           end
 
-          def fixer(node, corrector)
-            if node.parent.send_type? # :change was the only action
-              corrector.replace(node.loc.expression, ':create')
-            # chances are it's [:create, :change] since that's all that makes sense, but double check that theory
-            elsif node.parent.child_nodes.count == 2 &&
-                  node.parent.child_nodes.map(&:value).sort == [:change, :create]
-              corrector.replace(node.parent.loc.expression, ':create')
-            end
-          end
-
           private
 
           def check_action(ast_obj)
             if ast_obj.respond_to?(:value) && ast_obj.value == :change
               add_offense(ast_obj, message: MSG, severity: :warning) do |corrector|
-                fixer(ast_obj, corrector)
+                if ast_obj.parent.send_type? # :change was the only action
+                  corrector.replace(ast_obj.loc.expression, ':create')
+                # chances are it's [:create, :change] since that's all that makes sense, but double check that theory
+                elsif ast_obj.parent.child_nodes.count == 2 &&
+                      ast_obj.parent.child_nodes.map(&:value).sort == [:change, :create]
+                  corrector.replace(ast_obj.parent.loc.expression, ':create')
+                end
               end
             end
           end

--- a/lib/rubocop/cop/chef/deprecation/windows_version_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_version_helpers.rb
@@ -60,11 +60,7 @@ module RuboCop
                 when :workstation_version?
                   corrector.replace(node.loc.expression, 'node[\'kernel\'][\'product_type\'] == \'Workstation\'')
                 end
-            end
-          end
-
-          def autocorrect(node)
-            lambda 
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/windows_version_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_version_helpers.rb
@@ -35,8 +35,9 @@ module RuboCop
         #   node['kernel']['server_core']
         #   node['kernel']['product_type'] == 'Workstation'
         #
-        class WindowsVersionHelpers < Cop
+        class WindowsVersionHelpers < Base
           extend TargetChefVersion
+          extend AutoCorrector
 
           minimum_target_chef_version '14.0'
 
@@ -47,14 +48,8 @@ module RuboCop
           PATTERN
 
           def on_send(node)
-            windows_helper?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              windows_helper?(node) do |method|
+            windows_helper?(node) do |method|
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
                 case method
                 when :nt_version
                   corrector.replace(node.loc.expression, 'node[\'platform_version\'].to_f')
@@ -65,7 +60,11 @@ module RuboCop
                 when :workstation_version?
                   corrector.replace(node.loc.expression, 'node[\'kernel\'][\'product_type\'] == \'Workstation\'')
                 end
-              end
+            end
+          end
+
+          def autocorrect(node)
+            lambda 
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
@@ -28,6 +28,7 @@ module RuboCop
         #
         class IncludingXMLRubyRecipe < Base
           extend AutoCorrector
+
           MSG = 'Do not include the deprecated xml::ruby recipe to install the nokogiri gem. Chef Infra Client 12 and later ships with nokogiri included.'
 
           def_node_matcher :xml_ruby_recipe?, <<-PATTERN

--- a/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
@@ -26,7 +26,8 @@ module RuboCop
         #   # bad
         #   include_recipe 'xml::ruby'
         #
-        class IncludingXMLRubyRecipe < Cop
+        class IncludingXMLRubyRecipe < Base
+          extend AutoCorrector
           MSG = 'Do not include the deprecated xml::ruby recipe to install the nokogiri gem. Chef Infra Client 12 and later ships with nokogiri included.'
 
           def_node_matcher :xml_ruby_recipe?, <<-PATTERN
@@ -36,13 +37,9 @@ module RuboCop
           def on_send(node)
             xml_ruby_recipe?(node) do
               node = node.parent if node.parent&.conditional? && node.parent&.single_line_condition? # make sure we catch any inline conditionals
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(node.loc.expression)
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.remove(node.loc.expression)
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe.rb
@@ -27,8 +27,9 @@ module RuboCop
         #   # bad
         #   include_recipe 'yum::dnf_yum_compat'
         #
-        class IncludingYumDNFCompatRecipe < Cop
+        class IncludingYumDNFCompatRecipe < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'Do not include the deprecated yum::dnf_yum_compat default recipe to install yum on dnf systems. Chef Infra Client now includes built in support for DNF packages.'
 
@@ -39,13 +40,9 @@ module RuboCop
           def on_send(node)
             yum_dnf_compat_recipe_usage?(node) do
               node = node.parent if node.parent&.conditional? && node.parent&.single_line?
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
             end
           end
         end


### PR DESCRIPTION
## Description
This refactors deprecations rules to use the latest format in use by RuboCop:
https://docs.rubocop.org/rubocop/development.html

No new functionality added.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X ] I have read the **CONTRIBUTING** document.
- [ X] I have run the pre-merge tests locally and they pass.
- [ X] I have updated the documentation accordingly.
- [X ] I have added tests to cover my changes.
- [X ] All new and existing tests passed
- [ X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

## Testing
Ran existing RSpec tests, as this is not adding or removing functionality.

$ bundle exec rspec spec -f p
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 304
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 0.88479 seconds (files took 2.08 seconds to load)
752 examples, 0 failures

Randomized with seed 304

