### PR TITLE
Use RESTRICT_ON_SEND to speedup on_send checks

### DIFF
--- a/lib/rubocop/cop/chef/correctness/malformed_value_for_platform.rb
+++ b/lib/rubocop/cop/chef/correctness/malformed_value_for_platform.rb
@@ -45,9 +45,9 @@ module RuboCop
         #   )
         #
         class MalformedPlatformValueForPlatformHelper < Base
-          def on_send(node)
-            return unless node.method_name == :value_for_platform
+          RESTRICT_ON_SEND = [:value_for_platform].freeze
 
+          def on_send(node)
             if node.arguments.count > 1
               msg = 'Malformed value_for_platform helper argument. The value_for_platform helper takes a single hash of platforms as an argument.'
               add_offense(node, message: msg, severity: :refactor)

--- a/lib/rubocop/cop/chef/deprecation/ use_automatic_resource_name.rb
+++ b/lib/rubocop/cop/chef/deprecation/ use_automatic_resource_name.rb
@@ -37,10 +37,9 @@ module RuboCop
           include RangeHelp
 
           MSG = 'The use_automatic_resource_name method was removed in Chef Infra Client 16. The resource name/provides should be set explicitly instead.'
+          RESTRICT_ON_SEND = [:use_automatic_resource_name].freeze
 
           def on_send(node)
-            return unless node.method_name == :use_automatic_resource_name
-
             add_offense(node.loc.selector, message: MSG, severity: :warning) do |corrector|
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_windows_version_check.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_windows_version_check.rb
@@ -30,9 +30,10 @@ module RuboCop
         #
         class DeprecatedWindowsVersionCheck < Base
           MSG = "Don't use the deprecated older_than_win_2012_or_8? helper. Windows versions before 2012 and 8 are now end of life and this helper will always return false."
+          RESTRICT_ON_SEND = [:older_than_win_2012_or_8?].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :warning) if node.method_name == :older_than_win_2012_or_8?
+            add_offense(node, message: MSG, severity: :warning)
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/easy_install.rb
+++ b/lib/rubocop/cop/chef/deprecation/easy_install.rb
@@ -31,9 +31,10 @@ module RuboCop
         #
         class EasyInstallResource < Base
           MSG = "Don't use the deprecated easy_install resource removed in Chef Infra Client 13"
+          RESTRICT_ON_SEND = [:easy_install].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :warning) if node.method_name == :easy_install
+            add_offense(node, message: MSG, severity: :warning)
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/epic_fail.rb
+++ b/lib/rubocop/cop/chef/deprecation/epic_fail.rb
@@ -38,9 +38,9 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Use ignore_failure method instead of the deprecated epic_fail method'
+          RESTRICT_ON_SEND = [:epic_fail].freeze
 
           def on_send(node)
-            return unless node.method_name == :epic_fail
             add_offense(node, message: MSG, severity: :warning) do |corrector|
               corrector.replace(node.loc.expression, 'ignore_failure true')
             end

--- a/lib/rubocop/cop/chef/deprecation/erl_call.rb
+++ b/lib/rubocop/cop/chef/deprecation/erl_call.rb
@@ -31,9 +31,10 @@ module RuboCop
         #
         class ErlCallResource < Base
           MSG = "Don't use the deprecated erl_call resource removed in Chef Infra Client 13"
+          RESTRICT_ON_SEND = [:erl_call].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :warning) if node.method_name == :erl_call
+            add_offense(node, message: MSG, severity: :warning)
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/partial_search_helper_usage.rb
+++ b/lib/rubocop/cop/chef/deprecation/partial_search_helper_usage.rb
@@ -49,9 +49,10 @@ module RuboCop
         #
         class PartialSearchHelperUsage < Base
           MSG = 'Legacy partial_search usage should be updated to use :filter_result in the search helper instead'
