### PR TITLE
Resolve another regression in CustomResourceWithAllowedActions

### DIFF
--- a/lib/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions.rb
+++ b/lib/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions.rb
@@ -44,6 +44,9 @@ module RuboCop
           PATTERN
 
           def on_send(node)
+            # avoid triggering on things like new_resource.actions
+            return unless node.receiver.nil?
+
             # if the resource requires poise then bail out since we're in a poise resource where @allowed_actions is legit
             return if poise_require(processed_source.ast).any? || !resource_actions?(processed_source.ast)
 

--- a/spec/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions_spec.rb
@@ -78,4 +78,16 @@ describe RuboCop::Cop::Chef::ChefRedundantCode::CustomResourceWithAllowedActions
       end
     RUBY
   end
+
+  it 'does not register an offense when calling actions method on another object' do
+    expect_no_offenses(<<~RUBY)
+      action :create do
+        template ::File.join(apache_dir, 'mods-available', 'actions.conf') do
+          source 'mods/actions.conf.erb'
+          cookbook 'apache2'
+          variables(actions: new_resource.actions)
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Make sure we trigger on actions, but not something new new_resource.actions

Signed-off-by: Tim Smith <tsmith@chef.io>