### PR TITLE
Unpin parallel gem since it supports Ruby 2.4 again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,3 @@ group :development do
   gem 'rake'
   gem 'rspec', '>= 3.4'
 end
-
-# pin until we drop ruby 2.4 and then remove this entirely
-gem 'parallel', '< 1.20'


### PR DESCRIPTION
We don't need to pin this anymore. They added Ruby 2.4 support back.

Signed-off-by: Tim Smith <tsmith@chef.io>