### PR TITLE
Disable cop with potentially misleading warning message.

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2439,10 +2439,9 @@ Metrics/BlockNesting:
 Metrics/ParameterLists:
   Enabled: false
 
-# This updates how we send helpers into the Chef recipe/resource classes and makes WAY more sense
-# Chef::Recipe.send(:include, ::Apt::Helpers) -> Chef::Recipe.include ::Apt::Helpers
+# The warning message from this is misleading and can lead to wrong but syntactically valid code.
 Lint/SendWithMixinArgument:
-  Enabled: true
+  Enabled: false
 
 # this migrates old # rubocop: comments to use the latest namespaces, which prevents a ton of spam during cookstyle runs
 Migration/DepartmentName:


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

This came up in the PR on chef/chef-server: https://github.com/chef/chef-server/pull/2174/files#r527113845

The warning from this cop led the PR author to change this code:

> Chef::Node.send(:include, ChefOpsDCC::Helpers)

to this syntactically valid but incorrect code:

> Chef::Node.send(include ChefOpsDCC::Helpers)