### PR TITLE
Enable rubocop-performance in CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,9 @@
+require: rubocop-performance
+
+# enable new cops for rubocop-performance
+AllCops:
+  NewCops: enable
+
 ChefStyle/CommentFormat:
   Exclude:
     - 'lib/rubocop/cop/chef/comments_format.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,12 @@ group :docs do
 end
 
 group :profiling do
-  gem 'stackprof'
   gem 'memory_profiler'
+  gem 'stackprof'
+end
+
+group :rubocop_gems do
+  gem 'rubocop-performance'
 end
 
 group :development do


### PR DESCRIPTION
Make sure we're doing all we can for the perf of the gem.

Signed-off-by: Tim Smith <tsmith@chef.io>