### PR TITLE
Update Correctness cops to latest Rubocop format and added corrector for ResourceWithNoneAction

### DIFF
--- a/lib/rubocop/cop/chef/correctness/block_guard_clause_string_only.rb
+++ b/lib/rubocop/cop/chef/correctness/block_guard_clause_string_only.rb
@@ -37,7 +37,9 @@ module RuboCop
         #     only_if 'test -f /etc/foo'
         #   end
         #
-        class BlockGuardWithOnlyString < Cop
+        class BlockGuardWithOnlyString < Base
+          extend AutoCorrector
+
           MSG = 'A resource guard (not_if/only_if) that is a string should not be wrapped in {}. Wrapping a guard string in {} causes it be executed as Ruby code which will always returns true instead of a shell command that will actually run.'
 
           def_node_matcher :block_guard_with_only_string?, <<-PATTERN
@@ -46,14 +48,10 @@ module RuboCop
 
           def on_block(node)
             block_guard_with_only_string?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              new_val = "#{node.method_name} #{node.body.source}"
-              corrector.replace(node.loc.expression, new_val)
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
+                new_val = "#{node.method_name} #{node.body.source}"
+                corrector.replace(node.loc.expression, new_val)
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/chef_application_fatal.rb
+++ b/lib/rubocop/cop/chef/correctness/chef_application_fatal.rb
@@ -29,7 +29,9 @@ module RuboCop
         #   # good
         #   raise "Something horrible happened!"
         #
-        class ChefApplicationFatal < Cop
+        class ChefApplicationFatal < Base
+          extend AutoCorrector
+
           MSG = 'Use raise to force Chef Infra Client to fail instead of using Chef::Application.fatal'
 
           def_node_matcher :application_fatal?, <<-PATTERN
@@ -40,14 +42,8 @@ module RuboCop
           PATTERN
 
           def on_send(node)
-            application_fatal?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              application_fatal?(node) do |val|
+            application_fatal?(node) do |val|
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
                 corrector.replace(node.loc.expression, "raise(#{val.source})")
               end
             end

--- a/lib/rubocop/cop/chef/correctness/conditional_ruby_shellout.rb
+++ b/lib/rubocop/cop/chef/correctness/conditional_ruby_shellout.rb
@@ -40,8 +40,10 @@ module RuboCop
         #     only_if 'wget https://www.bar.com/foobar.txt -O /dev/null'
         #   end
         #
-        class ConditionalRubyShellout < Cop
+        class ConditionalRubyShellout < Base
+          extend AutoCorrector
           include RuboCop::Chef::CookbookHelpers
+
           MSG = "Don't use Ruby to shellout in an only_if / not_if conditional when you can shellout directly by wrapping the command in quotes."
 
           def_node_matcher :conditional_shellout?, <<-PATTERN
@@ -54,14 +56,8 @@ module RuboCop
           PATTERN
 
           def on_block(node)
-            conditional_shellout?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              conditional_shellout?(node) do |type, val|
+            conditional_shellout?(node) do |type, val|
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
                 corrector.replace(node.loc.expression, "#{type} #{val.source}")
               end
             end

--- a/lib/rubocop/cop/chef/correctness/dnf_package_allow_downgrades.rb
+++ b/lib/rubocop/cop/chef/correctness/dnf_package_allow_downgrades.rb
@@ -34,21 +34,18 @@ module RuboCop
         #     version '1.2.3'
         #   end
         #
-        class DnfPackageAllowDowngrades < Cop
+        class DnfPackageAllowDowngrades < Base
           include RangeHelp
           include RuboCop::Chef::CookbookHelpers
+          extend AutoCorrector
 
           MSG = 'dnf_package does not support the allow_downgrades property'
 
           def on_block(node)
             match_property_in_resource?(:dnf_package, :allow_downgrades, node) do |prop|
-              add_offense(prop, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              add_offense(prop, message: MSG, severity: :refactor) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: prop.loc.expression, side: :left))
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/invalid_default_action.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_default_action.rb
@@ -30,7 +30,7 @@ module RuboCop
       #   default_action :create
       #
       module ChefCorrectness
