### PR TITLE
Minor optimizations from rubocop-performance

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
+++ b/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
@@ -57,6 +57,8 @@ module RuboCop
 
           private
 
+          VALID_TYPES = %i(send hash block_pass).freeze
+
           #
           # Are the arguments in the passed node object positional
           #
@@ -68,7 +70,7 @@ module RuboCop
             return false if node.arguments.count < 3
             node.arguments[2..-1].each do |arg|
               # hashes, blocks, or variable/methods are valid. Anything else is not
-              return true unless %i(send hash block_pass).include?(arg.type)
+              return true unless VALID_TYPES.include?(arg.type)
             end
             false
           end

--- a/lib/rubocop/cop/chef/deprecation/windows_feature_servermanagercmd.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_feature_servermanagercmd.rb
@@ -48,7 +48,7 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(:windows_feature, :install_method, node) do |prop_node|
-              add_offense(prop_node, message: MSG, severity: :warning) if prop_node.source.match?(/:servermanagercmd/)
+              add_offense(prop_node, message: MSG, severity: :warning) if prop_node.source.include?(':servermanagercmd')
             end
           end
         end


### PR DESCRIPTION
Avoid a regex where we don't need one
Avoid creating an array object for each argument we parse

Signed-off-by: Tim Smith <tsmith@chef.io>