### PR TITLE
Resolve a regression in CustomResourceWithAllowedActions

### DIFF
--- a/lib/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions.rb
+++ b/lib/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions.rb
@@ -45,7 +45,7 @@ module RuboCop
 
           def on_send(node)
             # if the resource requires poise then bail out since we're in a poise resource where @allowed_actions is legit
-            return if poise_require(processed_source.ast).any? && !resource_actions?(processed_source.ast)
+            return if poise_require(processed_source.ast).any? || !resource_actions?(processed_source.ast)
 
             add_offense(node, message: MSG, severity: :refactor) do |corrector|
               corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))

--- a/spec/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions_spec.rb
@@ -58,4 +58,24 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::CustomResourceWithAllowedActions
       end
     RUBY
   end
+
+  it 'does not register an offense when in a LWRP resource' do
+    expect_no_offenses(<<~RUBY)
+      actions [:create, :remove]
+      allowed_actions [:create, :remove]
+    RUBY
+  end
+
+  it 'does not register an offense when in a Poise resource' do
+    expect_no_offenses(<<~RUBY)
+      require 'poise'
+
+      actions [:create, :remove]
+      allowed_actions [:create, :remove]
+
+      action :foo do
+        # action stuff
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
We need to not alert if the resource lacks actions OR it's a poise
action, not both. Add 2 tests for that.

Signed-off-by: Tim Smith