### PR TITLE
Handle more multipackage scenarios

### DIFF
--- a/lib/rubocop/cop/chef/modernize/use_multipackage_installs.rb
+++ b/lib/rubocop/cop/chef/modernize/use_multipackage_installs.rb
@@ -60,8 +60,8 @@ module RuboCop
                     (lvar _))}) nil?)
           PATTERN
 
-          def_node_matcher :package_array_install?, <<-PATTERN
-          (block
+          def_node_search :package_array_install, <<-PATTERN
+          $(block
             (send
               $(array ... ) :each)
             (args ... )
@@ -84,21 +84,24 @@ module RuboCop
 
           def on_when(node)
             return unless platform_or_platform_family?(node.parent.condition) &&
-                          package_array_install?(node.body) &&
                           multipackage_platforms?(node.conditions)
-            check_offense(node.body)
+            return if node.body.nil? # don't blow up on empty whens
+
+            package_array_install(node.body) do |install_block, pkgs|
+              add_offense(install_block, message: MSG, severity: :refactor) do |corrector|
+                corrector.replace(install_block, "package #{pkgs.source}")
+              end
+            end
           end
 
           def on_if(node)
             platform_helper?(node) do |plats, blk, _pkgs|
-              check_offense(blk) if multipackage_platforms?(plats)
-            end
-          end
+              return unless multipackage_platforms?(plats)
 
-          def check_offense(node)
-            add_offense(node, message: MSG, severity: :refactor) do |corrector|
-              package_array_install?(node) do |vals|
-                corrector.replace(node, "package #{vals.source}")
+              add_offense(blk, message: MSG, severity: :refactor) do |corrector|
+                package_array_install(blk) do |install_block, pkgs|
+                  corrector.replace(install_block, "package #{pkgs.source}")
+                end
               end
             end
           end

--- a/lib/rubocop/cop/chef/modernize/use_multipackage_installs.rb
+++ b/lib/rubocop/cop/chef/modernize/use_multipackage_installs.rb
@@ -78,7 +78,8 @@ module RuboCop
           # see if all platforms in the when condition are multi-package compliant
           def multipackage_platforms?(condition_obj)
             condition_obj.all? do |p|
-              MULTIPACKAGE_PLATS.include?(p.value)
+              # make sure it's a string (not a regex) and it's in the array
+              p.str_type? && MULTIPACKAGE_PLATS.include?(p.value)
             end
           end
 

--- a/spec/rubocop/cop/chef/modernize/use_multipackage_installs_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/use_multipackage_installs_spec.rb
@@ -25,6 +25,8 @@ describe RuboCop::Cop::Chef::Modernize::UseMultipackageInstalls, :config do
     expect_offense(<<~RUBY)
       case node['platform']
       when 'ubuntu'
+        include_recipe 'apt'
+
         %w(bmon htop vim curl).each do |pkg|
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pass an array of packages to package resources instead of iterating over an array of packages when using multi-package capable package subsystem such as apt, yum, chocolatey, dnf, or zypper. Multi-package installs are faster and simplify logs.
           package pkg do
@@ -37,7 +39,18 @@ describe RuboCop::Cop::Chef::Modernize::UseMultipackageInstalls, :config do
     expect_correction(<<~RUBY)
       case node['platform']
       when 'ubuntu'
+        include_recipe 'apt'
+
         package %w(bmon htop vim curl)
+      end
+    RUBY
+  end
+
+  it 'does not fail with an empty when statement' do
+    expect_no_offenses(<<~RUBY)
+      case node['platform_family']
+      when 'debian'
+        # nothing here
       end
     RUBY
   end

--- a/spec/rubocop/cop/chef/modernize/use_multipackage_installs_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/use_multipackage_installs_spec.rb
@@ -55,6 +55,15 @@ describe RuboCop::Cop::Chef::Modernize::UseMultipackageInstalls, :config do
     RUBY
   end
 
+  it 'does not fail if the when is a regex' do
+    expect_no_offenses(<<~RUBY)
+      case node['platform_family']
+      when /debian/
+        package 'it-is-fine'
+      end
+    RUBY
+  end
+
   it 'registers an offense when iterating over an array of packages in a case statement with a non-block package resource' do
     expect_offense(<<~RUBY)
       case node['platform']


### PR DESCRIPTION
Detect when blocks that include more than just the package install. It's pretty common that they also include an apt_update or an include_recipe 'apt' when we're on a debian-ish platform.

I plan to open another PR to refactor the if detection with this same support. baby steps here.

Signed-off-by: Tim Smith <tsmith@chef.io>