### PR TITLE
Fix indentation in windows_uac causes bad docs generation

### DIFF
--- a/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
@@ -32,12 +32,12 @@ module RuboCop
         #     action :create
         #   end
         #
-        #  #### correct
-        #  windows_uac 'Set Windows UAC settings' do
-        #    enable_uac false
-        #    prompt_on_secure_desktop true
-        #    consent_behavior_admins :no_prompt
-        #  end
+        #   #### correct
+        #   windows_uac 'Set Windows UAC settings' do
+        #     enable_uac false
+        #     prompt_on_secure_desktop true
+        #     consent_behavior_admins :no_prompt
+        #   end
         #
         class WindowsRegistryUAC < Base
           include RuboCop::Chef::CookbookHelpers


### PR DESCRIPTION
Turns out we need to keep the indentation the same here

Signed-off-by: Tim Smith <tsmith@chef.io>