### PR TITLE
Fix MetadataMissingName to properly autocorrect

### DIFF
--- a/lib/rubocop/cop/chef/correctness/metadata_missing_name.rb
+++ b/lib/rubocop/cop/chef/correctness/metadata_missing_name.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2019, Chef Software Inc.
+# Copyright:: 2019-2021, Chef Software Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@ module RuboCop
         #   name 'foo'
         #
         class MetadataMissingName < Base
+          extend AutoCorrector
           include RangeHelp
 
           MSG = 'metadata.rb needs to include the name method or it will fail on Chef Infra Client 12 and later.'
@@ -37,11 +38,10 @@ module RuboCop
             # Using range similar to RuboCop::Cop::Naming::Filename (file_name.rb)
             return if cb_name?(processed_source.ast)
             range = source_range(processed_source.buffer, 1, 0)
-            add_offense(range, message: MSG, severity: :refactor) do |_corrector|
+            add_offense(range, message: MSG, severity: :refactor) do |corrector|
               path = processed_source.path
               cb_name = File.basename(File.dirname(path))
-              metadata = IO.read(path)
-              IO.write(path, "name '#{cb_name}'\n" + metadata)
+              corrector.insert_before(processed_source.ast, "name '#{cb_name}'\n")
             end
           end
         end

--- a/spec/rubocop/cop/chef/correctness/metadata_missing_name_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/metadata_missing_name_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2019-2021, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,18 +20,16 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::Correctness::MetadataMissingName, :config do
   subject(:cop) { described_class.new(config) }
 
-  # prior to Rubocop 0.87 the autocorrect was not with expect_offense
-  # in Rubocop 0.87 the autocorrect method is being executed and this attempts to write data
-  before do
-    allow(IO).to receive(:read).and_call_original
-    allow(IO).to receive(:read).with('/foo/bar/metadata.rb').and_return("supports 'ubuntu'")
-    allow(IO).to receive(:write).with('/foo/bar/metadata.rb', "name 'bar'\nsupports 'ubuntu'")
-  end
-
   it 'registers an offense when the name method is missing' do
     expect_offense(<<~RUBY, '/foo/bar/metadata.rb')
       source_url 'http://github.com/something/something'
       ^ metadata.rb needs to include the name method or it will fail on Chef Infra Client 12 and later.
+      depends 'foo'
+    RUBY
+
+    expect_correction(<<~RUBY)
+      name 'bar'
+      source_url 'http://github.com/something/something'
       depends 'foo'
     RUBY
   end


### PR DESCRIPTION
Right now MetadataMissingName is firing anytime it scans. This means if
you have a non cookbook project that has a file named metadata.rb and
you use the chef vscode extension that file will be modified just by
opening it up in vscode. This keeps happening to me in omnibus. Convert
this to use native correct calls.

Signed-off-by: Tim Smith <tsmith@chef.io>