+          RESTRICT_ON_SEND = [:partial_search].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :warning) if node.method_name == :partial_search
+            add_offense(node, message: MSG, severity: :warning)
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/resource_overrides_provides_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_overrides_provides_method.rb
@@ -33,13 +33,12 @@ module RuboCop
         #
         class ResourceOverridesProvidesMethod < Base
           MSG = "Don't override the provides? method in a resource provider. Use provides :SOME_PROVIDER_NAME instead. This will cause failures in Chef Infra Client 13 and later."
+          RESTRICT_ON_SEND = [:provides?].freeze
 
           def_node_search :provides, '(send nil? :provides ...)'
 
           def on_def(node)
-            if node.method_name == :provides?
-              add_offense(node, message: MSG, severity: :warning) if provides(processed_source.ast).count == 0
-            end
+            add_offense(node, message: MSG, severity: :warning) if provides(processed_source.ast).count == 0
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_dsl_name_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_dsl_name_method.rb
@@ -31,9 +31,10 @@ module RuboCop
         #
         class ResourceUsesDslNameMethod < Base
           MSG = 'Use resource_name instead of the dsl_name method in resources. This will cause failures in Chef Infra Client 13 and later.'
+          RESTRICT_ON_SEND = [:dsl_name].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :warning) if node.method_name == :dsl_name
+            add_offense(node, message: MSG, severity: :warning)
           end
 
           # potential autocorrect is new_resource.updated_by_last_action true, but we need to actually see what class we were called from

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_provider_base_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_provider_base_method.rb
@@ -28,9 +28,10 @@ module RuboCop
         #
         class ResourceUsesProviderBaseMethod < Base
           MSG = "Don't use the deprecated provider_base method in a resource to specify the provider module to use. Instead, the provider should call provides to register itself, or the resource should call provider to specify the provider to use. This will cause failures in Chef Infra Client 13 and later."
+          RESTRICT_ON_SEND = [:provider_base].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :warning) if node.method_name == :provider_base
+            add_offense(node, message: MSG, severity: :warning)
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
@@ -34,21 +34,20 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'use_inline_resources is now the default for resources in Chef Infra Client 13+ and does not need to be specified.'
+          RESTRICT_ON_SEND = [:use_inline_resources].freeze
 
           def on_send(node)
-            if node.method_name == :use_inline_resources
-              # don't alert on the use_inline_resources within the defined? check
-              # that would result in 2 alerts on the same line and wouldn't be useful
-              return if node.parent && node.parent.defined_type?
+            # don't alert on the use_inline_resources within the defined? check
+            # that would result in 2 alerts on the same line and wouldn't be useful
+            return if node.parent && node.parent.defined_type?
 
-              # catch the full offense if the method is gated like this: use_inline_resources if defined?(use_inline_resources)
-              if node.parent && node.parent.if_type? && %i(defined? respond_to?).include?(node.parent.children.first.method_name)
-                node = node.parent
-              end
+            # catch the full offense if the method is gated like this: use_inline_resources if defined?(use_inline_resources)
+            if node.parent && node.parent.if_type? && %i(defined? respond_to?).include?(node.parent.children.first.method_name)
+              node = node.parent
+            end
 
-              add_offense(node, message: MSG, severity: :warning) do |corrector|
-                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
-              end
+            add_offense(node, message: MSG, severity: :warning) do |corrector|
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end
         end

--- a/lib/rubocop/cop/chef/effortless/data_bags.rb
+++ b/lib/rubocop/cop/chef/effortless/data_bags.rb
@@ -28,9 +28,10 @@ module RuboCop
         #   data_bag(data_bag_name)
         class CookbookUsesDatabags < Base
           MSG = 'Cookbook uses data bags, which cannot be used in the Effortless Infra pattern'
+          RESTRICT_ON_SEND = [:data_bag, :data_bag_item].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :refactor) if %i(data_bag data_bag_item).include?(node.method_name)
+            add_offense(node, message: MSG, severity: :refactor)
           end
         end
       end

--- a/lib/rubocop/cop/chef/effortless/node_environment.rb
+++ b/lib/rubocop/cop/chef/effortless/node_environment.rb
@@ -29,10 +29,10 @@ module RuboCop
         #
         class CookbookUsesEnvironments < Base
           MSG = 'Cookbook uses environments, which cannot be used in Policyfiles or Effortless Infra'
