### PR TITLE
Disable Style/NumericPredicate

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2493,10 +2493,9 @@ Style/EachForSimpleLoop:
 Style/EmptyCaseCondition:
   Enabled: true
 
-# == 0 is more performant than .zero? and .zero? also introduced several regressions
+# It doesn't matter if people use the friendly helpers or not for overall readability
 Style/NumericPredicate:
-  Enabled: true
-  EnforcedStyle: comparison
+  Enabled: false
 
 # this is bad %w(something     another_thing   one_more)
 Layout/SpaceInsideArrayPercentLiteral:


### PR DESCRIPTION
This cop has no autocorrect and there's really no advantage when someone
moves their code to this from the helpers. Really it just makes it
slightly harder to read.

Signed-off-by: Tim Smith <tsmith@chef.io>