### PR TITLE
Enable Style/CollectionCompact

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2764,3 +2764,7 @@ Style/ExpandPathArguments:
 # Avoid a safe navigation operator if we don't need it
 Lint/RedundantSafeNavigation:
   Enabled: true
+
+# Avoid using blocks to remove nils from a Hash/Array
+Style/CollectionCompact:
+  Enabled: true


### PR DESCRIPTION
This probably isn't very common in cookbooks, but if we run into one
it's a great way to reduce complexity.

Signed-off-by: Tim Smith <tsmith@chef.io>