### PR TITLE
Resolve a regression in ResourceOverridesProvidesMethod

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/resource_overrides_provides_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_overrides_provides_method.rb
@@ -33,11 +33,12 @@ module RuboCop
         #
         class ResourceOverridesProvidesMethod < Base
           MSG = "Don't override the provides? method in a resource provider. Use provides :SOME_PROVIDER_NAME instead. This will cause failures in Chef Infra Client 13 and later."
-          RESTRICT_ON_SEND = [:provides?].freeze
 
           def_node_search :provides, '(send nil? :provides ...)'
 
           def on_def(node)
+            return unless node.method_name == :provides?
+
             add_offense(node, message: MSG, severity: :warning) if provides(processed_source.ast).count == 0
           end
         end

--- a/spec/rubocop/cop/chef/deprecation/resource_overrides_provides_method_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/resource_overrides_provides_method_spec.rb
@@ -38,4 +38,12 @@ describe RuboCop::Cop::Chef::ChefDeprecations::ResourceOverridesProvidesMethod, 
       end
     RUBY
   end
+
+  it "doesn't register an offense with any old method" do
+    expect_no_offenses(<<~RUBY)
+      def foo
+       true
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
:facepalm: This is an on_def not an on_send. Add a test to catch this
sort of thing in the future.

Signed-off-by: Tim Smith <tsmith@chef.io>