-        class InvalidDefaultAction < Cop
+        class InvalidDefaultAction < Base
           MSG = 'Default actions in resources should be symbols or an array of symbols.'
 
           def_node_matcher :default_action?, '(send nil? :default_action $_)'
@@ -38,7 +38,7 @@ module RuboCop
           def on_send(node)
             default_action?(node) do |match|
               return if %i(send sym array).include?(match.type)
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/invalid_notification_timing.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_notification_timing.rb
@@ -35,7 +35,7 @@ module RuboCop
         #     notifies :restart, 'service[apache]', :immediately
         #   end
         #
-        class InvalidNotificationTiming < Cop
+        class InvalidNotificationTiming < Base
           MSG = 'Valid notification timings are :immediately, :immediate (alias for :immediately), :delayed, and :before.'
 
           def_node_matcher :notification_with_timing?, <<-PATTERN
@@ -44,7 +44,7 @@ module RuboCop
 
           def on_send(node)
             notification_with_timing?(node) do |timing|
-              add_offense(timing, location: :expression, message: MSG, severity: :refactor) unless %i(immediate immediately delayed before).include?(timing.value)
+              add_offense(timing, message: MSG, severity: :refactor) unless %i(immediate immediately delayed before).include?(timing.value)
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_helper.rb
@@ -32,7 +32,7 @@ module RuboCop
         #   platform?('mac_os_x')
         #   platform?('redhat)
         #   platform?('suse')
-        class InvalidPlatformHelper < Cop
+        class InvalidPlatformHelper < Base
           include ::RuboCop::Chef::PlatformHelpers
 
           MSG = 'Pass valid platforms to the platform? helper.'
@@ -44,7 +44,7 @@ module RuboCop
           def on_send(node)
             platform_helper?(node) do |plat|
               plat.to_a.each do |p|
-                add_offense(p, location: :expression, message: MSG, severity: :refactor) if INVALID_PLATFORMS.key?(p.value)
+                add_offense(p, message: MSG, severity: :refactor) if INVALID_PLATFORMS.key?(p.value)
               end
             end
           end

--- a/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_family_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_family_helper.rb
@@ -35,7 +35,7 @@ module RuboCop
         #     %w(mac_os_x) => 'foo'
         #   )
         #
-        class InvalidPlatformValueForPlatformFamilyHelper < Cop
+        class InvalidPlatformValueForPlatformFamilyHelper < Base
           include ::RuboCop::Chef::PlatformHelpers
 
           MSG = 'Pass valid platform families to the value_for_platform_family helper.'
@@ -53,10 +53,11 @@ module RuboCop
               plats.each do |p_hash|
                 if p_hash.key.array_type?
                   p_hash.key.values.each do |plat|
-                    add_offense(plat, location: :expression, message: MSG, severity: :refactor) if INVALID_PLATFORM_FAMILIES.key?(plat.value)
+                    next unless INVALID_PLATFORM_FAMILIES.key?(plat.value)
+                    add_offense(plat, message: MSG, severity: :refactor)
                   end
                 elsif INVALID_PLATFORM_FAMILIES.key?(p_hash.key.value)
-                  add_offense(p_hash.key, location: :expression, message: MSG, severity: :refactor)
+                  add_offense(p_hash.key, message: MSG, severity: :refactor)
                 end
               end
             end

--- a/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_helper.rb
@@ -34,7 +34,7 @@ module RuboCop
         #     %w(opensuseleap) => { 'default' => 'bar' }
         #   )
         #
-        class InvalidPlatformValueForPlatformHelper < Cop
+        class InvalidPlatformValueForPlatformHelper < Base
           include ::RuboCop::Chef::PlatformHelpers
 
           MSG = 'Pass valid platforms to the value_for_platform helper.'
@@ -52,10 +52,11 @@ module RuboCop
               plats.each do |p_hash|
                 if p_hash.key.array_type?
                   p_hash.key.values.each do |plat|
