### PR TITLE
Run Chef/Modernize/RespondToProvides in resources as well

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1211,6 +1211,7 @@ Chef/Modernize/RespondToProvides:
   VersionAdded: '5.2.0'
   Include:
     - '**/providers/*.rb'
+    - '**/resources/*.rb'
     - '**/libraries/*.rb'
 
 Chef/Modernize/SetOrReturnInResources:


### PR DESCRIPTION
It looks like the respond_to is being copied over as folks migrate from LWRPs to custom resources. There are 6 of these on the Supermarket and we might as well correct them while we're scanning for the occurrences in providers.

Signed-off-by: Tim Smith <tsmith@chef.io>