### PR TITLE
Restrict on_sends to specific methods throughout

### DIFF
--- a/lib/rubocop/cop/chef/correctness/invalid_default_action.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_default_action.rb
@@ -32,6 +32,7 @@ module RuboCop
       module ChefCorrectness
         class InvalidDefaultAction < Base
           MSG = 'Default actions in resources should be symbols or an array of symbols.'
+          RESTRICT_ON_SEND = [:default_action].freeze
 
           def_node_matcher :default_action?, '(send nil? :default_action $_)'
 

--- a/lib/rubocop/cop/chef/correctness/invalid_notification_timing.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_notification_timing.rb
@@ -37,6 +37,7 @@ module RuboCop
         #
         class InvalidNotificationTiming < Base
           MSG = 'Valid notification timings are :immediately, :immediate (alias for :immediately), :delayed, and :before.'
+          RESTRICT_ON_SEND = [:notifies, :subscribes].freeze
 
           def_node_matcher :notification_with_timing?, <<-PATTERN
             (send nil? {:notifies :subscribes} (sym _) (...) $(sym _))

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_family_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_family_helper.rb
@@ -37,6 +37,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Pass valid platform families to the platform_family? helper.'
+          RESTRICT_ON_SEND = [:platform_family?].freeze
 
           def_node_matcher :platform_family_helper?, <<-PATTERN
             (send nil? :platform_family? $str*)

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_helper.rb
@@ -36,6 +36,7 @@ module RuboCop
           include ::RuboCop::Chef::PlatformHelpers
 
           MSG = 'Pass valid platforms to the platform? helper.'
+          RESTRICT_ON_SEND = [:platform?].freeze
 
           def_node_matcher :platform_helper?, <<-PATTERN
             (send nil? :platform? $str*)

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_metadata.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_metadata.rb
@@ -37,6 +37,7 @@ module RuboCop
           include ::RuboCop::Chef::PlatformHelpers
 
           MSG = 'metadata.rb "supports" platform is invalid'
+          RESTRICT_ON_SEND = [:supports].freeze
 
           def_node_matcher :supports?, '(send nil? :supports $str ...)'
 

--- a/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_family_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_family_helper.rb
@@ -39,6 +39,7 @@ module RuboCop
           include ::RuboCop::Chef::PlatformHelpers
 
           MSG = 'Pass valid platform families to the value_for_platform_family helper.'
