### PR TITLE
Add new InSpec cops to Cookstyle

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2080,6 +2080,27 @@ Chef/Effortless/Berksfile:
   Include:
     - '**/Berksfile'
 
+#### InSpec cops
+
+InSpec/Deprecations:
+  StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
+
+InSpec/Deprecations/AttributeHelper:
+  Description: InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values.
+  StyleGuide: 'inspec_deprecations_attributehelper'
+  Enabled: true
+  VersionAdded: '7.14.0'
+  Include:
+    - '**/controls/*.rb'
+
+InSpec/Deprecations/AttributeDefault:
+  Description: The InSpec inputs `default` option has been replaced with the `value` option.
+  StyleGuide: 'inspec_deprecations_attributedefaults'
+  Enabled: true
+  VersionAdded: '7.14.0'
+  Include:
+    - '**/controls/*.rb'
+
 #### The base rubocop 0.37 enabled.yml file we started with ####
 
 Layout/AccessModifierIndentation:

--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -46,7 +46,7 @@ require_relative 'rubocop/chef/cookbook_only'
 require_relative 'rubocop/cop/target_chef_version'
 
 # Chef Infra specific cops
-Dir.glob(__dir__ + '/rubocop/cop/chef/**/*.rb') do |file|
+Dir.glob(__dir__ + '/rubocop/cop/**/*.rb') do |file|
   next if File.directory?(file)
 
   require_relative file # not actually relative but require_relative is faster

--- a/lib/rubocop/cop/inspec/deprecation/attribute_default.rb
+++ b/lib/rubocop/cop/inspec/deprecation/attribute_default.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module InSpec
+      module Deprecations
+        # The InSpec inputs `default` option has been replaced with the `value` option.
+        #
+        # @example
+        #
+        #   #### incorrect
+        #   login_defs_umask = input('login_defs_umask', default: '077', description: 'Default umask to set in login.defs')
+        #
+        #   #### correct
+        #   login_defs_umask = input('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
+        #
+        class AttributeDefault < Base
+          extend AutoCorrector
+
+          MSG = 'The InSpec inputs `default` option has been replaced with the `value` option.'
+          RESTRICT_ON_SEND = [:attribute, :input].freeze
+
+          def_node_matcher :default?, <<-PATTERN
+            (send nil? {:attribute :input} _ (hash <(pair $(sym :default) ...) ...>) )
+          PATTERN
+
+          def on_send(node)
+            default?(node) do |n|
+              add_offense(n, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(n, 'value')
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/inspec/deprecation/attribute_helper.rb
+++ b/lib/rubocop/cop/inspec/deprecation/attribute_helper.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module InSpec
+      module Deprecations
+        # InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values.
+        #
+        # @example
+        #
+        #   #### incorrect
+        #   login_defs_umask = attribute('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
+        #
+        #   #### correct
+        #   login_defs_umask = input('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
+        #
+        class AttributeHelper < Base
+          extend AutoCorrector
+
+          MSG = 'InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values.'
+          RESTRICT_ON_SEND = [:attribute].freeze
+
+          def on_send(node)
+            add_offense(node, message: MSG, severity: :warning) do |corrector|
+              corrector.replace(node.loc.expression, node.loc.expression.source.gsub(/^attribute/, 'input'))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/inspec/attribute_default_spec.rb
+++ b/spec/rubocop/cop/inspec/attribute_default_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::InSpec::Deprecations::AttributeDefault, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when an input method uses default' do
+    expect_offense(<<~RUBY)
+      login_defs_umask = input('login_defs_umask', default: '077', description: 'Default umask to set in login.defs')
+                                                   ^^^^^^^ The InSpec inputs `default` option has been replaced with the `value` option.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      login_defs_umask = input('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
+    RUBY
+  end
+
+  it 'registers an offense when an attribute method uses default' do
+    expect_offense(<<~RUBY)
+      login_defs_umask = attribute('login_defs_umask', default: '077', description: 'Default umask to set in login.defs')
+                                                       ^^^^^^^ The InSpec inputs `default` option has been replaced with the `value` option.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      login_defs_umask = attribute('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
+    RUBY
+  end
+
+  it "doesn't register an offense when an input method uses value" do
+    expect_no_offenses(<<~RUBY)
+      login_defs_umask = input('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/inspec/attribute_helper_spec.rb
+++ b/spec/rubocop/cop/inspec/attribute_helper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::InSpec::Deprecations::AttributeHelper, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when the attribute helper is used' do
+    expect_offense(<<~RUBY)
+      login_defs_umask = attribute('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ InSpec attributes have been renamed to inputs. Use the `input` method not the deprecation `attribute` method to access these values.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      login_defs_umask = input('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
+    RUBY
+  end
+
+  it "doesn't register an offense when the input helper is used" do
+    expect_no_offenses(<<~RUBY)
+      login_defs_umask = input('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
+    RUBY
+  end
+end


### PR DESCRIPTION
Add new cops for detecting incorrect attribute/input usage in InSpec controls.

Fixes https://github.com/chef/cookstyle/issues/26 and https://github.com/chef/customer-bugs/issues/363 and https://chef.aha.io/ideas/ideas/INSPEC-I-30

Signed-off-by: Tim Smith <tsmith@chef.io>