### PR TITLE
Always enable the styleguide links to provide better docs

### DIFF
--- a/bin/cookstyle
+++ b/bin/cookstyle
@@ -12,8 +12,13 @@ unless ARGV.include?('--fail-level')
   ARGV << 'C'
 end
 
-# if only -v is passed we'll get 3 args (-v, --fail-level, and C)
-if ARGV.size == 3 && %w(-v --version).include?(ARGV.first)
+# we want to link to our docs
+unless ARGV.include?('--display-style-guide')
+  ARGV << '--display-style-guide'
+end
+
+# if only -v is passed we'll get 4 args (-v, --fail-level. --display-style-guide, and C)
+if ARGV.size == 4 && %w(-v --version).include?(ARGV.first)
   puts "Cookstyle #{Cookstyle::VERSION}"
   print '  * RuboCop '
 end


### PR DESCRIPTION
We have documented each cop. This way we link to those docs.

Signed-off-by: Tim Smith <tsmith@chef.io>