### PR TITLE
Move CookbooksDependsOnSelf from ChefCorrectness to ChefDeprecations

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -210,14 +210,6 @@ ChefCorrectness/CookbookUsesNodeSave:
     - '**/metadata.rb'
     - '**/Berksfile'
 
-ChefCorrectness/CookbooksDependsOnSelf:
-  Description: A cookbook cannot depend on itself
-  StyleGuide: '#chefcorrectnesscookbooksdependonself'
-  Enabled: true
-  VersionAdded: '5.2.0'
-  Include:
-    - '**/metadata.rb'
-
 ChefCorrectness/MetadataMissingName:
   Description: The metadata.rb file is missing the name field which is required by Chef Infra Client 12 and later
   StyleGuide: '#chefcorrectnessmetadatamissingname'
@@ -1060,6 +1052,15 @@ ChefDeprecations/MacosUserdefaultsGlobalProperty:
   Exclude:
     - '**/metadata.rb'
     - '**/Berksfile'
+
+ChefDeprecations/CookbooksDependsOnSelf:
+  Description: A cookbook cannot depend on itself in Chef Infra Client 13 or later.
+  StyleGuide: '#chefdeprecationscookbooksdependonself'
+  Enabled: true
+  VersionAdded: '5.2.0'
+  VersionChanged: '6.16.0'
+  Include:
+    - '**/metadata.rb'
 
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources

--- a/lib/rubocop/cop/chef/deprecation/cb_depends_on_self.rb
+++ b/lib/rubocop/cop/chef/deprecation/cb_depends_on_self.rb
@@ -30,7 +30,7 @@ module RuboCop
       #   # good
       #   name 'foo'
       #
-      module ChefCorrectness
+      module ChefDeprecations
         class CookbooksDependsOnSelf < Base
           extend AutoCorrector
           include RangeHelp

--- a/spec/rubocop/cop/chef/deprecation/cb_depends_on_self_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/cb_depends_on_self_spec.rb
@@ -17,7 +17,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Chef::ChefCorrectness::CookbooksDependsOnSelf, :config do
+describe RuboCop::Cop::Chef::ChefDeprecations::CookbooksDependsOnSelf, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense when a cookbook depends on itself' do


### PR DESCRIPTION
This is a deprecation necessary to upgrade to Chef Infra Client 13 and we should flag it for folks that are only running the deprecation cops so they can complete their upgrades.

Signed-off-by: Tim Smith <tsmith@chef.io>