### PR TITLE
Optimize our slowest cop

### DIFF
--- a/lib/rubocop/cop/chef/modernize/respond_to_compile_time.rb
+++ b/lib/rubocop/cop/chef/modernize/respond_to_compile_time.rb
@@ -44,6 +44,7 @@ module RuboCop
         #   end
         #
         class RespondToCompileTime < Base
+          include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
           extend AutoCorrector
 
@@ -75,10 +76,12 @@ module RuboCop
               $(_)) nil?)
           PATTERN
 
-          def on_if(node)
-            compile_time_method_defined?(node) do |val|
-              add_offense(node, message: MSG, severity: :refactor) do |corrector|
-                corrector.replace(node.loc.expression, "compile_time #{val.source}")
+          def on_block(node)
+            match_property_in_resource?(:chef_gem, 'compile_time', node) do |compile_time_property|
+              compile_time_method_defined?(compile_time_property.parent) do |val|
+                add_offense(compile_time_property.parent, message: MSG, severity: :refactor) do |corrector|
+                  corrector.replace(compile_time_property.parent.loc.expression, "compile_time #{val.source}")
+                end
               end
             end
           end


### PR DESCRIPTION
This node match is still terrible and could be greatly improved, but this was our #1 slow spec:

before
```
  RuboCop::Cop::Chef::ChefModernize::RespondToCompileTime doesn't register an offense when using just compile_time true
    0.45545 seconds ./spec/rubocop/cop/chef/modernize/respond_to_compile_time_spec.rb:75
```

After it's not even on the list and the #10 is now 0.00252 seconds.

Signed-off-by: Tim Smith <tsmith@chef.io>