+          RESTRICT_ON_SEND = [:value_for_platform_family].freeze
 
           def_node_matcher :value_for_platform_family?, <<-PATTERN
           (send nil? :value_for_platform_family

--- a/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_helper.rb
@@ -38,6 +38,7 @@ module RuboCop
           include ::RuboCop::Chef::PlatformHelpers
 
           MSG = 'Pass valid platforms to the value_for_platform helper.'
+          RESTRICT_ON_SEND = [:value_for_platform].freeze
 
           def_node_matcher :value_for_platform?, <<-PATTERN
           (send nil? :value_for_platform

--- a/lib/rubocop/cop/chef/correctness/service_resource.rb
+++ b/lib/rubocop/cop/chef/correctness/service_resource.rb
@@ -29,6 +29,7 @@ module RuboCop
         #
         class ServiceResource < Base
           MSG = 'Use a service resource to start and stop services'
+          RESTRICT_ON_SEND = [:command].freeze
 
           def_node_matcher :execute_command?, <<-PATTERN
             (send nil? :command $str)

--- a/lib/rubocop/cop/chef/correctness/supports_must_be_float.rb
+++ b/lib/rubocop/cop/chef/correctness/supports_must_be_float.rb
@@ -34,6 +34,7 @@ module RuboCop
           extend RuboCop::Cop::AutoCorrector
 
           MSG = 'Versions used in metadata.rb supports calls should be floats not integers.'
+          RESTRICT_ON_SEND = [:supports].freeze
 
           def_node_matcher :supports_with_constraint?, '(send nil? :supports str $str)'
 

--- a/lib/rubocop/cop/chef/correctness/tmp_path.rb
+++ b/lib/rubocop/cop/chef/correctness/tmp_path.rb
@@ -32,6 +32,7 @@ module RuboCop
         #
         class TmpPath < Base
           MSG = 'Use file_cache_path rather than hard-coding tmp paths'
+          RESTRICT_ON_SEND = [:remote_file].freeze
 
           def_node_matcher :remote_file?, <<-PATTERN
             (send nil? :remote_file $str)

--- a/lib/rubocop/cop/chef/deprecation/cb_depends_on_self.rb
+++ b/lib/rubocop/cop/chef/deprecation/cb_depends_on_self.rb
@@ -36,6 +36,7 @@ module RuboCop
           include RangeHelp
 
           MSG = 'A cookbook cannot depend on itself. This will fail on Chef Infra Client 13+'
+          RESTRICT_ON_SEND = [:name].freeze
 
           def_node_search :dependencies, '(send nil? :depends str ...)'
           def_node_matcher :cb_name?, '(send nil? :name str ...)'

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
@@ -33,6 +33,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'There is no need to include the empty and deprecated chef_handler::default recipe in order to use the chef_handler resource'
+          RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :chef_handler_recipe?, <<-PATTERN
             (send nil? :include_recipe (str {"chef_handler" "chef_handler::default"}))

--- a/lib/rubocop/cop/chef/deprecation/chef_rest.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rest.rb
@@ -30,6 +30,7 @@ module RuboCop
         #
         class UsesChefRESTHelpers < Base
           MSG = "Don't use the helpers in Chef::REST which were removed in Chef Infra Client 13"
+          RESTRICT_ON_SEND = [:require].freeze
 
           def_node_matcher :require_rest?, <<-PATTERN
           (send nil? :require ( str "chef/rest"))

--- a/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rewind.rb
@@ -49,6 +49,7 @@ module RuboCop
           }.freeze
 
           MSG = 'Use delete_resource / edit_resource introduced in Chef Infra Client 12.10 instead of functionality in the deprecated chef-rewind gem'
+          RESTRICT_ON_SEND = [:chef_gem, :require, :rewind, :unwind].freeze
 
           def_node_matcher :rewind_gem_install?, <<-PATTERN
             (send nil? :chef_gem (str "chef-rewind"))

--- a/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
@@ -29,16 +29,17 @@ module RuboCop
         class CookbookDependsOnCompatResource < Base
           include RangeHelp
           extend TargetChefVersion
+          extend AutoCorrector
 
           minimum_target_chef_version '12.19'
 
           MSG = "Don't depend on the deprecated compat_resource cookbook made obsolete by Chef 12.19+"
+          RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :depends_compat_resource?, <<-PATTERN
             (send nil? :depends (str {"compat_resource"}))
           PATTERN
 
-          extend AutoCorrector
           def on_send(node)
             depends_compat_resource?(node) do
               add_offense(node, message: MSG, severity: :warning) do |corrector|

--- a/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
@@ -32,6 +32,7 @@ module RuboCop
           minimum_target_chef_version '13.0'
 
           MSG = "Don't depend on the deprecated partial_search cookbook made obsolete by Chef 13"
+          RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :depends_partial_search?, <<-PATTERN
             (send nil? :depends (str "partial_search"))

--- a/lib/rubocop/cop/chef/deprecation/depends_poise.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_poise.rb
@@ -29,6 +29,7 @@ module RuboCop
         #
         class CookbookDependsOnPoise < Base
           MSG = 'Cookbooks should not depend on the deprecated Poise framework'
+          RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :depends_method?, <<-PATTERN
             (send nil? :depends $str)

--- a/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
@@ -39,6 +39,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = "Don't use deprecated Mixins no longer included in Chef Infra Client 14 and later."
+          RESTRICT_ON_SEND = [:include, :require].freeze
 
           def_node_matcher :deprecated_mixin?, <<-PATTERN
             (send nil? :include (const (const (const nil? :Chef) :Mixin) { :Language :LanguageIncludeAttribute :RecipeDefinitionDSLCore :LanguageIncludeRecipe }))

--- a/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
@@ -44,20 +44,19 @@ module RuboCop
 
           minimum_target_chef_version '14.3'
 
-          DEPRECATED_SHELLOUT_METHODS = %i( shell_out_compact
-                                            shell_out_compact!
-                                            shell_out_compact_timeout
-                                            shell_out_compact_timeout!
-                                            shell_out_with_timeout
-                                            shell_out_with_timeout!
-                                            shell_out_with_systems_locale
-                                            shell_out_with_systems_locale!
-                                          ).freeze
-
           MSG = 'Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.'
+          RESTRICT_ON_SEND = %i( shell_out_compact
+          shell_out_compact!
+          shell_out_compact_timeout
+          shell_out_compact_timeout!
+          shell_out_with_timeout
+          shell_out_with_timeout!
+          shell_out_with_systems_locale
+          shell_out_with_systems_locale!
+        ).freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :warning) if DEPRECATED_SHELLOUT_METHODS.include?(node.method_name)
+            add_offense(node, message: MSG, severity: :warning)
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/eol_audit_mode.rb
+++ b/lib/rubocop/cop/chef/deprecation/eol_audit_mode.rb
@@ -34,6 +34,7 @@ module RuboCop
 
         class EOLAuditModeUsage < Base
           MSG = 'The beta Audit Mode feature in Chef Infra Client was removed in Chef Infra Client 15.0. Users should instead use InSpec and the audit cookbook. See https://www.inspec.io/ for more information.'
+          RESTRICT_ON_SEND = [:control_group].freeze
 
           def_node_matcher :control_group?, '(send nil? :control_group ...)'
 

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -61,6 +61,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Use the new-style notification syntax which allows you to notify resources defined later in a recipe or resource.'
+          RESTRICT_ON_SEND = [:notifies, :subscribes].freeze
 
           def_node_matcher :legacy_notify?, <<-PATTERN
             (send nil? ${:notifies :subscribes} $(sym _) (send nil? :resources (hash (pair $(sym _) $(...) ) ) ) $... )

--- a/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
@@ -35,6 +35,7 @@ module RuboCop
         #
         class LegacyYumCookbookRecipes < Base
           MSG = 'The elrepo, epel, ius, remi, and repoforge recipes were split into their own cookbooks and the yum recipe was renamed to be default with the release of yum cookbook 3.0 (Dec 2013).'
+          RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :old_yum_recipe?, <<-PATTERN
             (send nil? :include_recipe (str {"yum::elrepo" "yum::epel" "yum::ius" "yum::remi" "yum::repoforge" "yum::yum"}))

--- a/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
+++ b/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
@@ -36,6 +36,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = "A resource property can't be marked as a name_property and also have a default value. This will fail in Chef Infra Client 13 or later."
+          RESTRICT_ON_SEND = [:attribute, :property].freeze
 
           # match on a property or attribute that has any name and any type and a hash that
           # contains name_property/name_attribute true and any default value. These are wrapped in