+          RESTRICT_ON_SEND = [:environment, :chef_environment].freeze
 
           def on_send(node)
-            if %i(environment chef_environment).include?(node.method_name) &&
-               node.receiver &&
+            if node.receiver &&
                node.receiver.send_type? &&
                node.receiver.method_name == :node
               add_offense(node, message: MSG, severity: :refactor)

--- a/lib/rubocop/cop/chef/effortless/node_policygroup.rb
+++ b/lib/rubocop/cop/chef/effortless/node_policygroup.rb
@@ -28,10 +28,10 @@ module RuboCop
         #
         class CookbookUsesPolicygroups < Base
           MSG = 'Cookbook uses Policy Groups, which cannot be used with Effortless Infra'
+          RESTRICT_ON_SEND = [:policy_group].freeze
 
           def on_send(node)
-            if node.method_name == :policy_group &&
-               node.receiver &&
+            if node.receiver &&
                node.receiver.send_type? &&
                node.receiver.method_name == :node
               add_offense(node, message: MSG, severity: :refactor)

--- a/lib/rubocop/cop/chef/effortless/node_roles.rb
+++ b/lib/rubocop/cop/chef/effortless/node_roles.rb
@@ -29,10 +29,10 @@ module RuboCop
         #
         class CookbookUsesRoles < Base
           MSG = 'Cookbook uses roles, which cannot be used in Policyfiles or Effortless Infra'
+          RESTRICT_ON_SEND = [:role?, :roles].freeze
 
           def on_send(node)
-            if %i(role? roles).include?(node.method_name) &&
-               node.receiver &&
+            if node.receiver &&
                node.receiver.send_type? &&
                node.receiver.method_name == :node
               add_offense(node, message: MSG, severity: :refactor)

--- a/lib/rubocop/cop/chef/effortless/search_for_environments_or_roles.rb
+++ b/lib/rubocop/cop/chef/effortless/search_for_environments_or_roles.rb
@@ -29,10 +29,10 @@ module RuboCop
         #
         class SearchForEnvironmentsOrRoles < Base
           MSG = 'Cookbook uses search with a node query that looks for a role or environment'
+          RESTRICT_ON_SEND = [:search].freeze
 
           def on_send(node)
-            if node.method_name == :search &&
-               node.arguments[1]&.value&.match?(/chef_environment|role/)
+            if node.arguments[1]&.value&.match?(/chef_environment|role/)
               add_offense(node, message: MSG, severity: :refactor)
             end
           end

--- a/lib/rubocop/cop/chef/effortless/search_used.rb
+++ b/lib/rubocop/cop/chef/effortless/search_used.rb
@@ -28,9 +28,10 @@ module RuboCop
         #
         class CookbookUsesSearch < Base
           MSG = 'Cookbook uses search, which cannot be used in the Effortless Infra pattern'
+          RESTRICT_ON_SEND = [:search].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :refactor) if node.method_name == :search
+            add_offense(node, message: MSG, severity: :refactor)
           end
         end
       end

--- a/lib/rubocop/cop/chef/modernize/cron_manage_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_manage_resource.rb
@@ -36,10 +36,10 @@ module RuboCop
           minimum_target_chef_version '14.4'
 
           MSG = 'The cron_manage resource was renamed to cron_access in the 6.1 release of the cron cookbook and later shipped in Chef Infra Client 14.4. The new resource name should be used.'
+          RESTRICT_ON_SEND = [:cron_manage].freeze
 
           def on_send(node)
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
-              return unless node.method_name == :cron_manage
               corrector.replace(node.loc.expression, node.source.gsub(/^cron_manage/, 'cron_access'))
             end
           end


### PR DESCRIPTION
A lot of our cops are just looking for a particular method being used.
We can greatly speed these up with this new feature introduced in
RuboCop 0.90

Signed-off-by: Tim Smith <tsmith@chef.io>