### PR TITLE
Update Chef/Style/CommentSentenceSpacing to use the new RuboCop methods

### DIFF
--- a/lib/rubocop/cop/chef/style/comment_sentence_spacing.rb
+++ b/lib/rubocop/cop/chef/style/comment_sentence_spacing.rb
@@ -26,7 +26,7 @@ module RuboCop
           extend AutoCorrector
           MSG = 'Use a single space after sentences in comments'
 
-          def investigate(processed_source)
+          def on_new_investigation
             return unless processed_source.ast
 
             processed_source.comments.each do |comment|


### PR DESCRIPTION
I'm fairly certain this cop was broken.

Signed-off-by: Tim Smith <tsmith@chef.io>