### PR TITLE
Enable Lint/DeprecatedConstants

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2803,3 +2803,7 @@ Lint/RedundantSafeNavigation:
 # Avoid using blocks to remove nils from a Hash/Array
 Style/CollectionCompact:
   Enabled: true
+
+# eventually these constants are going to break code so fix them
+Lint/DeprecatedConstants:
+  Enabled: true


### PR DESCRIPTION
This will prevent broken cookbooks in future ruby releases where this
code won't work

Signed-off-by: Tim Smith <tsmith@chef.io>