### PR TITLE
Remove beginning slash from exclude path

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -3,8 +3,8 @@ AllCops:
   TargetRubyVersion: 2.5
   TargetChefVersion: ~
   Exclude:
-    - '/**/files/**/*'
-    - '/**/vendor/**/*'
+    - '**/files/**/*'
+    - '**/vendor/**/*'
     - Guardfile
 
 ###############################


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
With the beginning slash cookstyle will ignore all files if a parent
directory in the current path is named `files` or `vendor`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
