### PR TITLE
Prevent ResourceWithoutUnifiedTrue fails with empty files

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/resource_without_unified_mode_true.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_without_unified_mode_true.rb
@@ -54,6 +54,9 @@ module RuboCop
           def_node_search :provides, '(send nil? :provides ...)'
 
           def on_new_investigation
+            # gracefully fail if the resource is empty
+            return if processed_source.ast.nil?
+
             # Using range similar to RuboCop::Cop::Naming::Filename (file_name.rb)
             return if unified_mode?(processed_source.ast)
             range = source_range(processed_source.buffer, 1, 0)

--- a/spec/rubocop/cop/chef/deprecation/resource_without_unified_mode_true_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/resource_without_unified_mode_true_spec.rb
@@ -71,6 +71,10 @@ describe RuboCop::Cop::Chef::Deprecations::ResourceWithoutUnifiedTrue, :config d
     RUBY
   end
 
+  it "doesn't register an offense when the custom resource file is empty" do
+    expect_no_offenses('')
+  end
+
   context 'with TargetChefVersion set before 15.3' do
     let(:config) { target_chef_version(15.2) }
 


### PR DESCRIPTION
Exit if the processed AST is nil

Signed-off-by: Tim Smith <tsmith@chef.io>