### PR TITLE
Replace uses of File.dirname(__FILE__) with __dir__

### DIFF
--- a/bin/cookstyle
+++ b/bin/cookstyle
@@ -2,7 +2,7 @@
 # -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.join(File.dirname(__FILE__), %w(.. lib))
+$LOAD_PATH.unshift File.join(__dir__, %w(.. lib))
 
 require 'cookstyle'
 

--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -19,7 +19,7 @@ module RuboCop
   class ConfigLoader
     RUBOCOP_HOME.gsub!(
       /^.*$/,
-      File.realpath(File.join(File.dirname(__FILE__), '..'))
+      File.realpath(File.join(__dir__, '..'))
     )
 
     DEFAULT_FILE.gsub!(
@@ -46,7 +46,7 @@ require_relative 'rubocop/chef/cookbook_only'
 require_relative 'rubocop/cop/target_chef_version'
 
 # Chef Infra specific cops
-Dir.glob(File.dirname(__FILE__) + '/rubocop/cop/chef/**/*.rb') do |file|
+Dir.glob(__dir__ + '/rubocop/cop/chef/**/*.rb') do |file|
   next if File.directory?(file)
 
   require_relative file # not actually relative but require_relative is faster

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,8 @@ RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense
 end
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-$LOAD_PATH.unshift(File.dirname(__FILE__))
+$LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
+$LOAD_PATH.unshift(__dir__)
 
 # small helper for use in let blocks
 def target_chef_version(version)


### PR DESCRIPTION
Avoid using File.dirname(__FILE__) when we can just use __dir__ to get the same thing.

Signed-off-by: Tim Smith <tsmith@chef.io>