### PR TITLE
Add ChefDeprecations/UseYamlDump cop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ task :vendor do
   require 'rubocop'
   require 'yaml'
   cfg = RuboCop::Cop::Cop.all.each_with_object({}) { |cop, acc| acc[cop.cop_name] = { 'Enabled' => false } unless cop.cop_name.start_with?('Chef'); }
-  File.open(dst.join('disable_all.yml'), 'w') { |fh| fh.write cfg.to_yaml }
+  File.open(dst.join('disable_all.yml'), 'w') { |fh| fh.write YAML.dump(cfg) }
 
   sh %(git add #{dst}/{upstream,disable_all}.yml)
   sh %(git commit -m "Vendor rubocop-#{upstream.version} upstream configuration.")

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1121,6 +1121,12 @@ ChefDeprecations/WindowsPackageInstallerTypeString:
     - '**/attributes/*.rb'
     - '**/Berksfile'
 
+ChefDeprecations/UseYamlDump:
+  Description: Chef Infra Client 16.5 introduced performance enhancements to Ruby library loading. Due to the underlying implementation of Ruby's `.to_yaml` method, it does not automatically load the `yaml` library and `YAML.dump()` should be used instead to properly load the `yaml` library.
+  StyleGuide: '#chefdeprecationsuseyamldump'
+  Enabled: true
+  VersionAdded: '6.21.0'
+
 ###############################
 # ChefModernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/use_yaml_dump.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_yaml_dump.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module ChefDeprecations
+        # Chef Infra Client 16.5 introduced performance enhancements to Ruby library loading. Due to the underlying implementation of Ruby's `.to_yaml` method, it does not automatically load the `yaml` library and `YAML.dump()` should be used instead to properly load the `yaml` library.
+        #
+        # @example
+        #
+        #   # bad
+        #   {"foo" => "bar"}.to_yaml
+        #
+        #   # good
+        #   YAML.dump({"foo" => "bar"})
+        #
+        class UseYamlDump < Base
+          extend AutoCorrector
+
+          MSG = "Chef Infra Client 16.5 introduced performance enhancements to Ruby library loading. Due to the underlying implementation of Ruby's `.to_yaml` method, it does not automatically load the `yaml` library and `YAML.dump()` should be used instead to properly load the `yaml` library."
+          RESTRICT_ON_SEND = [:to_yaml].freeze
+
+          def on_send(node)
+            add_offense(node, message: MSG, severity: :warning) do |corrector|
+              corrector.replace(node, "YAML.dump(#{node.receiver.source})")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/use_yaml_dump_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/use_yaml_dump_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2020, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::ChefDeprecations::UseYamlDump, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using .to_yaml' do
+    expect_offense(<<~RUBY)
+      Foo.bar.to_yaml
+      ^^^^^^^^^^^^^^^ Chef Infra Client 16.5 introduced performance enhancements to Ruby library loading. Due to the underlying implementation of Ruby's `.to_yaml` method, it does not automatically load the `yaml` library and `YAML.dump()` should be used instead to properly load the `yaml` library.
+    RUBY
+
+    expect_correction("YAML.dump(Foo.bar)\n")
+  end
+end


### PR DESCRIPTION
This works around the issues with autoload and Chef Infra Client 16.5+

Signed-off-by: Tim Smith <tsmith@chef.io>