### PR TITLE
Add 5 new cops to detect deprecated cookbooks

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1272,7 +1272,7 @@ Chef/Modernize/WhyRunSupportedTrue:
     - '**/libraries/*.rb'
 
 Chef/Modernize/UnnecessaryDependsChef14:
-  Description: Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+  Description: Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
   StyleGuide: 'chef_modernize_unnecessarydependschef14'
   Enabled: true
   VersionAdded: '5.1.0'
@@ -1398,7 +1398,7 @@ Chef/Modernize/SevenZipArchiveResource:
     - '**/metadata.rb'
 
 Chef/Modernize/LibarchiveFileResource:
-  Description: Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource
+  Description: Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource from the libarchive cookbook
   StyleGuide: 'chef_modernize_libarchivefileresource'
   Enabled: true
   VersionAdded: '5.5.0'
@@ -1807,6 +1807,46 @@ Chef/Modernize/ActionMethodInResource:
   Include:
     - '**/resources/*.rb'
     - '**/providers/*.rb'
+
+Chef/Modernize/UnnecessaryDependsChef15:
+  Description: Don't depend on cookbooks made obsolete by Chef Infra Client 15.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+  StyleGuide: 'chef_modernize_unnecessarydependschef15'
+  Enabled: true
+  VersionAdded: '7.19.0'
+  Include:
+    - '**/metadata.rb'
+
+Chef/Modernize/DependsOnLocaleCookbook:
+  Description: Don't depend on the locale cookbook made obsolete by Chef Infra Client 14.5. The locale resource is now included in Chef Infra Client itself.
+  StyleGuide: 'chef_modernize_dependsonlocalecookbook'
+  Enabled: true
+  VersionAdded: '7.19.0'
+  Include:
+    - '**/metadata.rb'
+
+Chef/Modernize/DependsOnTimezoneLwrpCookbook:
+  Description: Don't depend on the timezone_lwrp cookbook made obsolete by Chef Infra Client 14.6. The timezone resource is now included in Chef Infra Client itself.
+  StyleGuide: 'chef_modernize_dependsontimezonelwrpcookbook'
+  Enabled: true
+  VersionAdded: '7.19.0'
+  Include:
+    - '**/metadata.rb'
+
+Chef/Modernize/DependsOnWindowsFirewallCookbook:
+  Description: Don't depend on the windows_firewall cookbook made obsolete by Chef Infra Client 14.7. The windows_firewall resource is now included in Chef Infra Client itself.
+  StyleGuide: 'chef_modernize_dependsonwindowsfirewallcookbook'
+  Enabled: true
+  VersionAdded: '7.19.0'
+  Include:
+    - '**/metadata.rb'
+
+Chef/Modernize/DependsOnKernelModuleCookbook:
+  Description: Don't depend on the kernel_module cookbook made obsolete by Chef Infra Client 14.3. The kernel_module resource is now included in Chef Infra Client itself.
+  StyleGuide: 'chef_modernize_dependsonkernelmodulecookbook'
+  Enabled: true
+  VersionAdded: '7.19.0'
+  Include:
+    - '**/metadata.rb'
 
 ###############################
 # Chef/RedundantCode: Cleanup unnecessary code in your cookbooks regardless of Chef Infra Client release

--- a/docs-chef-io/data/cookstyle/cops_chef_modernize_unnecessarydependschef14.yml
+++ b/docs-chef-io/data/cookstyle/cops_chef_modernize_unnecessarydependschef14.yml
@@ -2,7 +2,7 @@
 short_name: UnnecessaryDependsChef14
 full_name: Chef/Modernize/UnnecessaryDependsChef14
 department: Chef/Modernize
-description: Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These
+description: Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These
   community cookbooks contain resources that are now included in Chef Infra Client
   itself.
 autocorrection: true

--- a/lib/rubocop/cop/chef/modernize/chef_15_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_15_resources.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2021, Chef Software, Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,31 +19,28 @@ module RuboCop
   module Cop
     module Chef
       module Modernize
-        # Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+ These community cookbooks contain resources that are now included in Chef Infra Client itself.
+        # Don't depend on cookbooks made obsolete by Chef Infra Client 15.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
         #
         # @example
         #
         #   #### incorrect
-        #   depends 'build-essential'
-        #   depends 'chef_handler'
-        #   depends 'chef_hostname'
-        #   depends 'dmg'
-        #   depends 'mac_os_x'
-        #   depends 'swap'
-        #   depends 'sysctl'
+        #   depends 'libarchive'
+        #   depends 'windows_dns'
+        #   depends 'windows_uac'
+        #   depends 'windows_dfs'
         #
