### PR TITLE
Add new ChefCorrectness/OctalModeAsString cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -469,6 +469,16 @@ ChefCorrectness/PropertyWithoutType:
     - '**/libraries/*.rb'
     - '**/resources/*.rb'
 
+ChefCorrectness/OctalModeAsString:
+  Description: Don't represent file modes as strings containing octal values. Use standard base 10 file modes instead.
+  StyleGuide: '#chefcorrectnessoctalmodeasstring'
+  Enabled: true
+  VersionAdded: '6.21.0'
+  Exclude:
+    - '**/attributes/*.rb'
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # ChefSharing: Issues that prevent sharing code with other teams or with the Chef community in general
 ###############################

--- a/lib/rubocop/cop/chef/correctness/octal_mode_as_string.rb
+++ b/lib/rubocop/cop/chef/correctness/octal_mode_as_string.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefCorrectness
+        # Don't represent file modes as Strings containing octal values.
+        #
+        # @example
+        #
+        #   # bad
+        #   file '/etc/some_file' do
+        #     mode '0o755'
+        #   end
+        #
+        #   # good
+        #   file '/etc/some_file' do
+        #     mode '0755'
+        #   end
+        #
+        class OctalModeAsString < Base
+          MSG = "Don't represent file modes as strings containing octal values. Use standard base 10 file modes instead. For example: '0755'."
+          RESTRICT_ON_SEND = [:mode].freeze
+
+          def on_send(node)
+            return unless node.arguments.first&.str_type? && node.arguments.first.value.match?(/^0o/)
+            add_offense(node, message: MSG, severity: :refactor)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/octal_mode_as_string_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/octal_mode_as_string_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2020, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefCorrectness::OctalModeAsString do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense with an octal string mode' do
+    expect_offense(<<~RUBY)
+      file '/logs/foo/error.log' do
+        mode '0o755'
+        ^^^^^^^^^^^^ Don't represent file modes as strings containing octal values. Use standard base 10 file modes instead. For example: '0755'.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense with a valid string mode' do
+    expect_no_offenses(<<~RUBY)
+      file '/logs/foo/error.log' do
+        mode '0755'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense with an octal mode' do
+    expect_no_offenses(<<~RUBY)
+      file '/logs/foo/error.log' do
+        mode 0o755
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the mode argument is a non-string/integer' do
+    expect_no_offenses(<<~RUBY)
+      file '/logs/foo/error.log' do
+        mode new_resource.mode
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
These are not valid and we should call them out.

Signed-off-by: Tim Smith <tsmith@chef.io>