### PR TITLE
Ignore specs for Chef/Deprecations/ResourceWithoutUnifiedTrue

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1205,6 +1205,8 @@ Chef/Deprecations/ResourceWithoutUnifiedTrue:
   VersionAdded: '7.12.0'
   Include:
     - '**/resources/*.rb'
+  Exclude:
+    - '**/spec/**/*.rb'
 
 ###############################
 # Chef/Modernize: Cleaning up legacy code and using new built-in resources


### PR DESCRIPTION
As noted in [1], we should ignore anything under the specs folder for this check.

[1] https://github.com/chef/cookstyle/pull/853/files#r632997244

Signed-off-by: Lance Albertson <lance@osuosl.org>