--- a/lib/rubocop/cop/chef/deprecation/poise_archive.rb
+++ b/lib/rubocop/cop/chef/deprecation/poise_archive.rb
@@ -39,6 +39,7 @@ module RuboCop
           minimum_target_chef_version '15.0'
 
           MSG = 'The poise_archive resource in the deprecated poise-archive should be replaced with the archive_file resource found in Chef Infra Client 15+'
+          RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :depends_poise_archive?, <<-PATTERN
             (send nil? :depends (str "poise-archive"))

--- a/lib/rubocop/cop/chef/deprecation/require_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/require_recipe.rb
@@ -34,6 +34,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Use include_recipe instead of the require_recipe method'
+          RESTRICT_ON_SEND = [:require_recipe].freeze
 
           def_node_matcher :require_recipe?, <<-PATTERN
             (send nil? :require_recipe $str)

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
@@ -33,6 +33,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Starting with Chef Infra Client 16, using `resource_name` without also using `provides` will result in resource failures. Make sure to use both `resource_name` and `provides` to change the name of the resource. You can also omit `resource_name` entirely if the value set matches the name Chef Infra Client automatically assigns based on COOKBOOKNAME_FILENAME.'
+          RESTRICT_ON_SEND = [:resource_name].freeze
 
           def_node_matcher :resource_name?, '(send nil? :resource_name (sym $_ ))'
 

--- a/lib/rubocop/cop/chef/deprecation/ruby_27_keyword_argument_warnings.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_27_keyword_argument_warnings.rb
@@ -36,6 +36,7 @@ module RuboCop
           extend RuboCop::Cop::AutoCorrector
 
           MSG = 'Pass options to shell_out helpers without the brackets to avoid Ruby 2.7 deprecation warnings.'
+          RESTRICT_ON_SEND = [:shell_out!, :shell_out].freeze
 
           def_node_matcher :positional_shellout?, <<-PATTERN
             (send nil? {:shell_out :shell_out!} ... $(hash ... ))

--- a/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
@@ -35,6 +35,7 @@ module RuboCop
         #
         class UsesRunCommandHelper < Base
           MSG = "Use 'shell_out!' instead of the legacy 'run_command' or 'run_command_with_systems_locale' helpers for shelling out. The run_command helper was removed in Chef Infra Client 13."
+          RESTRICT_ON_SEND = [:require, :run_command, :run_command_with_systems_locale, :include].freeze
 
           def_node_matcher :calls_run_command?, '(send nil? {:run_command :run_command_with_systems_locale} ...)'
           def_node_matcher :require_mixin_command?, '(send nil? :require (str "chef/mixin/command"))'

--- a/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
+++ b/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
@@ -39,6 +39,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = "Don't use deprecated positional parameters in cookbook search queries."
+          RESTRICT_ON_SEND = [:search].freeze
 
           NAMED_PARAM_LOOKUP_TABLE = [nil, nil, 'start', 'rows', 'filter_result'].freeze
 

--- a/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
@@ -30,6 +30,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Do not include the deprecated xml::ruby recipe to install the nokogiri gem. Chef Infra Client 12 and later ships with nokogiri included.'
+          RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :xml_ruby_recipe?, <<-PATTERN
             (send nil? :include_recipe (str "xml::ruby"))

--- a/lib/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe.rb
@@ -32,6 +32,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Do not include the deprecated yum::dnf_yum_compat default recipe to install yum on dnf systems. Chef Infra Client now includes built in support for DNF packages.'
+          RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :yum_dnf_compat_recipe_usage?, <<-PATTERN
             (send nil? :include_recipe (str "yum::dnf_yum_compat"))

--- a/lib/rubocop/cop/chef/modernize/apt_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/apt_default_recipe.rb
@@ -36,6 +36,7 @@ module RuboCop
           minimum_target_chef_version '12.7'
 
           MSG = 'Do not include the Apt default recipe to update package cache. Instead use the apt_update resource, which is built into Chef Infra Client 12.7 and later.'
+          RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :apt_recipe_usage?, <<-PATTERN
             (send nil? :include_recipe (str {"apt" "apt::default"}))

--- a/lib/rubocop/cop/chef/modernize/berksfile_source.rb
+++ b/lib/rubocop/cop/chef/modernize/berksfile_source.rb
@@ -38,6 +38,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Do not use legacy Berksfile community sources. Use Chef Supermarket instead.'
+          RESTRICT_ON_SEND = [:source, :site].freeze
 
           def_node_matcher :berksfile_site?, <<-PATTERN
             (send nil? :site (:sym _))

--- a/lib/rubocop/cop/chef/modernize/build_essential.rb
+++ b/lib/rubocop/cop/chef/modernize/build_essential.rb
@@ -35,6 +35,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+'
+          RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :build_essential_recipe_usage?, <<-PATTERN
             (send nil? :include_recipe (str {"build-essential" "build-essential::default"}))

--- a/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
@@ -40,6 +40,7 @@ module RuboCop
           minimum_target_chef_version '14.0'
 
           MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself."
+          RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :legacy_depends?, <<-PATTERN
             (send nil? :depends (str {"build-essential" "chef_handler" "chef_hostname" "dmg" "mac_os_x" "swap" "sysctl"}) ... )

--- a/lib/rubocop/cop/chef/modernize/chef_gem_nokogiri.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_gem_nokogiri.rb
@@ -33,6 +33,7 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
 
           MSG = 'The nokogiri gem ships in Chef Infra Client 12+ and does not need to be installed before being used.'
+          RESTRICT_ON_SEND = [:chef_gem].freeze
 
           def_node_matcher :nokogiri_install?, <<-PATTERN
             (send nil? :chef_gem (str "nokogiri"))

