### PR TITLE
Ignore resource partials for Chef/Deprecations/ResourceWithoutUnifiedTrue

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1206,6 +1206,7 @@ Chef/Deprecations/ResourceWithoutUnifiedTrue:
   Include:
     - '**/resources/*.rb'
   Exclude:
+    - '**/resources/_*.rb'
     - '**/spec/**/*.rb'
 
 Chef/Deprecations/PolicyfileCommunitySource:


### PR DESCRIPTION
Resource partials are stored in a cookbook’s /resources directory just like custom resources, but they start with the _ prefix. They should be excluded from Chef/Deprecations/ResourceWithoutUnifiedTrue.