### PR TITLE
Run a single regex per comment line instead of 9

### DIFF
--- a/lib/rubocop/cop/chef/style/comments_format.rb
+++ b/lib/rubocop/cop/chef/style/comments_format.rb
@@ -66,11 +66,11 @@ module RuboCop
 
           private
 
+          #
+          # @return [Boolean]
+          #
           def invalid_comment?(comment)
-            comment_types = %w(Author Cookbook Library Attribute Copyright Recipe Resource Definition License)
-            comment_types.any? do |comment_type|
-              /^#\s*#{comment_type}\s+/.match(comment.text)
-            end
+            /^#\s*(Author|Cookbook|Library|Attribute|Copyright|Recipe|Resource|Definition|License)\s+/.match?(comment.text)
           end
         end
       end


### PR DESCRIPTION
I have no idea what I was thinking here. This is pretty terrible. This was #21 on CPU usage and now it's not in the top 100.

Before:

```
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       327   (1.0%)         327   (1.0%)     RuboCop::Cop::Chef::ChefStyle::CommentFormat#invalid_comment?
```

Signed-off-by: Tim Smith <tsmith@chef.io>