### PR TITLE
Effortless and Redundant cops refactor to latest Rubocop format

### DIFF
--- a/lib/rubocop/cop/chef/effortless/berksfile.rb
+++ b/lib/rubocop/cop/chef/effortless/berksfile.rb
@@ -22,18 +22,16 @@ module RuboCop
       module ChefEffortless
         # Policyfiles should be used for cookbook dependency solving instead of a Berkshelf Berksfile.
         #
-        class Berksfile < Cop
+        class Berksfile < Base
           include RangeHelp
 
           MSG = 'Policyfiles should be used for cookbook dependency solving instead of a Berkshelf Berksfile.'
 
-          def investigate(processed_source)
-            return if processed_source.blank?
-
+          def on_new_investigation
             # Using range similar to RuboCop::Cop::Naming::Filename (file_name.rb)
             range = source_range(processed_source.buffer, 1, 0)
 
-            add_offense(nil, location: range, message: MSG, severity: :refactor)
+            add_offense(range, message: MSG, severity: :refactor)
           end
         end
       end

--- a/lib/rubocop/cop/chef/effortless/data_bags.rb
+++ b/lib/rubocop/cop/chef/effortless/data_bags.rb
@@ -26,11 +26,11 @@ module RuboCop
         #   # bad
         #   data_bag_item('admins', login)
         #   data_bag(data_bag_name)
-        class CookbookUsesDatabags < Cop
+        class CookbookUsesDatabags < Base
           MSG = 'Cookbook uses data bags, which cannot be used in the Effortless Infra pattern'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if %i(data_bag data_bag_item).include?(node.method_name)
+            add_offense(node, message: MSG, severity: :refactor) if %i(data_bag data_bag_item).include?(node.method_name)
           end
         end
       end

--- a/lib/rubocop/cop/chef/effortless/node_environment.rb
+++ b/lib/rubocop/cop/chef/effortless/node_environment.rb
@@ -27,12 +27,15 @@ module RuboCop
         #   node.environment == "production"
         #   node.chef_environment == "production"
         #
-        class CookbookUsesEnvironments < Cop
+        class CookbookUsesEnvironments < Base
           MSG = 'Cookbook uses environments, which cannot be used in Policyfiles or Effortless Infra'
 
           def on_send(node)
