### PR TITLE
Add new Chef/Deprecations/PolicyfileCommunitySource cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1208,6 +1208,14 @@ Chef/Deprecations/ResourceWithoutUnifiedTrue:
   Exclude:
     - '**/spec/**/*.rb'
 
+Chef/Deprecations/PolicyfileCommunitySource:
+  Description: The Policyfile source of `:community` has been replaced with `:supermarket`
+  StyleGuide: 'chef_deprecations_policyfilecommunitysource'
+  Enabled: true
+  VersionAdded: '7.15.0'
+  Include:
+    - '**/Policyfile.rb'
+
 ###############################
 # Chef/Modernize: Cleaning up legacy code and using new built-in resources
 ###############################

--- a/lib/rubocop/cop/chef/deprecation/policyfile_community_source.rb
+++ b/lib/rubocop/cop/chef/deprecation/policyfile_community_source.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Deprecations
+        # The Policyfile source of `:community` has been replaced with `:supermarket`
+        #
+        # @example
+        #
+        #   #### incorrect
+        #   default_source :community
+        #
+        #   #### correct
+        #   default_source :supermarket
+        #
+        class PolicyfileCommunitySource < Base
+          extend AutoCorrector
+
+          MSG = 'The Policyfile source of `:community` has been replaced with `:supermarket`.'
+          RESTRICT_ON_SEND = [:default_source].freeze
+
+          def_node_matcher :community_source?, <<-PATTERN
+            (send nil? :default_source (:sym :community))
+          PATTERN
+
+          def on_send(node)
+            community_source?(node) do
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.replace(node, 'default_source :supermarket')
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/policyfile_community_source_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/policyfile_community_source_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Deprecations::PolicyfileCommunitySource, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when default_source is :community' do
+    expect_offense(<<~RUBY)
+      default_source :community
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ The Policyfile source of `:community` has been replaced with `:supermarket`.
+    RUBY
+
+    expect_correction("default_source :supermarket\n")
+  end
+
+  it "doesn't register an offense when default_source is :supermarket" do
+    expect_no_offenses('default_source :supermarket')
+  end
+end


### PR DESCRIPTION
Detect the usage of the old :community source in Policyfiles

Signed-off-by: Tim Smith <tsmith@chef.io>