### PR TITLE
Add missing description to rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ task :vendor do
 end
 
 require 'cookstyle'
+desc 'Run cookstyle against cookstyle'
 task :style do
   sh('bundle exec cookstyle')
 end


### PR DESCRIPTION
It doesn't show up in the task list without this.

Signed-off-by: Tim Smith <tsmith@chef.io>