### PR TITLE
Backport a fix for Layout/RescueEnsureAlignment

### DIFF
--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -15,6 +15,9 @@ require_relative 'rubocop/monkey_patches/base.rb'
 require_relative 'rubocop/monkey_patches/team.rb'
 require_relative 'rubocop/monkey_patches/registry_cop.rb'
 
+# @TODO remove this monkeypatch after we upgrade from 0.91.0
+require_relative 'rubocop/monkey_patches/rescue_ensure_alignment.rb'
+
 module RuboCop
   class ConfigLoader
     RUBOCOP_HOME.gsub!(

--- a/lib/rubocop/monkey_patches/rescue_ensure_alignment.rb
+++ b/lib/rubocop/monkey_patches/rescue_ensure_alignment.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module RuboCop
+  module Cop
+    module Layout
+      class RescueEnsureAlignment < Base
+        # @TODO remove this monkeypatch after we upgrade from RuboCop 0.91.0
+        def begin_end_alignment_style
+          # FIXME: Workaround for pending status for `Layout/BeginEndAlignment` cop
+          #        When RuboCop 1.0 is released, please replace it with the following condition.
+          #
+          # config.for_cop('Layout/BeginEndAlignment')['Enabled'] &&
+          #   config.for_cop('Layout/BeginEndAlignment')['EnforcedStyleAlignWith']
+          if config.for_all_cops['NewCops'] == 'enable' ||
+             config.for_cop('Layout/BeginEndAlignment')['Enabled'] &&
+             config.for_cop('Layout/BeginEndAlignment')['Enabled'] != 'pending'
+            config.for_cop('Layout/BeginEndAlignment')['EnforcedStyleAlignWith']
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/monkey_patches/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/monkey_patches/rescue_ensure_alignment_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# this tests the monkey patch we do in lib/rubocop/monkey_patches/rescue_ensure_alignment.rb
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Layout::RescueEnsureAlignment, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'is not monkeypatching a version of RuboCop with the fix' do
+    expect(Cookstyle::RUBOCOP_VERSION).to eq('0.91.0')
+  end
+end


### PR DESCRIPTION
This was a bug I reported that sadly didn't make it into the 0.91.0
release

Signed-off-by: Tim Smith <tsmith@chef.io>