### PR TITLE
Update dstr handling for new rubocop-ast

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -74,7 +74,7 @@ module RuboCop
                                 when :str
                                   "'#{type.source}[#{name.value}]'"
                                 when :dstr
-                                  "\"#{type.source}[#{name.value.source}]\""
+                                  "\"#{type.source}[#{name.value}]\""
                                 else
                                   "\"#{type.source}[\#{#{name.source}}]\""
                                 end


### PR DESCRIPTION
This was fixed in rubocop-ast so we don't have to get the source anymore
to get the actual string.

https://github.com/rubocop-hq/rubocop-ast/pull/167

Signed-off-by: Tim Smith <tsmith@chef.io>