-            if %i(environment chef_environment).include?(node.method_name) && node.receiver && node.receiver.send_type? && node.receiver.method_name == :node
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            if %i(environment chef_environment).include?(node.method_name) &&
+               node.receiver &&
+               node.receiver.send_type? &&
+               node.receiver.method_name == :node
+              add_offense(node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/effortless/node_policygroup.rb
+++ b/lib/rubocop/cop/chef/effortless/node_policygroup.rb
@@ -26,12 +26,15 @@ module RuboCop
         #   # bad
         #   node.policy_group == "foo"
         #
-        class CookbookUsesPolicygroups < Cop
+        class CookbookUsesPolicygroups < Base
           MSG = 'Cookbook uses Policy Groups, which cannot be used with Effortless Infra'
 
           def on_send(node)
-            if node.method_name == :policy_group && node.receiver && node.receiver.send_type? && node.receiver.method_name == :node
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            if node.method_name == :policy_group &&
+               node.receiver &&
+               node.receiver.send_type? &&
+               node.receiver.method_name == :node
+              add_offense(node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/effortless/node_roles.rb
+++ b/lib/rubocop/cop/chef/effortless/node_roles.rb
@@ -27,12 +27,15 @@ module RuboCop
         #   node.role?('web_server')
         #   node.roles.include?('web_server')
         #
-        class CookbookUsesRoles < Cop
+        class CookbookUsesRoles < Base
           MSG = 'Cookbook uses roles, which cannot be used in Policyfiles or Effortless Infra'
 
           def on_send(node)
-            if %i(role? roles).include?(node.method_name) && node.receiver && node.receiver.send_type? && node.receiver.method_name == :node
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            if %i(role? roles).include?(node.method_name) &&
+               node.receiver &&
+               node.receiver.send_type? &&
+               node.receiver.method_name == :node
+              add_offense(node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/effortless/search_for_environments_or_roles.rb
+++ b/lib/rubocop/cop/chef/effortless/search_for_environments_or_roles.rb
@@ -27,12 +27,13 @@ module RuboCop
         #   search(:node, 'chef_environment:foo')
         #   search(:node, 'role:bar')
         #
-        class SearchForEnvironmentsOrRoles < Cop
+        class SearchForEnvironmentsOrRoles < Base
           MSG = 'Cookbook uses search with a node query that looks for a role or environment'
 
           def on_send(node)
-            if node.method_name == :search && node.arguments[1]&.value&.match?(/chef_environment|role/)
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+            if node.method_name == :search &&
+               node.arguments[1]&.value&.match?(/chef_environment|role/)
+              add_offense(node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/effortless/search_used.rb
+++ b/lib/rubocop/cop/chef/effortless/search_used.rb
@@ -26,11 +26,11 @@ module RuboCop
         #   # bad
         #   search(:node, 'run_list:recipe\[bacula\:\:server\]')
         #
-        class CookbookUsesSearch < Cop
+        class CookbookUsesSearch < Base
           MSG = 'Cookbook uses search, which cannot be used in the Effortless Infra pattern'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :search
+            add_offense(node, message: MSG, severity: :refactor) if node.method_name == :search
           end
         end
       end

--- a/lib/rubocop/cop/chef/redundant/apt_repository_distribution_default.rb
+++ b/lib/rubocop/cop/chef/redundant/apt_repository_distribution_default.rb
@@ -36,9 +36,10 @@ module RuboCop
         #     deb_src false
         #   end
         #
-        class AptRepositoryDistributionDefault < Cop
+        class AptRepositoryDistributionDefault < Base
           include RuboCop::Chef::CookbookHelpers
           include RangeHelp
+          extend AutoCorrector
 
           MSG = "There is no need to pass `distribution node['lsb']['codename']` to an apt_repository resource as this is done automatically by the apt_repository resource."
 
@@ -49,14 +50,10 @@ module RuboCop
           def on_block(node)
             match_property_in_resource?(:apt_repository, 'distribution', node) do |dist|
               default_dist?(dist) do
-                add_offense(dist, location: :expression, message: MSG, severity: :refactor)
+                add_offense(dist, message: MSG, severity: :refactor) do |corrector|
+                  corrector.remove(range_with_surrounding_space(range: dist.loc.expression, side: :left))
+                end
               end
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/apt_repository_notifies_apt_update.rb
+++ b/lib/rubocop/cop/chef/redundant/apt_repository_notifies_apt_update.rb
@@ -36,21 +36,19 @@ module RuboCop
         #     deb_src false
         #   end
         #
-        class AptRepositoryNotifiesAptUpdate < Cop
+        class AptRepositoryNotifiesAptUpdate < Base
           include RuboCop::Chef::CookbookHelpers
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'There is no need to notify an apt-get update when an apt_repository is created as this is done automatically by the apt_repository resource.'
 
           def on_block(node)
             match_property_in_resource?(:apt_repository, 'notifies', node) do |notifies|
-              add_offense(notifies, location: :expression, message: MSG, severity: :refactor) if notifies.arguments[1] == s(:str, 'execute[apt-get update]')
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              return unless notifies.arguments[1] == s(:str, 'execute[apt-get update]')
+              add_offense(notifies, message: MSG, severity: :refactor) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: notifies.loc.expression, side: :left))
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/attribute_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/attribute_metadata.rb
@@ -33,18 +33,16 @@ module RuboCop
         #              required: 'optional',
         #              default: '"127.0.0.1:2181"'
         #
-        class AttributeMetadata < Cop
+        class AttributeMetadata < Base
           include RangeHelp
           include RuboCop::Chef::AutocorrectHelpers
+          extend AutoCorrector
 
           MSG = 'The attribute metadata.rb method is not used and is unnecessary in cookbooks.'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :attribute
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
+            return unless node.method_name == :attribute
+            add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end
           end

--- a/lib/rubocop/cop/chef/redundant/conflicts_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/conflicts_metadata.rb
@@ -28,17 +28,15 @@ module RuboCop
         #
         #   conflicts "another_cookbook"
         #
-        class ConflictsMetadata < Cop
+        class ConflictsMetadata < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'The conflicts metadata.rb method is not used and is unnecessary in cookbooks.'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :conflicts
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
+            return unless node.method_name == :conflicts
+            add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
             end
           end

--- a/lib/rubocop/cop/chef/redundant/grouping_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/grouping_metadata.rb
@@ -27,18 +27,17 @@ module RuboCop
         #   # bad
         #   grouping 'windows_log_rotate', title: 'Demonstration cookbook with code to switch loggers'
         #
-        class GroupingMetadata < Cop
+        class GroupingMetadata < Base
           include RangeHelp
           include RuboCop::Chef::AutocorrectHelpers
+          extend AutoCorrector
 
           MSG = 'The grouping metadata.rb method is not used and is unnecessary in cookbooks.'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :grouping
-          end
+            return unless node.method_name == :grouping
 
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end
           end

--- a/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
@@ -27,18 +27,17 @@ module RuboCop
         #   # bad
         #   long_description 'this is my cookbook and this description will never be seen'
         #
-        class LongDescriptionMetadata < Cop
+        class LongDescriptionMetadata < Base
           include RangeHelp
           include RuboCop::Chef::AutocorrectHelpers
+          extend AutoCorrector
 
           MSG = 'The long_description metadata.rb method is not used and is unnecessary in cookbooks.'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :long_description
-          end
+            return unless node.method_name == :long_description
 
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end
           end

--- a/lib/rubocop/cop/chef/redundant/name_property_and_required.rb
+++ b/lib/rubocop/cop/chef/redundant/name_property_and_required.rb
@@ -59,7 +59,7 @@ module RuboCop
         #   # good
         #   property :config_file, String, required: true
         #
-        class NamePropertyIsRequired < Cop
+        class NamePropertyIsRequired < Base
           MSG = 'Resource properties marked as name properties should not also be required properties'
 
           # match on a property or attribute that has any name and any type and a hash that
@@ -71,7 +71,7 @@ module RuboCop
 
           def on_send(node)
             name_property_and_required?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/ohai_attribute_to_string.rb
+++ b/lib/rubocop/cop/chef/redundant/ohai_attribute_to_string.rb
@@ -42,7 +42,9 @@ module RuboCop
         #   node['os']
         #   node['name']
         #
-        class OhaiAttributeToString < Cop
+        class OhaiAttributeToString < Base
+          extend AutoCorrector
+
           MSG = "This Ohai node attribute is already a string and doesn't need to be converted"
 
           def_node_matcher :attribute_to_s?, <<-PATTERN
@@ -50,14 +52,8 @@ module RuboCop
           PATTERN
 
           def on_send(node)
-            attribute_to_s?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
             attribute_to_s?(node) do |method|
-              lambda do |corrector|
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
                 corrector.replace(node.loc.expression, "node['#{method.value}']")
               end
             end

--- a/lib/rubocop/cop/chef/redundant/property_splat_regex.rb
+++ b/lib/rubocop/cop/chef/redundant/property_splat_regex.rb
@@ -31,8 +31,9 @@ module RuboCop
         #   property :config_file, String
         #   attribute :config_file, String
         #
-        class PropertySplatRegex < Cop
+        class PropertySplatRegex < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'There is no need to validate the input of properties in resources using a regex value that will always pass.'
 
@@ -42,14 +43,12 @@ module RuboCop
 
           def on_send(node)
             property_with_regex_splat?(node) do |splat|
-              add_offense(splat, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              range = range_with_surrounding_comma(range_with_surrounding_space(range: node.loc.expression, side: :left), :left)
-              corrector.remove(range)
+              add_offense(splat, message: MSG, severity: :refactor) do |corrector|
+                range = range_with_surrounding_comma(
+                  range_with_surrounding_space(
+                    range: splat.loc.expression, side: :left), :left)
+                corrector.remove(range)
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/property_with_default_and_required.rb
+++ b/lib/rubocop/cop/chef/redundant/property_with_default_and_required.rb
@@ -32,8 +32,9 @@ module RuboCop
         #   # good
         #   property :bob, String, required: true
         #
-        class PropertyWithRequiredAndDefault < Cop
+        class PropertyWithRequiredAndDefault < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'Resource properties should not be both required and have a default value. This will fail on Chef Infra Client 13+'
 
@@ -45,14 +46,8 @@ module RuboCop
           PATTERN
 
           def on_send(node)
-            required_and_default?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              required_and_default?(node) do |default|
+            required_and_default?(node) do |default|
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
                 range = range_with_surrounding_comma(range_with_surrounding_space(range: default.loc.expression, side: :left), :left)
                 corrector.remove(range)
               end

--- a/lib/rubocop/cop/chef/redundant/provides_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/provides_metadata.rb
@@ -28,17 +28,16 @@ module RuboCop
         #
         #   provides "some_thing"
         #
-        class ProvidesMetadata < Cop
+        class ProvidesMetadata < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'The provides metadata.rb method is not used and is unnecessary in cookbooks.'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :provides
-          end
+            return unless node.method_name == :provides
 
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end

--- a/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
@@ -28,18 +28,17 @@ module RuboCop
         #   recipe 'openldap::default', 'Install and configure OpenLDAP'
         #
         #
-        class RecipeMetadata < Cop
+        class RecipeMetadata < Base
           include RangeHelp
           include RuboCop::Chef::AutocorrectHelpers
+          extend AutoCorrector
 
           MSG = "The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the cookbook's README.md file instead."
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :recipe
-          end
+            return unless node.method_name == :recipe
 
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end
           end

--- a/lib/rubocop/cop/chef/redundant/replaces_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/replaces_metadata.rb
@@ -28,17 +28,16 @@ module RuboCop
         #
         #   replaces "another_cookbook"
         #
-        class ReplacesMetadata < Cop
+        class ReplacesMetadata < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'The replaces metadata.rb method is not used and is unnecessary in cookbooks.'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :replaces
-          end
+            return unless node.method_name == :replaces
 
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end

--- a/lib/rubocop/cop/chef/redundant/resource_with_nothing_action.rb
+++ b/lib/rubocop/cop/chef/redundant/resource_with_nothing_action.rb
@@ -28,8 +28,9 @@ module RuboCop
         #     # let's do nothing
         #   end
         #
-        class ResourceWithNothingAction < Cop
+        class ResourceWithNothingAction < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'There is no need to define a :nothing action in your resource as Chef Infra Client provides the :nothing action by default for every resource.'
 
@@ -39,13 +40,9 @@ module RuboCop
 
           def on_block(node)
             nothing_action?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/sensitive_property_in_resource.rb
+++ b/lib/rubocop/cop/chef/redundant/sensitive_property_in_resource.rb
@@ -24,7 +24,9 @@ module RuboCop
         # # bad
         # property :sensitive, [true, false], default: false
         #
-        class SensitivePropertyInResource < Cop
+        class SensitivePropertyInResource < Base
+          extend AutoCorrector
+
           MSG = 'Every Chef Infra resource already includes a sensitive property with a default value of false.'
 
           def_node_matcher :sensitive_property?, <<-PATTERN
@@ -32,13 +34,9 @@ module RuboCop
           PATTERN
 
           def on_send(node)
-            if sensitive_property?(node)
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
+            return unless sensitive_property?(node)
 
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(node.source_range)
             end
           end

--- a/lib/rubocop/cop/chef/redundant/string_property_with_nil_default.rb
+++ b/lib/rubocop/cop/chef/redundant/string_property_with_nil_default.rb
@@ -31,8 +31,9 @@ module RuboCop
         #   property :config_file, String
         #   property :config_file, [String, NilClass]
         #
-        class StringPropertyWithNilDefault < Cop
+        class StringPropertyWithNilDefault < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'Properties have a nil value by default so there is no need to set the default value to nil.'
 
@@ -49,14 +50,10 @@ module RuboCop
 
           def on_send(node)
             string_property_with_nil_default?(node) do |nil_default|
-              add_offense(nil_default, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              range = range_with_surrounding_comma(range_with_surrounding_space(range: node.loc.expression, side: :left), :left)
-              corrector.remove(range)
+              add_offense(nil_default, message: MSG, severity: :refactor) do |corrector|
+                range = range_with_surrounding_comma(range_with_surrounding_space(range: nil_default.loc.expression, side: :left), :left)
+                corrector.remove(range)
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/suggests_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/suggests_metadata.rb
@@ -28,17 +28,16 @@ module RuboCop
         #
         #   suggests "another_cookbook"
         #
-        class SuggestsMetadata < Cop
+        class SuggestsMetadata < Base
           include RangeHelp
+          extend AutoCorrector
 
           MSG = 'The suggests metadata.rb method is not used and is unnecessary in cookbooks.'
 
           def on_send(node)
-            add_offense(node, location: :expression, message: MSG, severity: :refactor) if node.method_name == :suggests
-          end
+            return unless node.method_name == :suggests
 
-          def autocorrect(node)
-            lambda do |corrector|
+            add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end

--- a/lib/rubocop/cop/chef/redundant/unnecessary_name_property.rb
+++ b/lib/rubocop/cop/chef/redundant/unnecessary_name_property.rb
@@ -29,7 +29,9 @@ module RuboCop
         #   attribute :name, kind_of: String
         #   attribute :name, kind_of: String, name_attribute: true
         #
-        class UnnecessaryNameProperty < Cop
+        class UnnecessaryNameProperty < Base
+          extend AutoCorrector
+
           MSG = 'There is no need to define a property or attribute named :name in a resource as Chef Infra defines this on all resources by default.'
 
           def_node_matcher :name_attribute?, <<-PATTERN
@@ -56,17 +58,15 @@ module RuboCop
 
           def on_send(node)
             name_property?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
+                corrector.remove(node.source_range)
+              end
             end
 
             name_attribute?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(node.source_range)
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
+                corrector.remove(node.source_range)
+              end
             end
           end
         end


### PR DESCRIPTION
## Description
These changes update all cops in the Effortless and Redundant rule sets to the format used in the latest Rubocop versions. This will provide us the flexibility to update Rubocop versions if/when they ever stop supporting the legacy format.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have run the pre-merge tests locally and they pass.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ x ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