-                    add_offense(plat, location: :expression, message: MSG, severity: :refactor) if INVALID_PLATFORMS.key?(plat.value)
+                    next unless INVALID_PLATFORMS.key?(plat.value)
+                    add_offense(plat, message: MSG, severity: :refactor)
                   end
                 elsif INVALID_PLATFORMS.key?(p_hash.key.value)
-                  add_offense(p_hash.key, location: :expression, message: MSG, severity: :refactor)
+                  add_offense(p_hash.key, message: MSG, severity: :refactor)
                 end
               end
             end

--- a/lib/rubocop/cop/chef/correctness/invalid_version_metadata.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_version_metadata.rb
@@ -30,16 +30,15 @@ module RuboCop
         #   # good
         #   version '1.2.3'
         #
-        class InvalidVersionMetadata < Cop
+        class InvalidVersionMetadata < Base
           MSG = 'Cookbook metadata.rb version field should follow X.Y.Z version format.'
 
           def_node_matcher :version?, '(send nil? :version $str ...)'
 
           def on_send(node)
             version?(node) do |ver|
-              unless /\A\d+\.\d+(\.\d+)?\z/.match?(ver.value) # entirely borrowed from Foodcritic.
-                add_offense(ver, location: :expression, message: MSG, severity: :refactor)
-              end
+              next if /\A\d+\.\d+(\.\d+)?\z/.match?(ver.value) # entirely borrowed from Foodcritic.
+              add_offense(ver, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/lazy_eval_node_attribute_defaults.rb
+++ b/lib/rubocop/cop/chef/correctness/lazy_eval_node_attribute_defaults.rb
@@ -30,7 +30,8 @@ module RuboCop
         #   # good
         #   property :Something, String, default: lazy { node['hostname'] }
         #
-        class LazyEvalNodeAttributeDefaults < Cop
+        class LazyEvalNodeAttributeDefaults < Base
+          extend AutoCorrector
           include RuboCop::Chef::CookbookHelpers
 
           MSG = 'When setting a node attribute as the default value for a custom resource property, wrap the node attribute in `lazy {}` so that its value is available when the resource executes.'
@@ -41,13 +42,9 @@ module RuboCop
 
           def on_send(node)
             non_lazy_node_attribute_default?(node) do |default|
-              add_offense(default, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, "lazy { #{node.loc.expression.source} }")
+              add_offense(default, message: MSG, severity: :refactor) do |corrector|
+                corrector.replace(default.loc.expression, "lazy { #{default.loc.expression.source} }")
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type.rb
+++ b/lib/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type.rb
@@ -55,9 +55,8 @@ module RuboCop
               type_val = method_arg_ast_to_string(type)
               return if VALID_VALUES.include?(type_val)
               add_offense(type.loc.expression, message: MSG, severity: :refactor) do |corrector|
-                if INVALID_VALUE_MAP[type_val]
-                  corrector.replace(type.loc.expression, "type '#{INVALID_VALUE_MAP[type_val]}'")
-                end
+                next unless INVALID_VALUE_MAP[type_val]
+                corrector.replace(type.loc.expression, "type '#{INVALID_VALUE_MAP[type_val]}'")
               end
             end
           end

--- a/lib/rubocop/cop/chef/correctness/malformed_value_for_platform.rb
+++ b/lib/rubocop/cop/chef/correctness/malformed_value_for_platform.rb
@@ -44,20 +44,19 @@ module RuboCop
         #     'default' => 'bar'
         #   )
         #
-        class MalformedPlatformValueForPlatformHelper < Cop
+        class MalformedPlatformValueForPlatformHelper < Base
           def on_send(node)
             return unless node.method_name == :value_for_platform
 
             if node.arguments.count > 1
               msg = 'Malformed value_for_platform helper argument. The value_for_platform helper takes a single hash of platforms as an argument.'
-              add_offense(node, location: :expression, message: msg, severity: :refactor)
+              add_offense(node, message: msg, severity: :refactor)
             elsif node.arguments.first.hash_type? # if it's a variable we can't check what's in that variable so skip
               msg = "Malformed value_for_platform helper argument. The value for each platform in your hash must be a hash of either platform version strings or a value with a key of 'default'"
               node.arguments.first.each_pair do |plats, plat_vals|
                 # instead of a platform the hash key can be default with a value of anything. Depending on the hash format this is a string or symbol
-                unless plat_vals.hash_type? || plats == s(:str, 'default') || plats == s(:sym, :default)
-                  add_offense(plat_vals, location: :expression, message: msg, severity: :refactor)
-                end
+                next if plat_vals.hash_type? || plats == s(:str, 'default') || plats == s(:sym, :default)
+                add_offense(plat_vals, message: msg, severity: :refactor)
               end
             end
           end

--- a/lib/rubocop/cop/chef/correctness/node_normal.rb
+++ b/lib/rubocop/cop/chef/correctness/node_normal.rb
@@ -37,7 +37,7 @@ module RuboCop
         #   node.force_default['foo'] = true
         #   node.force_override['foo'] = true
         #
-        class NodeNormal < Cop
+        class NodeNormal < Base
           MSG = 'Do not use node.normal. Replace with default/override/force_default/force_override attribute levels.'
 
           def_node_matcher :node_normal?, <<-PATTERN
@@ -46,7 +46,7 @@ module RuboCop
 
           def on_send(node)
             node_normal?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/node_normal_unless.rb
+++ b/lib/rubocop/cop/chef/correctness/node_normal_unless.rb
@@ -37,7 +37,7 @@ module RuboCop
         #   node.force_default_unless['foo'] = true
         #   node.force_override_unless['foo'] = true
         #
-        class NodeNormalUnless < Cop
+        class NodeNormalUnless < Base
           MSG = 'Do not use node.normal_unless. Replace with default/override/force_default/force_override attribute levels.'
 
           def_node_matcher :node_normal_unless?, <<-PATTERN
@@ -46,7 +46,7 @@ module RuboCop
 
           def on_send(node)
             node_normal_unless?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/node_save.rb
+++ b/lib/rubocop/cop/chef/correctness/node_save.rb
@@ -28,7 +28,7 @@ module RuboCop
         #   # bad
         #   node.save
         #
-        class CookbookUsesNodeSave < Cop
+        class CookbookUsesNodeSave < Base
           MSG = "Don't use node.save to save partial node data to the Chef Infra Server mid-run unless it's absolutely necessary. Node.save can result in failed Chef Infra runs appearing in search and increases load on the Chef Infra Server."
 
           def_node_matcher :node_save?, <<-PATTERN
@@ -37,7 +37,7 @@ module RuboCop
 
           def on_send(node)
             node_save?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/notifies_action_not_symbol.rb
+++ b/lib/rubocop/cop/chef/correctness/notifies_action_not_symbol.rb
@@ -42,20 +42,20 @@ module RuboCop
         #     subscribes :restart, 'service[httpd]', 'delayed'
         #   end
         #
-        class NotifiesActionNotSymbol < Cop
+        class NotifiesActionNotSymbol < Base
           include RuboCop::Chef::CookbookHelpers
+          extend AutoCorrector
 
           MSG = 'Resource notification and subscription actions should be symbols not strings.'
 
           def on_block(node)
             match_property_in_resource?(nil, %w(notifies subscribes), node) do |notifies_property|
-              add_offense(notifies_property, location: :expression, message: MSG, severity: :refactor) if notifies_property.node_parts[2].str_type?
-            end
-          end
+              return unless notifies_property.node_parts[2].str_type?
 
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.first_argument.loc.expression, ":#{node.node_parts[2].value}")
+              add_offense(notifies_property, message: MSG, severity: :refactor) do |corrector|
+                corrector.replace(notifies_property.first_argument.loc.expression,
+                  ":#{notifies_property.node_parts[2].value}")
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/openssl_password_helpers.rb
+++ b/lib/rubocop/cop/chef/correctness/openssl_password_helpers.rb
@@ -25,7 +25,7 @@ module RuboCop
         #   ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
         #   basic_auth_password = secure_password
         #