-        class UnnecessaryDependsChef14 < Base
+        class UnnecessaryDependsChef15 < Base
           extend AutoCorrector
           extend TargetChefVersion
           include RangeHelp
 
-          minimum_target_chef_version '14.0'
+          minimum_target_chef_version '15.0'
 
-          MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself."
+          MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 15.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself."
           RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :legacy_depends?, <<-PATTERN
-            (send nil? :depends (str {"build-essential" "chef_handler" "chef_hostname" "dmg" "mac_os_x" "swap" "sysctl"}) ... )
+            (send nil? :depends (str {"libarchive" "windows_dns" "windows_uac" "windows_dfs"}) ... )
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/depends_kernel_module_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_kernel_module_cookbook.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2021, Chef Software, Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,31 +19,25 @@ module RuboCop
   module Cop
     module Chef
       module Modernize
-        # Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+ These community cookbooks contain resources that are now included in Chef Infra Client itself.
+        # Don't depend on the kernel_module cookbook made obsolete by Chef Infra Client 14.3. The kernel_module resource is now included in Chef Infra Client itself.
         #
         # @example
         #
         #   #### incorrect
-        #   depends 'build-essential'
-        #   depends 'chef_handler'
-        #   depends 'chef_hostname'
-        #   depends 'dmg'
-        #   depends 'mac_os_x'
-        #   depends 'swap'
-        #   depends 'sysctl'
+        #   depends 'kernel_module'
         #
-        class UnnecessaryDependsChef14 < Base
+        class DependsOnKernelModuleCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion
           include RangeHelp
 
-          minimum_target_chef_version '14.0'
+          minimum_target_chef_version '14.3'
 
-          MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself."
+          MSG = "Don't depend on the kernel_module cookbook made obsolete by Chef Infra Client 14.3. The kernel_module resource is now included in Chef Infra Client itself."
           RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :legacy_depends?, <<-PATTERN
-            (send nil? :depends (str {"build-essential" "chef_handler" "chef_hostname" "dmg" "mac_os_x" "swap" "sysctl"}) ... )
+            (send nil? :depends (str "kernel_module") ... )
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/depends_locale_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_locale_cookbook.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2021, Chef Software, Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,31 +19,25 @@ module RuboCop
   module Cop
     module Chef
       module Modernize
-        # Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+ These community cookbooks contain resources that are now included in Chef Infra Client itself.
+        # Don't depend on the locale cookbook made obsolete by Chef Infra Client 14.5. The locale resource is now included in Chef Infra Client itself.
         #
         # @example
         #
         #   #### incorrect
-        #   depends 'build-essential'
-        #   depends 'chef_handler'
-        #   depends 'chef_hostname'
-        #   depends 'dmg'
-        #   depends 'mac_os_x'
-        #   depends 'swap'
-        #   depends 'sysctl'
+        #   depends 'locale'
         #
-        class UnnecessaryDependsChef14 < Base
+        class DependsOnLocaleCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion
           include RangeHelp
 
-          minimum_target_chef_version '14.0'
+          minimum_target_chef_version '14.5'
 
-          MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself."
+          MSG = "Don't depend on the locale cookbook made obsolete by Chef Infra Client 14.5. The locale resource is now included in Chef Infra Client itself."
           RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :legacy_depends?, <<-PATTERN
-            (send nil? :depends (str {"build-essential" "chef_handler" "chef_hostname" "dmg" "mac_os_x" "swap" "sysctl"}) ... )
+            (send nil? :depends (str "locale") ... )
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/depends_timezone_lwrp_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_timezone_lwrp_cookbook.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2021, Chef Software, Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,31 +19,25 @@ module RuboCop
   module Cop
     module Chef
       module Modernize
-        # Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+ These community cookbooks contain resources that are now included in Chef Infra Client itself.
+        # Don't depend on the timezone_lwrp cookbook made obsolete by Chef Infra Client 14.6. The timezone resource is now included in Chef Infra Client itself.
         #
         # @example
         #
         #   #### incorrect
-        #   depends 'build-essential'
-        #   depends 'chef_handler'
-        #   depends 'chef_hostname'
-        #   depends 'dmg'
-        #   depends 'mac_os_x'
-        #   depends 'swap'
-        #   depends 'sysctl'
+        #   depends 'timezone_lwrp'
         #
-        class UnnecessaryDependsChef14 < Base
+        class DependsOnTimezoneLwrpCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion
           include RangeHelp
 
-          minimum_target_chef_version '14.0'
+          minimum_target_chef_version '14.6'
 
