### PR TITLE
Use + instead of dup to unfreeze a string

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -78,7 +78,7 @@ module RuboCop
                                 else
                                   "\"#{type.source}[\#{#{name.source}}]\""
                                 end
-                new_val = "#{notify_type} #{action.source}, #{service_value}".dup
+                new_val = +"#{notify_type} #{action.source}, #{service_value}"
                 new_val << ", #{timing.first.source}" unless timing.empty?
                 corrector.replace(node, new_val)
               end


### PR DESCRIPTION
This is slightly faster than .dup

Signed-off-by: Tim Smith <tsmith@chef.io>