### PR TITLE
Disable Style/RedundantBegin for now

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2247,8 +2247,9 @@ Style/Proc:
   Enabled: true
 Style/RaiseArgs:
   Enabled: true
+# disabled for now as this breaks ruby_block resources
 Style/RedundantBegin:
-  Enabled: true
+  Enabled: false
 Style/RedundantException:
   Enabled: true
 Style/RedundantFreeze:


### PR DESCRIPTION
This is causing failures when the begin/end is in a ruby block

Signed-off-by: Tim Smith <tsmith@chef.io>