### PR TITLE
Update UnnecessaryNameProperty to not care about order

### DIFF
--- a/spec/rubocop/cop/chef/redundant/unnecessary_name_property_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/unnecessary_name_property_spec.rb
@@ -57,6 +57,15 @@ describe RuboCop::Cop::Chef::RedundantCode::UnnecessaryNameProperty, :config do
     expect_correction("\n")
   end
 
+  it 'registers an offense when a resource has a attribute called name that is a name_attribute in non-standard order' do
+    expect_offense(<<~RUBY)
+      attribute :name, name_attribute: true, kind_of: String
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this on all resources by default.
+    RUBY
+
+    expect_correction("\n")
+  end
+
   it 'does not register an offense when when a resource defined the name property with a default value' do
     expect_no_offenses(<<~RUBY)
       property :name, String, default: ''


### PR DESCRIPTION
Before the hash has to be in the right order to match. If kind_of is last it wouldn't alert. Now we catch that additional scenario. There are 65 resources that define it that way on Supermarket.

Signed-off-by: Tim Smith <tsmith@chef.io>