-        class OpenSSLPasswordHelpers < Cop
+        class OpenSSLPasswordHelpers < Base
           MSG = 'The `secure_password` helper from the openssl cookbooks `Opscode::OpenSSL::Password` class should not be used to generate passwords.'
 
           def_node_matcher :openssl_helper?, <<~PATTERN
@@ -36,7 +36,7 @@ module RuboCop
 
           def on_const(node)
             openssl_helper?(node) do
-              add_offense(node, location: :expression, message: MSG, severity: :warning)
+              add_offense(node, message: MSG, severity: :warning)
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/powershell_delete_file.rb
+++ b/lib/rubocop/cop/chef/correctness/powershell_delete_file.rb
@@ -34,7 +34,7 @@ module RuboCop
         #    action :delete
         #  end
         #
-        class PowershellScriptDeleteFile < Cop
+        class PowershellScriptDeleteFile < Base
           include RuboCop::Chef::CookbookHelpers
 
           MSG = 'Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of using Remove-Item in a powershell_script resource'
@@ -42,9 +42,9 @@ module RuboCop
           def on_block(node)
             match_property_in_resource?(:powershell_script, 'code', node) do |code_property|
               property_data = method_arg_ast_to_string(code_property)
-              if property_data && property_data.match?(/^remove-item/i) && !property_data.include?('*')
-                add_offense(node, location: :expression, message: MSG, severity: :refactor)
-              end
+              return unless property_data && property_data.match?(/^remove-item/i) &&
+                            !property_data.include?('*')
+              add_offense(node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/resource_sets_internal_properties.rb
+++ b/lib/rubocop/cop/chef/correctness/resource_sets_internal_properties.rb
@@ -36,14 +36,14 @@ module RuboCop
         #     action [:start, :enable]
         #   end
         #
-        class ResourceSetsInternalProperties < Cop
+        class ResourceSetsInternalProperties < Base
           include RuboCop::Chef::CookbookHelpers
 
           MSG = 'Do not set properties used internally by Chef Infra Client to track the system state.'
 
           def on_block(node)
             match_property_in_resource?(:service, 'running', node) do |prop|
-              add_offense(prop, location: :expression, message: MSG, severity: :refactor)
+              add_offense(prop, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/resource_sets_name_property.rb
+++ b/lib/rubocop/cop/chef/correctness/resource_sets_name_property.rb
@@ -35,14 +35,14 @@ module RuboCop
         #    service_name 'bar'
         #   end
         #
-        class ResourceSetsNameProperty < Cop
+        class ResourceSetsNameProperty < Base
           include RuboCop::Chef::CookbookHelpers
 
           MSG = 'Resource sets the name property in the resource instead of using a name_property.'
 
           def on_block(node)
             match_property_in_resource?(nil, 'name', node) do |name_node|
-              add_offense(name_node, location: :expression, message: MSG, severity: :refactor)
+              add_offense(name_node, message: MSG, severity: :refactor)
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/resource_with_none_action.rb
+++ b/lib/rubocop/cop/chef/correctness/resource_with_none_action.rb
@@ -34,15 +34,19 @@ module RuboCop
         #    action :nothing
         #   end
         #
-        class ResourceWithNoneAction < Cop
+        class ResourceWithNoneAction < Base
           include RuboCop::Chef::CookbookHelpers
+          extend AutoCorrector
 
           MSG = 'Resource uses the nonexistent :none action instead of the :nothing action'
 
           def on_block(node)
             match_property_in_resource?(nil, 'action', node) do |action_node|
               action_node.arguments.each do |action|
-                add_offense(action, location: :expression, message: MSG, severity: :refactor) if action.source == ':none'
+                next unless action.source == ':none'
+                add_offense(action, message: MSG, severity: :refactor) do |corrector|
+                  corrector.replace(action.loc.expression, ':nothing')
+                end
               end
             end
           end

--- a/lib/rubocop/cop/chef/correctness/scoped_file_exist.rb
+++ b/lib/rubocop/cop/chef/correctness/scoped_file_exist.rb
@@ -29,7 +29,9 @@ module RuboCop
         #   # good
         #   not_if { ::File.exist?('/etc/foo/bar') }
         #
-        class ScopedFileExist < Cop
+        class ScopedFileExist < Base
+          extend AutoCorrector
+
           MSG = 'Scope file exist to access the correct File class by using ::File.exist? not File.exist?.'
 
           def_node_matcher :unscoped_file_exist?, <<-PATTERN
@@ -38,13 +40,9 @@ module RuboCop
 
           def on_block(node)
             unscoped_file_exist?(node) do |m|
-              add_offense(m, location: :expression, message: MSG, severity: :refactor)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, '::File')
+              add_offense(m, message: MSG, severity: :refactor) do |corrector|
+                corrector.replace(m.loc.expression, '::File')
+              end
             end
           end
         end

--- a/lib/rubocop/cop/chef/correctness/service_resource.rb
+++ b/lib/rubocop/cop/chef/correctness/service_resource.rb
@@ -27,7 +27,7 @@ module RuboCop
         #   command "/etc/init.d/mysql start"
         #   command "/sbin/service/memcached start"
         #
-        class ServiceResource < Cop
+        class ServiceResource < Base
           MSG = 'Use a service resource to start and stop services'
 
           def_node_matcher :execute_command?, <<-PATTERN
@@ -37,7 +37,7 @@ module RuboCop
           def on_send(node)
             execute_command?(node) do |command|
               if starts_service?(command)
-                add_offense(command, location: :expression, message: MSG, severity: :refactor)
+                add_offense(command, message: MSG, severity: :refactor)
               end
             end
           end

--- a/lib/rubocop/cop/chef/correctness/tmp_path.rb
+++ b/lib/rubocop/cop/chef/correctness/tmp_path.rb
@@ -30,7 +30,7 @@ module RuboCop
         #   remote_file "#{Chef::Config[:file_cache_path]}/large-file.tar.gz" do
         #
         #
-        class TmpPath < Cop
+        class TmpPath < Base
           MSG = 'Use file_cache_path rather than hard-coding tmp paths'
 
           def_node_matcher :remote_file?, <<-PATTERN
@@ -39,9 +39,8 @@ module RuboCop
 
           def on_send(node)
             remote_file?(node) do |command|
-              if hardcoded_tmp?(command) && !file_cache_path?(command)
-                add_offense(command, location: :expression, message: MSG, severity: :refactor)
-              end
+              return unless hardcoded_tmp?(command) && !file_cache_path?(command)
+              add_offense(command, message: MSG, severity: :refactor)
             end
           end
 

--- a/spec/rubocop/cop/chef/correctness/resource_with_none_action_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/resource_with_none_action_spec.rb
@@ -27,6 +27,12 @@ describe RuboCop::Cop::Chef::ChefCorrectness::ResourceWithNoneAction, :config do
                ^^^^^ Resource uses the nonexistent :none action instead of the :nothing action
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      execute 'apache_start' do
+        action :nothing
+      end
+    RUBY
   end
 
   it 'does not register an offense when a resource calls the :nothing action' do


### PR DESCRIPTION

Signed-off-by: Scott Vidmar <svidmar@chef.io>


## Description
This brings the Correctness cops up-to-date with the latest cop format used in Rubocop. This will ensure we can pull in the latest Rubocop if/when the legacy format is no longer supported. Also added an autocorrect for Correctness/ResourceWithNoneAction along with a test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Tests:
 cookstyle .
Inspecting 438 files
......................................................................................................................................................................................................................................................................................................................................................................................................................................................

438 files inspected, no offenses detected

 rspec spec . -f p
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 9755
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 1.97 seconds (files took 1.2 seconds to load)
752 examples, 0 failures

Randomized with seed 9755

