### PR TITLE
Spec cleanup from rubocop-rspec

### DIFF
--- a/spec/rubocop/chef/cookbook_helpers_spec.rb
+++ b/spec/rubocop/chef/cookbook_helpers_spec.rb
@@ -21,7 +21,7 @@ require 'spec_helper'
 
 RSpec.describe RuboCop::Chef::CookbookHelpers do
   include RuboCop::AST::Sexp
-  include RuboCop::Chef::CookbookHelpers
+  include described_class
 
   let (:running_false_ast) { s(:send, nil, :running, s(:false)) }
 
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
     describe 'when the the resource name is a string' do
       let(:resource_source) { "service 'foo' do; running true; end" }
 
-      it 'should return the resource name string' do
+      it 'returns the resource name string' do
         expect(resource_block_name_if_string(parse_source(resource_source).ast)).to eq 'foo'
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
     describe 'when the the resource name is a variable' do
       let(:resource_source) { 'service foo_service do; running true; end' }
 
-      it 'should return nil' do
+      it 'returns nil' do
         expect(resource_block_name_if_string(parse_source(resource_source).ast)).to be_nil
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
     describe 'when the passed name matches the resource' do
       let(:resource_source) { "service 'foo' do; running true; end" }
 
-      it 'should yield a the service block ast objects' do
+      it 'yields a the service block ast objects' do
         expect { |b| match_resource_type?(:service, parse_source(resource_source).ast, &b) }.to yield_successive_args(s(:block, s(:send, nil, :service, s(:str, 'foo')), s(:args), s(:send, nil, :running, s(:true))))
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
     describe "when the passed name doesn't match the resource" do
       let(:resource_source) { "service 'foo' do; running true; end" }
 
-      it 'should not yield anything' do
+      it 'does not yield anything' do
         expect { |b| match_resource_type?(:archive_file, parse_source(resource_source).ast, &b) }.not_to yield_control
       end
     end
@@ -67,11 +67,11 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
     describe 'single property in a resource' do
       let(:resource_source) { "service 'single_property' do; running true; end" }
 
-      it "should yield a single 'running' property ast objects" do
+      it "yields a single 'running' property ast objects" do
         expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
       end
 
-      it "should yield a single 'running' property ast objects when passed an array" do
+      it "yields a single 'running' property ast objects when passed an array" do
         expect { |b| match_property_in_resource?(%i(service file), 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
       end
     end
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
     describe 'multiple properties in a resource' do
       let(:resource_source) { "service 'single_property' do; not_running true; running true; end" }
 
-      it "should yield a single 'running' property ast objects" do
+      it "yields a single 'running' property ast objects" do
         expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
       end
     end
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
         RUBY
       end
 
-      it "should yield a single 'running' property ast objects" do
+      it "yields a single 'running' property ast objects" do
         expect { |b| match_property_in_resource?(:service, %w(running verify), parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
       end
     end
@@ -111,7 +111,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
         RUBY
       end
 
-      it "should yield a single 'running' property ast objects" do
+      it "yields a single 'running' property ast objects" do
         expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast)
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
         RUBY
       end
 
-      it "should yield both 'running' property ast objects" do
+      it "yields both 'running' property ast objects" do
         expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast, running_false_ast)
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
         RUBY
       end
 
-      it "should yield three 'running' property ast objects" do
+      it "yields three 'running' property ast objects" do
         expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_true_ast, running_false_ast, running_true_ast)
       end
     end
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
         RUBY
       end
 
-      it "should yield a single 'running' property ast objects" do
+      it "yields a single 'running' property ast objects" do
         expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_false_ast)
       end
     end
@@ -188,7 +188,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
         RUBY
       end
 
-      it "should yield a single 'running' property ast objects" do
+      it "yields a single 'running' property ast objects" do
         expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_false_ast)
       end
     end
@@ -204,7 +204,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
         RUBY
       end
 