-          MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself."
+          MSG = "Don't depend on the timezone_lwrp cookbook made obsolete by Chef Infra Client 14.6. The timezone resource is now included in Chef Infra Client itself."
           RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :legacy_depends?, <<-PATTERN
-            (send nil? :depends (str {"build-essential" "chef_handler" "chef_hostname" "dmg" "mac_os_x" "swap" "sysctl"}) ... )
+            (send nil? :depends (str "timezone_lwrp") ... )
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/depends_windows_firewall_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_windows_firewall_cookbook.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2019, Chef Software, Inc.
+# Copyright:: 2021, Chef Software, Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,31 +19,25 @@ module RuboCop
   module Cop
     module Chef
       module Modernize
-        # Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+ These community cookbooks contain resources that are now included in Chef Infra Client itself.
+        # Don't depend on the windows_firewall cookbook made obsolete by Chef Infra Client 14.7. The windows_firewall resource is now included in Chef Infra Client itself.
         #
         # @example
         #
         #   #### incorrect
-        #   depends 'build-essential'
-        #   depends 'chef_handler'
-        #   depends 'chef_hostname'
-        #   depends 'dmg'
-        #   depends 'mac_os_x'
-        #   depends 'swap'
-        #   depends 'sysctl'
+        #   depends 'windows_firewall'
         #
-        class UnnecessaryDependsChef14 < Base
+        class DependsOnWindowsFirewallCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion
           include RangeHelp
 
-          minimum_target_chef_version '14.0'
+          minimum_target_chef_version '14.7'
 
-          MSG = "Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself."
+          MSG = "Don't depend on the windows_firewall cookbook made obsolete by Chef Infra Client 14.7. The windows_firewall resource is now included in Chef Infra Client itself."
           RESTRICT_ON_SEND = [:depends].freeze
 
           def_node_matcher :legacy_depends?, <<-PATTERN
-            (send nil? :depends (str {"build-essential" "chef_handler" "chef_hostname" "dmg" "mac_os_x" "swap" "sysctl"}) ... )
+            (send nil? :depends (str "windows_firewall") ... )
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/libarchive_file.rb
+++ b/lib/rubocop/cop/chef/modernize/libarchive_file.rb
@@ -19,11 +19,13 @@ module RuboCop
   module Cop
     module Chef
       module Modernize
-        # Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive_file resource.
+        # Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive_file resource from the libarchive cookbook.
         #
         # @example
         #
         #   #### incorrect
+        #   depends 'libarchive'
+        #
         #   libarchive_file "C:\file.zip" do
         #     path 'C:\expand_here'
         #   end
@@ -39,7 +41,7 @@ module RuboCop
 
           minimum_target_chef_version '15.0'
 
-          MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource'
+          MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource from the libarchive cookbook'
           RESTRICT_ON_SEND = [:libarchive_file, :notifies, :subscribes].freeze
 
           def_node_matcher :notification_property?, <<-PATTERN

--- a/spec/rubocop/cop/chef/modernize/chef_14_resources_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/chef_14_resources_spec.rb
@@ -23,49 +23,49 @@ describe RuboCop::Cop::Chef::Modernize::UnnecessaryDependsChef14, :config do
   it 'registers an offense when a cookbook depends on "build-essential"' do
     expect_offense(<<~RUBY)
       depends 'build-essential'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "chef_handler"' do
     expect_offense(<<~RUBY)
       depends 'chef_handler'
-      ^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+      ^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "chef_hostname"' do
     expect_offense(<<~RUBY)
       depends 'chef_hostname'
-      ^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+      ^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "dmg"' do
     expect_offense(<<~RUBY)
       depends 'dmg'
-      ^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+      ^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "mac_os_x"' do
     expect_offense(<<~RUBY)
       depends 'mac_os_x'
-      ^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+      ^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "swap"' do
     expect_offense(<<~RUBY)
       depends 'swap'
-      ^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+      ^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
   it 'registers an offense when a cookbook depends on "sysctl"' do
     expect_offense(<<~RUBY)
       depends 'sysctl'
-      ^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+      ^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Chef::Modernize::UnnecessaryDependsChef14, :config do
   it 'registers an offense when a cookbook depends on "build-essential" and specifies a version constraint' do
     expect_offense(<<~RUBY)
       depends 'build-essential', '>= 8.0.1'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 14.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
     RUBY
   end
 

