### PR TITLE
Update RuboCop to 1.6.2

### DIFF
--- a/config/upstream.yml
+++ b/config/upstream.yml
@@ -3209,9 +3209,10 @@ Style/ExponentialNotation:
 Style/FloatDivision:
   Description: 'For performing float division, coerce one side only.'
   StyleGuide: '#float-division'
-  Reference: 'https://github.com/rubocop-hq/ruby-style-guide/issues/628'
+  Reference: 'https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html'
   Enabled: true
   VersionAdded: '0.72'
+  VersionChanged: '1.6'
   EnforcedStyle: single_coerce
   SupportedStyles:
     - left_coerce
@@ -4025,6 +4026,7 @@ Style/RedundantArgument:
   Enabled: pending
   Safe: false
   VersionAdded: '1.4'
+  VersionChanged: '1.6'
   Methods:
     # Array#join
     join: ''
@@ -4272,7 +4274,7 @@ Style/SingleLineBlockParams:
   Description: 'Enforces the names of some block params.'
   Enabled: false
   VersionAdded: '0.16'
-  VersionChanged: '0.47'
+  VersionChanged: '1.6'
   Methods:
     - reduce:
         - acc
@@ -4345,6 +4347,7 @@ Style/StringConcatenation:
   Enabled: true
   Safe: false
   VersionAdded: '0.89'
+  VersionChanged: '1.6'
 
 Style/StringHashKeys:
   Description: 'Prefer symbols instead of strings as hash keys.'

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Cookstyle
   VERSION = "7.3.11" # rubocop: disable Style/StringLiterals
-  RUBOCOP_VERSION = '1.5.2'
+  RUBOCOP_VERSION = '1.6.1'
 end

--- a/spec/rubocop/cop/chef/correctness/metadata_missing_name_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/metadata_missing_name_spec.rb
@@ -23,6 +23,7 @@ describe RuboCop::Cop::Chef::Correctness::MetadataMissingName, :config do
   # prior to Rubocop 0.87 the autocorrect was not with expect_offense
   # in Rubocop 0.87 the autocorrect method is being executed and this attempts to write data
   before do
+    allow(IO).to receive(:read).and_call_original
     allow(IO).to receive(:read).with('/foo/bar/metadata.rb').and_return("supports 'ubuntu'")
     allow(IO).to receive(:write).with('/foo/bar/metadata.rb', "name 'bar'\nsupports 'ubuntu'")
   end


### PR DESCRIPTION
A bunch of autocorrects have been added as well as some nice bug fixes and hints when cops in configs are wrong.