### PR TITLE
Add new Chef/Correctness/PowershellFileExists cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -489,6 +489,15 @@ Chef/Correctness/MetadataMalformedDepends:
   Include:
     - '**/metadata.rb'
 
+Chef/Correctness/PowershellFileExists:
+  Description: Use Ruby's built-in `File.exist?('C:\somefile') instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
+  StyleGuide: 'chef_correctness_powershellfileexists'
+  Enabled: true
+  VersionAdded: '7.19'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # Chef/Sharing: Issues that prevent sharing code with other teams or with the Chef community in general
 ###############################

--- a/lib/rubocop/cop/chef/correctness/powershell_file_exists.rb
+++ b/lib/rubocop/cop/chef/correctness/powershell_file_exists.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Correctness
+        # Use Ruby's built-in `File.exist?('C:\somefile') instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
+        #
+        # @example
+        #
+        #  #### incorrect
+        #  powershell_out('Test-Path "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"').stdout.strip == 'True'
+        #
+        #  #### correct
+        #  ::File.exist?('C:\Program Files\LAPS\CSE\AdmPwd.dll')
+        #
+        class PowershellFileExists < Base
+          RESTRICT_ON_SEND = [:powershell_out, :powershell_out!].freeze
+          MSG = "Use Ruby's built-in `File.exist?('C:\somefile') instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load."
+
+          def_node_matcher :powershell_out_exists?, <<-PATTERN
+            (send nil? {:powershell_out :powershell_out!} (str $_))
+          PATTERN
+
+          def on_send(node)
+            powershell_out_exists?(node) do |exists_string|
+              return unless exists_string.match?(/^Test-Path/)
+              add_offense(node, message: MSG, severity: :refactor)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/powershell_file_exists_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/powershell_file_exists_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Correctness::PowershellFileExists, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when when using powershell_out to run Test-Path' do
+    expect_offense(<<~RUBY)
+      powershell_out('Test-Path "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"').stdout.strip == 'True'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Ruby's built-in `File.exist?('C:\somefile') instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
+    RUBY
+  end
+
+  it 'registers an offense when when using powershell_out! to run Test-Path' do
+    expect_offense(<<~RUBY)
+      powershell_out!('Test-Path "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"').stdout.strip == 'True'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Ruby's built-in `File.exist?('C:\somefile') instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
+    RUBY
+  end
+
+  it 'does not register an offense when Test-Path is not the first cmdlet' do
+    expect_no_offenses(<<~RUBY)
+      powershell_out('FooBar; Test-Path "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"').stdout.strip == 'True'
+    RUBY
+  end
+
+  it 'does not register an offense when running other cmdlets in powershell_out' do
+    expect_no_offenses(<<~RUBY)
+      powershell_out('FooBar "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"')
+    RUBY
+  end
+end


### PR DESCRIPTION
Detect when someone uses PowerShell to see if a file exists on disk.
This is super slow and way more complex/error prone.

Signed-off-by: Tim Smith <tsmith@chef.io>