--- a/lib/rubocop/cop/chef/modernize/conditional_using_test.rb
+++ b/lib/rubocop/cop/chef/modernize/conditional_using_test.rb
@@ -33,6 +33,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = "Use ::File.exist?('/foo/bar') instead of the slower 'test -f /foo/bar' which requires shelling out"
+          RESTRICT_ON_SEND = [:not_if, :only_if].freeze
 
           def_node_matcher :resource_conditional?, <<~PATTERN
           (send nil? {:not_if :only_if} $str )

--- a/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
@@ -34,6 +34,7 @@ module RuboCop
           minimum_target_chef_version '13.3'
 
           MSG = "Don't depend on the zypper cookbook as the zypper_repository resource is built into Chef Infra Client 13.3+"
+          RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :zypper_depends?, <<-PATTERN
             (send nil? :depends (str "zypper"))

--- a/lib/rubocop/cop/chef/modernize/dsl_include_in_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/dsl_include_in_resource.rb
@@ -30,6 +30,7 @@ module RuboCop
           include RangeHelp
 
           MSG = 'Chef Infra Client 12.4+ includes the Chef::DSL::Recipe in the resource and provider classed by default so there is no need to include this DSL in your resources or providers.'
+          RESTRICT_ON_SEND = [:include].freeze
 
           def_node_matcher :dsl_include?, <<-PATTERN
           (send nil? :include

--- a/lib/rubocop/cop/chef/modernize/execute_apt_update.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_apt_update.rb
@@ -46,6 +46,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Use the apt_update resource instead of the execute resource to run an apt-get update package cache update'
+          RESTRICT_ON_SEND = [:execute, :notifies, :subscribes, :command].freeze
 
           def_node_matcher :execute_apt_update?, <<-PATTERN
             (send nil? :execute (str { "apt-get update" "apt-get update -y" "apt-get -y update" }))

--- a/lib/rubocop/cop/chef/modernize/execute_sc_exe.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_sc_exe.rb
@@ -39,12 +39,13 @@ module RuboCop
           minimum_target_chef_version '14.0'
 
           MSG = 'Chef Infra Client 14.0 and later includes :create, :delete, and :configure actions with the full idempotency of the windows_service resource. See the windows_service documentation at https://docs.chef.io/resource_windows_service.html for additional details on creating services with the windows_service resource'
+          RESTRICT_ON_SEND = [:execute].freeze
 
           # non block execute resources
           def on_send(node)
             # use a regex on source instead of .value in case there's string interpolation which adds a complex dstr type
             # with a nested string and a begin. Source allows us to avoid a lot of defensive programming here
-            return unless node&.arguments.first&.source&.match?(/^("|')sc.exe/) && node.method_name == :execute
+            return unless node&.arguments.first&.source&.match?(/^("|')sc.exe/)
 
             add_offense(node, message: MSG, severity: :refactor)
           end

--- a/lib/rubocop/cop/chef/modernize/execute_sleep.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_sleep.rb
@@ -43,12 +43,13 @@ module RuboCop
           minimum_target_chef_version '15.5'
 
           MSG = 'Chef Infra Client 15.5 and later include a chef_sleep resource that should be used to sleep between executing resources if necessary instead of using the bash or execute resources to run the sleep command.'
+          RESTRICT_ON_SEND = [:execute].freeze
 
           # non block execute resources
           def on_send(node)
             # use a regex on source instead of .value in case there's string interpolation which adds a complex dstr type
             # with a nested string and a begin. Source allows us to avoid a lot of defensive programming here
-            return unless node.method_name == :execute && node&.arguments.first&.source&.match?(/^("|')sleep/)
+            return unless node&.arguments.first&.source&.match?(/^("|')sleep/)
             add_offense(node, message: MSG, severity: :refactor)
           end
 

--- a/lib/rubocop/cop/chef/modernize/execute_sysctl.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_sysctl.rb
@@ -43,12 +43,13 @@ module RuboCop
           minimum_target_chef_version '14.0'
 
           MSG = 'Chef Infra Client 14.0 and later includes a sysctl resource that should be used to idempotently load sysctl values instead of templating files and using execute to load them.'
+          RESTRICT_ON_SEND = [:execute].freeze
 
           # non block execute resources
           def on_send(node)
             # use a regex on source instead of .value in case there's string interpolation which adds a complex dstr type
             # with a nested string and a begin. Source allows us to avoid a lot of defensive programming here
-            return unless node.method_name == :execute && node&.arguments.first&.source&.match?(/^("|')sysctl -p/)
+            return unless node&.arguments.first&.source&.match?(/^("|')sysctl -p/)
             add_offense(node, message: MSG, severity: :refactor)
           end
 

--- a/lib/rubocop/cop/chef/modernize/execute_tzutil.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_tzutil.rb
@@ -44,6 +44,7 @@ module RuboCop
           minimum_target_chef_version '14.6'
 
           MSG = 'Use the timezone resource included in Chef Infra Client 14.6+ instead of shelling out to tzutil'
+          RESTRICT_ON_SEND = [:execute].freeze
 
           def_node_matcher :execute_resource?, <<-PATTERN
             (send nil? :execute $str)

--- a/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
+++ b/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
@@ -35,6 +35,7 @@ module RuboCop
           include RangeHelp
 
           MSG = 'There is no need to include Chef::Mixin::ShellOut or Chef::Mixin::PowershellOut in resources or providers as this is already done by Chef Infra Client 12.4+.'
+          RESTRICT_ON_SEND = [:include, :require].freeze
 
           def_node_matcher :include_shellout?, <<-PATTERN
             (send nil? :include (const (const (const nil? :Chef) :Mixin) {:ShellOut :PowershellOut}))

--- a/lib/rubocop/cop/chef/modernize/libarchive_file.rb
+++ b/lib/rubocop/cop/chef/modernize/libarchive_file.rb
@@ -41,6 +41,7 @@ module RuboCop
           minimum_target_chef_version '15.0'
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource'
+          RESTRICT_ON_SEND = [:libarchive_file, :notifies, :subscribes].freeze
 
           def_node_matcher :notification_property?, <<-PATTERN
             (send nil? {:notifies :subscribes} (sym _) $(...) (sym _))

--- a/lib/rubocop/cop/chef/modernize/macos_user_defaults.rb
+++ b/lib/rubocop/cop/chef/modernize/macos_user_defaults.rb
@@ -43,9 +43,9 @@ module RuboCop
           minimum_target_chef_version '14.0'
 
           MSG = 'The mac_os_x_userdefaults resource was renamed to macos_userdefaults when it was added to Chef Infra Client 14.0. The new resource name should be used.'
+          RESTRICT_ON_SEND = [:mac_os_x_userdefaults].freeze
 
           def on_send(node)
-            return unless node.method_name == :mac_os_x_userdefaults
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.replace(node.loc.expression, node.source.gsub(/^mac_os_x_userdefaults/, 'macos_userdefaults'))
             end

--- a/lib/rubocop/cop/chef/modernize/minitest_handler_usage.rb
+++ b/lib/rubocop/cop/chef/modernize/minitest_handler_usage.rb
@@ -31,6 +31,7 @@ module RuboCop
           include RangeHelp
 
           MSG = 'Use Chef InSpec for testing instead of the Minitest Handler cookbook pattern.'
+          RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :minitest_depends?, <<-PATTERN
             (send nil? :depends (str "minitest-handler"))

--- a/lib/rubocop/cop/chef/modernize/ohai_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/ohai_default_recipe.rb
@@ -31,6 +31,7 @@ module RuboCop
         #
         class IncludingOhaiDefaultRecipe < Base
           MSG = "Use the ohai_plugin resource to ship custom Ohai plugins instead of using the ohai::default recipe. If you're not shipping custom Ohai plugins, then you can remove this recipe entirely"
+          RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :ohai_recipe_usage?, <<-PATTERN
             (send nil? :include_recipe (str {"ohai" "ohai::default"}))

--- a/lib/rubocop/cop/chef/modernize/openssl_rsa_key_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/openssl_rsa_key_resource.rb
@@ -39,9 +39,9 @@ module RuboCop
           minimum_target_chef_version '14.0'
 
           MSG = 'The openssl_rsa_key resource was renamed to openssl_rsa_private_key in Chef Infra Client 14.0. The new resource name should be used.'
+          RESTRICT_ON_SEND = [:openssl_rsa_key].freeze
 
           def on_send(node)
-            return unless node.method_name == :openssl_rsa_key
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.replace(node.loc.expression, node.source.gsub(/^openssl_rsa_key/, 'openssl_rsa_private_key'))
             end

--- a/lib/rubocop/cop/chef/modernize/openssl_x509_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/openssl_x509_resource.rb
@@ -45,9 +45,9 @@ module RuboCop
           minimum_target_chef_version '14.4'
 
           MSG = 'The openssl_x509 resource was renamed to openssl_x509_certificate in Chef Infra Client 14.4. The new resource name should be used.'
+          RESTRICT_ON_SEND = [:openssl_x509].freeze
 
           def on_send(node)
-            return unless node.method_name == :openssl_x509
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.replace(node.loc.expression, node.source.gsub(/^openssl_x509/, 'openssl_x509_certificate'))
             end

--- a/lib/rubocop/cop/chef/modernize/osx_config_profile_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/osx_config_profile_resource.rb
@@ -36,9 +36,9 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'The osx_config_profile resource was renamed to osx_profile. The new resource name should be used.'
+          RESTRICT_ON_SEND = [:osx_config_profile].freeze
 
           def on_send(node)
-            return unless node.method_name == :osx_config_profile
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.replace(node.loc.expression, node.source.gsub(/^osx_config_profile/, 'osx_profile'))
             end

--- a/lib/rubocop/cop/chef/modernize/property_with_name_attribute.rb
+++ b/lib/rubocop/cop/chef/modernize/property_with_name_attribute.rb
@@ -33,6 +33,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Resource property sets name_attribute instead of name_property'
+          RESTRICT_ON_SEND = [:property].freeze
 
           # match on a property that has any name and any type and a hash that
           # contains name_attribute true. The hash pairs are wrapped in

--- a/lib/rubocop/cop/chef/modernize/resource_set_or_return.rb
+++ b/lib/rubocop/cop/chef/modernize/resource_set_or_return.rb
@@ -40,9 +40,9 @@ module RuboCop
         #
         class SetOrReturnInResources < Base
           MSG = 'Do not use set_or_return within a method to define a property for a resource. Use the property method instead, which supports validation, reporting, and documentation functionality'
+          RESTRICT_ON_SEND = [:set_or_return].freeze
 
           def on_send(node)
-            return unless node.method_name == :set_or_return
             add_offense(node, message: MSG, severity: :refactor)
           end
         end

--- a/lib/rubocop/cop/chef/modernize/resource_with_attributes.rb
+++ b/lib/rubocop/cop/chef/modernize/resource_with_attributes.rb
@@ -44,6 +44,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Custom Resources should contain properties not attributes'
+          RESTRICT_ON_SEND = [:attribute].freeze
 
           def_node_matcher :attribute?, <<-PATTERN
             (send nil? $:attribute ... )

--- a/lib/rubocop/cop/chef/modernize/sc_windows_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/sc_windows_resource.rb
@@ -39,9 +39,10 @@ module RuboCop
           minimum_target_chef_version '14.0'
 
           MSG = 'Chef Infra Client 14.0 and later includes :create, :delete, and :configure actions without the need for the sc cookbook dependency. See the windows_service documentation at https://docs.chef.io/resource_windows_service.html for additional details.'
+          RESTRICT_ON_SEND = [:sc_windows].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :refactor) if node.method_name == :sc_windows
+            add_offense(node, message: MSG, severity: :refactor)
           end
         end
       end

--- a/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
@@ -35,9 +35,10 @@ module RuboCop
           minimum_target_chef_version '15.0'
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the seven_zip_archive'
+          RESTRICT_ON_SEND = [:seven_zip_archive].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :refactor) if node.method_name == :seven_zip_archive
+            add_offense(node, message: MSG, severity: :refactor)
           end
         end
       end

--- a/lib/rubocop/cop/chef/modernize/sysctl_param_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/sysctl_param_resource.rb
@@ -39,9 +39,9 @@ module RuboCop
           minimum_target_chef_version '14.0'
 
           MSG = 'The sysctl_param resource was renamed to sysctl when it was added to Chef Infra Client 14.0. The new resource name should be used.'
+          RESTRICT_ON_SEND = [:sysctl_param].freeze
 
           def on_send(node)
-            return unless node.method_name == :sysctl_param
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.replace(node.loc.expression, node.source.gsub(/^sysctl_param/, 'sysctl'))
             end

--- a/lib/rubocop/cop/chef/modernize/unnecessary_mixlib_shellout_require.rb
+++ b/lib/rubocop/cop/chef/modernize/unnecessary_mixlib_shellout_require.rb
@@ -32,6 +32,7 @@ module RuboCop
           include RangeHelp
 
           MSG = 'Chef Infra Client 12.4+ includes mixlib/shellout automatically in resources and providers.'
+          RESTRICT_ON_SEND = [:require].freeze
 
           def_node_matcher :require_mixlibshellout?, <<-PATTERN
           (send nil? :require ( str "mixlib/shellout"))

--- a/lib/rubocop/cop/chef/modernize/use_require_relative.rb
+++ b/lib/rubocop/cop/chef/modernize/use_require_relative.rb
@@ -33,6 +33,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Instead of using require with a File.expand_path and __FILE__ use the simpler require_relative method.'
+          RESTRICT_ON_SEND = [:require].freeze
 
           def_node_matcher :require_with_expand_path?, <<-PATTERN
             (send nil? :require

--- a/lib/rubocop/cop/chef/modernize/windows_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_default_recipe.rb
@@ -32,6 +32,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Do not include the Windows default recipe, which only installs win32 gems already included in Chef Infra Client'
+          RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :windows_recipe_usage?, <<-PATTERN
             (send nil? :include_recipe (str {"windows" "windows::default"}))

--- a/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
@@ -44,11 +44,11 @@ module RuboCop
           minimum_target_chef_version '15.0'
 
           MSG = 'Chef Infra Client 15.0 and later includes a windows_uac resource that should be used to set Windows UAC values instead of setting registry keys directly.'
+          RESTRICT_ON_SEND = [:registry_key].freeze
 
           # non block execute resources
           def on_send(node)
-            return unless node.method_name == :registry_key &&
-                          node&.arguments.first&.source.match?(/(HKLM|HKEY_LOCAL_MACHINE)\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/i) &&
+            return unless node&.arguments.first&.source.match?(/(HKLM|HKEY_LOCAL_MACHINE)\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System/i) &&
                           node.parent&.method_name != :describe
 
             # use source instead of .value in case there's string interpolation which adds a complex dstr type

--- a/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
@@ -34,9 +34,10 @@ module RuboCop
           minimum_target_chef_version '15.0'
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the windows_zipfile from the Windows cookbook'
+          RESTRICT_ON_SEND = [:windows_zipfile].freeze
 
           def on_send(node)
-            add_offense(node, message: MSG, severity: :refactor) if node.method_name == :windows_zipfile
+            add_offense(node, message: MSG, severity: :refactor)
           end
         end
       end

--- a/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
@@ -36,6 +36,7 @@ module RuboCop
           minimum_target_chef_version '15.0'
 
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the zipfile resource from the zipfile cookbook.'
+          RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :depends_zipfile?, <<-PATTERN
             (send nil? :depends (str "zipfile"))

--- a/lib/rubocop/cop/chef/modernize/zypper_repo.rb
+++ b/lib/rubocop/cop/chef/modernize/zypper_repo.rb
@@ -46,9 +46,9 @@ module RuboCop
           minimum_target_chef_version '13.3'
 
           MSG = 'The zypper_repo resource was renamed zypper_repository when it was added to Chef Infra Client 13.3.'
+          RESTRICT_ON_SEND = [:zypper_repo].freeze
 
           def on_send(node)
-            return unless node.method_name == :zypper_repo
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.replace(node.loc.expression, node.source.gsub(/^zypper_repo/, 'zypper_repository'))
             end

--- a/lib/rubocop/cop/chef/redundant/attribute_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/attribute_metadata.rb
@@ -39,9 +39,9 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'The attribute metadata.rb method is not used and is unnecessary in cookbooks.'
+          RESTRICT_ON_SEND = [:attribute].freeze
 
           def on_send(node)
-            return unless node.method_name == :attribute
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end

--- a/lib/rubocop/cop/chef/redundant/conflicts_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/conflicts_metadata.rb
@@ -33,9 +33,9 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'The conflicts metadata.rb method is not used and is unnecessary in cookbooks.'
+          RESTRICT_ON_SEND = [:conflicts].freeze
 
           def on_send(node)
-            return unless node.method_name == :conflicts
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :right))
             end

--- a/lib/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions.rb
+++ b/lib/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions.rb
@@ -35,10 +35,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'It is not necessary to set `actions` or `allowed_actions` in custom resources as Chef Infra Client determines these automatically from the set of all actions defined in the resource'
-
-          def_node_matcher :allowed_actions?, <<-PATTERN
-            (send nil? {:allowed_actions :actions} ... )
-          PATTERN
+          RESTRICT_ON_SEND = [:allowed_actions, :actions].freeze
 
           def_node_search :poise_require, '(send nil? :require (str "poise"))'
 
@@ -50,10 +47,8 @@ module RuboCop
             # if the resource requires poise then bail out since we're in a poise resource where @allowed_actions is legit
             return if poise_require(processed_source.ast).any? && !resource_actions?(processed_source.ast)
 
-            allowed_actions?(node) do
-              add_offense(node, message: MSG, severity: :refactor) do |corrector|
-                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
-              end
+            add_offense(node, message: MSG, severity: :refactor) do |corrector|
+              corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end
           end
         end

--- a/lib/rubocop/cop/chef/redundant/grouping_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/grouping_metadata.rb
@@ -33,10 +33,9 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'The grouping metadata.rb method is not used and is unnecessary in cookbooks.'
+          RESTRICT_ON_SEND = [:grouping].freeze
 
           def on_send(node)
-            return unless node.method_name == :grouping
-
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end

--- a/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
@@ -33,10 +33,9 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'The long_description metadata.rb method is not used and is unnecessary in cookbooks.'
+          RESTRICT_ON_SEND = [:long_description].freeze
 
           def on_send(node)
-            return unless node.method_name == :long_description
-
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end

--- a/lib/rubocop/cop/chef/redundant/property_with_default_and_required.rb
+++ b/lib/rubocop/cop/chef/redundant/property_with_default_and_required.rb
@@ -37,6 +37,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Resource properties should not be both required and have a default value. This will fail on Chef Infra Client 13+'
+          RESTRICT_ON_SEND = [:property, :attribute].freeze
 
           # match on a property or attribute that has any name and any type and a hash that
           # contains default: true and required: true. These are wrapped in <> which means

--- a/lib/rubocop/cop/chef/redundant/provides_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/provides_metadata.rb
@@ -33,10 +33,9 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'The provides metadata.rb method is not used and is unnecessary in cookbooks.'
+          RESTRICT_ON_SEND = [:provides].freeze
 
           def on_send(node)
-            return unless node.method_name == :provides
-
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end

--- a/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
@@ -34,10 +34,9 @@ module RuboCop
           extend AutoCorrector
 
           MSG = "The recipe metadata.rb method is not used and is unnecessary in cookbooks. Recipes should be documented in the cookbook's README.md file instead."
+          RESTRICT_ON_SEND = [:recipe].freeze
 
           def on_send(node)
-            return unless node.method_name == :recipe
-
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: expression_including_heredocs(node), side: :left))
             end

--- a/lib/rubocop/cop/chef/redundant/replaces_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/replaces_metadata.rb
@@ -33,10 +33,9 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'The replaces metadata.rb method is not used and is unnecessary in cookbooks.'
+          RESTRICT_ON_SEND = [:replaces].freeze
 
           def on_send(node)
-            return unless node.method_name == :replaces
-
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end

--- a/lib/rubocop/cop/chef/redundant/sensitive_property_in_resource.rb
+++ b/lib/rubocop/cop/chef/redundant/sensitive_property_in_resource.rb
@@ -28,6 +28,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Every Chef Infra resource already includes a sensitive property with a default value of false.'
+          RESTRICT_ON_SEND = [:property, :attribute].freeze
 
           def_node_matcher :sensitive_property?, <<-PATTERN
             (send nil? {:property :attribute} (sym :sensitive) ... (hash (pair (sym :default) (false))))

--- a/lib/rubocop/cop/chef/redundant/string_property_with_nil_default.rb
+++ b/lib/rubocop/cop/chef/redundant/string_property_with_nil_default.rb
@@ -36,6 +36,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Properties have a nil value by default so there is no need to set the default value to nil.'
+          RESTRICT_ON_SEND = [:property].freeze
 
           def_node_matcher :string_property_with_nil_default?, <<-PATTERN
             (send nil? :property (sym _)

--- a/lib/rubocop/cop/chef/redundant/suggests_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/suggests_metadata.rb
@@ -33,10 +33,9 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'The suggests metadata.rb method is not used and is unnecessary in cookbooks.'
+          RESTRICT_ON_SEND = [:suggests].freeze
 
           def on_send(node)
-            return unless node.method_name == :suggests
-
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
             end

--- a/lib/rubocop/cop/chef/redundant/unnecessary_desired_state.rb
+++ b/lib/rubocop/cop/chef/redundant/unnecessary_desired_state.rb
@@ -30,6 +30,7 @@ module RuboCop
           include RangeHelp
 
           MSG = 'There is no need to set a property to desired_state: true as all properties have a desired_state of true by default.'
+          RESTRICT_ON_SEND = [:property, :attribute].freeze
 
           def_node_matcher :property?, <<-PATTERN
             (send nil? {:property :attribute} (sym _) ... $(hash ...))

--- a/lib/rubocop/cop/chef/redundant/unnecessary_name_property.rb
+++ b/lib/rubocop/cop/chef/redundant/unnecessary_name_property.rb
@@ -33,6 +33,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'There is no need to define a property or attribute named :name in a resource as Chef Infra defines this on all resources by default.'
+          RESTRICT_ON_SEND = [:property, :attribute].freeze
 
           def_node_matcher :name_attribute?, <<-PATTERN
           (send nil? :attribute

--- a/lib/rubocop/cop/chef/sharing/default_maintainer_metadata.rb
+++ b/lib/rubocop/cop/chef/sharing/default_maintainer_metadata.rb
@@ -35,6 +35,7 @@ module RuboCop
         #
         class DefaultMetadataMaintainer < Base
           MSG = 'Metadata contains default maintainer information from the cookbook generator. Add actual cookbook maintainer information to the metadata.rb.'
+          RESTRICT_ON_SEND = [:maintainer, :maintainer_email].freeze
 
           def_node_matcher :default_metadata?, '(send nil? {:maintainer :maintainer_email} (str {"YOUR_COMPANY_NAME" "The Authors" "YOUR_EMAIL" "you@example.com"}))'
 

--- a/lib/rubocop/cop/chef/sharing/include_property_descriptions.rb
+++ b/lib/rubocop/cop/chef/sharing/include_property_descriptions.rb
@@ -35,6 +35,7 @@ module RuboCop
           minimum_target_chef_version '13.9'
 
           MSG = 'Resource properties should include description fields to allow automated documentation. Requires Chef Infra Client 13.9 or later.'
+          RESTRICT_ON_SEND = [:property].freeze
 
           # any method named property being called with a symbol argument and anything else
           def_node_matcher :property?, '(send nil? :property (sym _) ...)'

--- a/lib/rubocop/cop/chef/sharing/insecure_cookbook_url.rb
+++ b/lib/rubocop/cop/chef/sharing/insecure_cookbook_url.rb
@@ -37,6 +37,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Insecure http Github or Gitlab URLs for metadata source_url/issues_url fields'
+          RESTRICT_ON_SEND = [:source_url, :issues_url].freeze
 
           def_node_matcher :insecure_cb_url?, <<-PATTERN
             (send nil? {:source_url :issues_url} (str #insecure_url?))

--- a/lib/rubocop/cop/chef/sharing/invalid_license_string.rb
+++ b/lib/rubocop/cop/chef/sharing/invalid_license_string.rb
@@ -458,6 +458,7 @@ module RuboCop
           }.freeze
 
           MSG = 'Cookbook metadata.rb does not use a SPDX compliant license string or "all rights reserved". See https://spdx.org/licenses/ for a complete list of license identifiers.'
+          RESTRICT_ON_SEND = [:license].freeze
 
           def_node_matcher :license?, '(send nil? :license $str ...)'
 

--- a/lib/rubocop/cop/chef/style/file_mode.rb
+++ b/lib/rubocop/cop/chef/style/file_mode.rb
@@ -55,6 +55,7 @@ module RuboCop
           extend RuboCop::Cop::AutoCorrector
 
           MSG = 'Use strings to represent file modes to avoid confusion between octal and base 10 integer formats'
+          RESTRICT_ON_SEND = [:mode, :files_mode].freeze
 
           def_node_matcher :resource_mode?, <<-PATTERN
             (send nil? {:mode :files_mode} $int)

--- a/lib/rubocop/cop/chef/style/immediate_notification_timing.rb
+++ b/lib/rubocop/cop/chef/style/immediate_notification_timing.rb
@@ -39,6 +39,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG = 'Use :immediately instead of :immediate for resource notification timing'
+          RESTRICT_ON_SEND = [:notifies].freeze
 
           def_node_matcher :immediate_notify?, <<-PATTERN
             (send nil? :notifies (sym _) (...) $(sym :immediate))

--- a/lib/rubocop/cop/chef/style/include_recipe_with_parentheses.rb
+++ b/lib/rubocop/cop/chef/style/include_recipe_with_parentheses.rb
@@ -34,6 +34,7 @@ module RuboCop
           extend RuboCop::Cop::AutoCorrector
 
           MSG = 'There is no need to wrap the recipe in parentheses when using the include_recipe helper'
+          RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :include_recipe?, <<-PATTERN
             (send nil? :include_recipe $(str _))

--- a/lib/rubocop/cop/chef/style/true_false_resource_properties.rb
+++ b/lib/rubocop/cop/chef/style/true_false_resource_properties.rb
@@ -31,7 +31,9 @@ module RuboCop
         #
         class TrueClassFalseClassResourceProperties < Base
           extend AutoCorrector
+
           MSG = "When setting the allowed types for a resource to accept either true or false values it's much simpler to use true and false instead of TrueClass and FalseClass."
+          RESTRICT_ON_SEND = [:property, :attribute].freeze
 
           def_node_matcher :trueclass_falseclass_property?, <<-PATTERN
             (send nil? {:property :attribute} (sym _) $(array (const nil? :TrueClass) (const nil? :FalseClass)) ... )


### PR DESCRIPTION
This gets us a 15% speedup scanning the chef-cookbooks org.

Signed-off-by: Tim Smith <tsmith@chef.io>