--- a/spec/rubocop/cop/chef/modernize/chef_15_resources_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/chef_15_resources_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Modernize::UnnecessaryDependsChef15, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a cookbook depends on "libarchive"' do
+    expect_offense(<<~RUBY)
+      depends 'libarchive'
+      ^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 15.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+    RUBY
+  end
+
+  it 'registers an offense when a cookbook depends on "windows_dns"' do
+    expect_offense(<<~RUBY)
+      depends 'windows_dns'
+      ^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 15.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+    RUBY
+  end
+
+  it 'registers an offense when a cookbook depends on "windows_uac"' do
+    expect_offense(<<~RUBY)
+      depends 'windows_uac'
+      ^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 15.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+    RUBY
+  end
+
+  it 'registers an offense when a cookbook depends on "windows_dfs"' do
+    expect_offense(<<~RUBY)
+      depends 'windows_dfs'
+      ^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 15.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+    RUBY
+  end
+
+  it "doesn't register an offense when depending on any old cookbook" do
+    expect_no_offenses(<<~RUBY)
+      depends 'build-essentially'
+    RUBY
+  end
+
+  it 'registers an offense when a cookbook depends on "windows_dfs" and specifies a version constraint' do
+    expect_offense(<<~RUBY)
+      depends 'windows_dfs', '>= 8.0.1'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on cookbooks made obsolete by Chef Infra Client 15.0+. These community cookbooks contain resources that are now included in Chef Infra Client itself.
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 14' do
+    let(:config) { target_chef_version(14) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'windows_dfs', '>= 8.0.1'
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/depends_kernel_module_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/depends_kernel_module_cookbook_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Modernize::DependsOnKernelModuleCookbook, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when depending on the kernel_module cookbook' do
+    expect_offense(<<~RUBY)
+      depends 'kernel_module'
+      ^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on the kernel_module cookbook made obsolete by Chef Infra Client 14.3. The kernel_module resource is now included in Chef Infra Client itself.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when depending on other cookbooks" do
+    expect_no_offenses(<<~RUBY)
+      depends 'foo'
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 14.2' do
+    let(:config) { target_chef_version(14.2) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'kernel_module'
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/depends_locale_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/depends_locale_cookbook_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Modernize::DependsOnLocaleCookbook, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when depending on the zypper cookbook' do
+    expect_offense(<<~RUBY)
+      depends 'locale'
+      ^^^^^^^^^^^^^^^^ Don't depend on the locale cookbook made obsolete by Chef Infra Client 14.5. The locale resource is now included in Chef Infra Client itself.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when depending on other cookbooks" do
+    expect_no_offenses(<<~RUBY)
+      depends 'foo'
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 14.4' do
+    let(:config) { target_chef_version(14.4) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'locale'
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/depends_timezone_lwrp_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/depends_timezone_lwrp_cookbook_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Modernize::DependsOnTimezoneLwrpCookbook, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when depending on the timezone_lwrp cookbook' do
+    expect_offense(<<~RUBY)
+      depends 'timezone_lwrp'
+      ^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on the timezone_lwrp cookbook made obsolete by Chef Infra Client 14.6. The timezone resource is now included in Chef Infra Client itself.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when depending on other cookbooks" do
+    expect_no_offenses(<<~RUBY)
+      depends 'foo'
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 14.5' do
+    let(:config) { target_chef_version(14.5) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'timezone_lwrp'
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/depends_windows_firewall_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/depends_windows_firewall_cookbook_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Modernize::DependsOnWindowsFirewallCookbook, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when depending on the windows_firewall cookbook' do
+    expect_offense(<<~RUBY)
+      depends 'windows_firewall'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on the windows_firewall cookbook made obsolete by Chef Infra Client 14.7. The windows_firewall resource is now included in Chef Infra Client itself.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when depending on other cookbooks" do
+    expect_no_offenses(<<~RUBY)
+      depends 'foo'
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 14.6' do
+    let(:config) { target_chef_version(14.6) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'windows_firewall'
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/libarchive_file_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/libarchive_file_spec.rb
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Chef::Modernize::LibarchiveFileResource, :config do
   it 'registers an offense when using the libarchive_file resource' do
     expect_offense(<<~RUBY)
       libarchive_file 'Precompiled.zip' do
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource from the libarchive cookbook
         path "foo/bar.zip"
         extract_to "/foo/bar"
       end
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Chef::Modernize::LibarchiveFileResource, :config do
       remote_file archive_path do
         action :create_if_missing
         notifies :extract, 'libarchive_file[extract_yajsw]', :immediately
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive file resource from the libarchive cookbook
       end
     RUBY
 


### PR DESCRIPTION
Detect metadata depends for cookbooks in the client itself now.

Signed-off-by: Tim Smith <tsmith@chef.io>