-      it "should yield a single 'running' property ast objects" do
+      it "yields a single 'running' property ast objects" do
         expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.to yield_successive_args(running_false_ast)
       end
     end
@@ -218,7 +218,7 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
         RUBY
       end
 
-      it 'should not yield anything' do
+      it 'does not yield anything' do
         expect { |b| match_property_in_resource?(:service, 'running', parse_source(resource_source).ast, &b) }.not_to yield_control
       end
     end

--- a/spec/rubocop/cop/chef/correctness/metadata_missing_name_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/metadata_missing_name_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Chef::ChefCorrectness::MetadataMissingName, :config do
 
   # prior to Rubocop 0.87 the autocorrect was not with expect_offense
   # in Rubocop 0.87 the autocorrect method is being executed and this attempts to write data
-  before(:each) do
+  before do
     allow(IO).to receive(:read).with('/foo/bar/metadata.rb').and_return("supports 'ubuntu'")
     allow(IO).to receive(:write).with('/foo/bar/metadata.rb', "name 'bar'\nsupports 'ubuntu'")
   end

--- a/spec/rubocop/cop/chef/modernize/node_init_package_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/node_init_package_spec.rb
@@ -43,17 +43,6 @@ describe RuboCop::Cop::Chef::ChefModernize::NodeInitPackage, :config do
     RUBY
   end
 
-  it "registers an offense with File.exist?('/proc/1/comm') && File.open('/proc/1/comm').chomp == 'systemd'" do
-    expect_offense(<<~RUBY)
-      File.exist?('/proc/1/comm') && File.open('/proc/1/comm').chomp == 'systemd'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use node['init_package'] to check for systemd instead of reading the contents of '/proc/1/comm'
-    RUBY
-
-    expect_correction(<<~RUBY)
-      node['init_package'] == 'systemd'
-    RUBY
-  end
-
   it "registers an offense with IO.read('/proc/1/comm').chomp == 'systemd'" do
     expect_offense(<<~RUBY)
       IO.read('/proc/1/comm').chomp == 'systemd'

--- a/spec/rubocop/cop/chef/modernize/respond_to_resource_name_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/respond_to_resource_name_spec.rb
@@ -63,7 +63,7 @@ describe RuboCop::Cop::Chef::ChefModernize::RespondToResourceName, :config do
     RUBY
   end
 
-  it 'registers an offense with a HWRP that uses respond_to? with resource_name' do
+  it 'does not register an offense with a HWRP does not use respond_to? with resource_name' do
     expect_no_offenses(<<~RUBY)
     class Chef
       class Resource

--- a/spec/rubocop/cop/chef/modernize/simplify_apt_ppa_setup_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/simplify_apt_ppa_setup_spec.rb
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Chef::ChefModernize::SimplifyAptPpaSetup, :config do
     RUBY
   end
 
-  it "doesn't register an offense when apt_repository sets a non-PPA uri" do
+  it "doesn't register an offense with a simplified PPA uri" do
     expect_no_offenses(<<~RUBY)
       apt_repository 'atom-ppa' do
         uri 'ppa:webupd8team/atom'

--- a/spec/rubocop/cop/chef/style/file_mode_spec.rb
+++ b/spec/rubocop/cop/chef/style/file_mode_spec.rb
@@ -63,15 +63,6 @@ describe RuboCop::Cop::Chef::ChefStyle::FileMode do
     RUBY
   end
 
-  it 'does not register an offense when setting a mode using a double quoted string' do
-    expect_no_offenses(<<~RUBY)
-      file '/foo' do
-        owner 'root'
-        mode '644'
-      end
-    RUBY
-  end
-
   it 'registers an offense when setting a files_mode as well' do
     expect_offense(<<~RUBY)
       file '/foo' do


### PR DESCRIPTION
Identify some duplicate specs
Stop saying "should"

Signed-off-by: Tim Smith <tsmith@chef.io>