### PR TITLE
Add new ChefCorrectness/PropertyWithoutType cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -460,6 +460,15 @@ ChefCorrectness/LazyInResourceGuard:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+ChefCorrectness/PropertyWithoutType:
+  Description: Custom resource properties or attributes should always define a type to help users understand the correct allowed values.
+  StyleGuide: '#chefcorrectnesspropertywithouttype'
+  Enabled: true
+  VersionAdded: '6.18.0'
+  Include:
+    - '**/libraries/*.rb'
+    - '**/resources/*.rb'
+
 ###############################
 # ChefSharing: Issues that prevent sharing code with other teams or with the Chef community in general
 ###############################

--- a/lib/rubocop/cop/chef/correctness/property_without_type.rb
+++ b/lib/rubocop/cop/chef/correctness/property_without_type.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # Resource properties or attributes should always define a type to help users understand the correct allowed values.
+        #
+        # @example
+        #
+        #   # bad
+        #   property :size, regex: /^\d+[KMGTP]$/
+        #   attribute :size, regex: /^\d+[KMGTP]$/
+        #
+        #   # good
+        #   property :size, String, regex: /^\d+[KMGTP]$/
+        #   attribute :size, kind_of: String, regex: /^\d+[KMGTP]$/
+        #
+        class PropertyWithoutType < Base
+          MSG = 'Resource properties or attributes should always define a type to help users understand the correct allowed values.'
+          RESTRICT_ON_SEND = [:property, :attribute].freeze
+
+          def_node_matcher :property_without_type?, <<-PATTERN
+          (send nil? {:property :attribute}
+            (sym _)
+            $(hash
+
+              ...
+            )?
+          )
+          PATTERN
+
+          def on_send(node)
+            property_without_type?(node) do |hash_vals|
+              return if hash_vals&.first&.keys&.include?(s(:sym, :kind_of))
+
+              add_offense(node, message: MSG, severity: :refactor)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/property_without_type_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/property_without_type_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::PropertyWithoutType do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when an property has no type' do
+    expect_offense(<<~RUBY)
+      property :size, regex: /^\d+[KMGTP]$/
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resource properties or attributes should always define a type to help users understand the correct allowed values.
+    RUBY
+  end
+
+  it 'registers an offense when an property has no type and no hash options' do
+    expect_offense(<<~RUBY)
+      property :size
+      ^^^^^^^^^^^^^^ Resource properties or attributes should always define a type to help users understand the correct allowed values.
+    RUBY
+  end
+
+  it 'registers an offense when an attribute has no type' do
+    expect_offense(<<~RUBY)
+      attribute :size, regex: /^\d+[KMGTP]$/
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Resource properties or attributes should always define a type to help users understand the correct allowed values.
+    RUBY
+  end
+
+  it 'registers an offense when an attribute has no type and no hash options' do
+    expect_offense(<<~RUBY)
+      attribute :size
+      ^^^^^^^^^^^^^^^ Resource properties or attributes should always define a type to help users understand the correct allowed values.
+    RUBY
+  end
+
+  it 'does not register an offense if a propety uses kind_of option' do
+    expect_no_offenses('property :size, regex: /^\d+[KMGTP]$/, kind_of: String')
+  end
+
+  it 'does not register an offense if an attribute uses kind_of option' do
+    expect_no_offenses('attribute :size, regex: /^\d+[KMGTP]$/, kind_of: String')
+  end
+
+  it 'does not register an offense if a property has positional type' do
+    expect_no_offenses('property :size, String, regex: /^\d+[KMGTP]$/')
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/property_without_type_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/property_without_type_spec.rb
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Chef::ChefCorrectness::PropertyWithoutType do
     RUBY
   end
 
-  it 'does not register an offense if a propety uses kind_of option' do
+  it 'does not register an offense if a property uses kind_of option' do
     expect_no_offenses('property :size, regex: /^\d+[KMGTP]$/, kind_of: String')
   end
 


### PR DESCRIPTION
People should really be passing a type in even if they're using some other form of validation later on like a regex

Signed-off-by: Tim Smith <tsmith@chef.io>