### PR TITLE
Enable Lint/Syntax cop that previously enabled by default

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2613,3 +2613,7 @@ Style/BisectedAttrAccessor:
 # avoid assignments that aren't needed
 Style/RedundantAssignment:
   Enabled: true
+
+# alert on invalid ruby
+Lint/Syntax:
+  Enabled: true

--- a/config/upstream.yml
+++ b/config/upstream.yml
@@ -1861,7 +1861,6 @@ Lint/Syntax:
   Enabled: true
   VersionAdded: '0.9'
 
-
 Lint/ToJSON:
   Description: 'Ensure #to_json includes an optional argument.'
   Enabled: true


### PR DESCRIPTION
Something in one of the older RuboCop releases made this always run.
Recently it stopped running and it's one of the most important cops for
detecting invalid code.

Signed-off-by: Tim Smith <tsmith@chef.io>