### PR TITLE
Add 6 more cops to detect deprecated or integrated cookbooks

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -490,7 +490,7 @@ Chef/Correctness/MetadataMalformedDepends:
     - '**/metadata.rb'
 
 Chef/Correctness/PowershellFileExists:
-  Description: Use Ruby's built-in `File.exist?('C:\somefile') instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
+  Description: Use Ruby's built-in `File.exist?('C:\somefile')` method instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
   StyleGuide: 'chef_correctness_powershellfileexists'
   Enabled: true
   VersionAdded: '7.19'
@@ -1246,6 +1246,30 @@ Chef/Deprecations/DeprecatedSudoActions:
     - '**/Berksfile'
     - '**/Rakefile'
 
+Chef/Deprecations/DependsOnChefNginxCookbook:
+  Description: Don't depend on the deprecated `chef_nginx` cookbook that was replaced by the `nginx` cookbook. The legacy chef_nginx cookbook may not be compatible with newer Chef Infra Client releases.
+  StyleGuide: 'chef_deprecations_dependsonchefnginxcookbook'
+  Enabled: true
+  VersionAdded: '7.20.0'
+  Include:
+    - '**/metadata.rb'
+
+Chef/Deprecations/DependsOnChefReportingCookbook:
+  Description: Don't depend on the chef-reporting cookbook made obsolete by Chef Infra Client 11.6. This cookbook installs a gem that is not compatible with newer Chef Infra Client releases.
+  StyleGuide: 'chef_deprecations_dependsonchefreportingcookbook'
+  Enabled: true
+  VersionAdded: '7.20.0'
+  Include:
+    - '**/metadata.rb'
+
+Chef/Deprecations/DependsOnOmnibusUpdaterCookbook:
+  Description: Don't depend on the EOL `omnibus_updater` cookbook. This cookbook no longer works with newer Chef Infra Client releases and has been replaced by with the more reliable `chef_client_updater` cookbook.
+  StyleGuide: 'chef_deprecations_dependsonomnibusupdatercookbook'
+  Enabled: true
+  VersionAdded: '7.20.0'
+  Include:
+    - '**/metadata.rb'
+
 ###############################
 # Chef/Modernize: Cleaning up legacy code and using new built-in resources
 ###############################
@@ -1845,6 +1869,30 @@ Chef/Modernize/DependsOnKernelModuleCookbook:
   StyleGuide: 'chef_modernize_dependsonkernelmodulecookbook'
   Enabled: true
   VersionAdded: '7.19.0'
+  Include:
+    - '**/metadata.rb'
+
+Chef/Modernize/DependsOnChefVaultCookbook:
+  Description: Don't depend on the chef-vault cookbook made obsolete by Chef Infra Client 16.0. The chef-vault gem and helpers are now included in Chef Infra Client itself.
+  StyleGuide: 'chef_modernize_dependsonchefvaultcookbook'
+  Enabled: true
+  VersionAdded: '7.20.0'
+  Include:
+    - '**/metadata.rb'
+
+Chef/Modernize/DependsOnChocolateyCookbooks:
+  Description: Don't depend on the chocolatey_source or chocolatey_config cookbooks made obsolete by Chef Infra Client 14.3. The chocolatey_source and chocolatey_config resources are now included in Chef Infra Client itself.
+  StyleGuide: 'chef_modernize_dependsonchocolateycookbooks'
+  Enabled: true
+  VersionAdded: '7.20.0'
+  Include:
+    - '**/metadata.rb'
+
+Chef/Modernize/DependsOnOpensslCookbook:
+  Description: Don't depend on the openssl cookbook which was made obsolete by Chef Infra Client 14.4. All openssl resource are now included directly in Chef Infra Client.
+  StyleGuide: 'chef_modernize_dependsonopensslcookbook'
+  Enabled: true
+  VersionAdded: '7.20.0'
   Include:
     - '**/metadata.rb'
 

--- a/docs-chef-io/data/cookstyle/cops_chef_correctness_powershellfileexists.yml
+++ b/docs-chef-io/data/cookstyle/cops_chef_correctness_powershellfileexists.yml
@@ -2,7 +2,7 @@
 short_name: PowershellFileExists
 full_name: Chef/Correctness/PowershellFileExists
 department: Chef/Correctness
-description: Use Ruby's built-in `File.exist?('C:\somefile') instead of executing
+description: Use Ruby's built-in `File.exist?('C:\somefile')` method instead of executing
   PowerShell's `Test-Path` cmdlet, which takes longer to load.
 autocorrection: false
 target_chef_version: All Versions

--- a/lib/rubocop/cop/chef/correctness/powershell_file_exists.rb
+++ b/lib/rubocop/cop/chef/correctness/powershell_file_exists.rb
@@ -19,7 +19,7 @@ module RuboCop
   module Cop
     module Chef
       module Correctness
-        # Use Ruby's built-in `File.exist?('C:\somefile') instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
+        # Use Ruby's built-in `File.exist?('C:\somefile')` method instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
         #
         # @example
         #
@@ -31,7 +31,7 @@ module RuboCop
         #
         class PowershellFileExists < Base
           RESTRICT_ON_SEND = [:powershell_out, :powershell_out!].freeze
-          MSG = "Use Ruby's built-in `File.exist?('C:\somefile') instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load."
+          MSG = "Use Ruby's built-in `File.exist?('C:\\somefile')` method instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load."
 
           def_node_matcher :powershell_out_exists?, <<-PATTERN
             (send nil? {:powershell_out :powershell_out!} (str $_))

--- a/lib/rubocop/cop/chef/deprecation/depends_chef_nginx_cookbook.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_chef_nginx_cookbook.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Deprecations
+        # Don't depend on the deprecated `chef_nginx` cookbook that was replaced by the `nginx` cookbook. The legacy chef_nginx cookbook may not be compatible with newer Chef Infra Client releases.
+        #
+        # @example
+        #
+        #   #### incorrect
+        #   depends 'chef_nginx'
+        #
+        #   #### correct
+        #   depends 'nginx'
+        #
+        class DependsOnChefNginxCookbook < Base
+          include RangeHelp
+          extend AutoCorrector
+
+          MSG = "Don't depend on the deprecated `chef_nginx` cookbook that was replaced by the `nginx` cookbook."
+          RESTRICT_ON_SEND = [:depends].freeze
+
+          def_node_matcher :depends_compat_resource?, <<-PATTERN
+            (send nil? :depends (str {"chef_nginx"}))
+          PATTERN
+
+          def on_send(node)
+            depends_compat_resource?(node) do
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/deprecation/depends_chef_reporting_cookbook.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_chef_reporting_cookbook.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Deprecations
+        # Don't depend on the chef-reporting cookbook made obsolete by Chef Infra Client 11.6. This cookbook installs a gem that is not compatible with newer Chef Infra Client releases.
+        #
+        # @example
+        #
+        #   #### incorrect
+        #   depends 'chef-reporting'
+        #
+        class DependsOnChefReportingCookbook < Base
+          extend AutoCorrector
+          include RangeHelp
+
+          MSG = "Don't depend on the chef-reporting cookbook made obsolete by Chef Infra Client 11.6. This cookbook installs a gem that is not compatible with newer Chef Infra Client releases."
+          RESTRICT_ON_SEND = [:depends].freeze
+
+          def_node_matcher :legacy_depends?, <<-PATTERN
+            (send nil? :depends (str "chef-reporting") ... )
+          PATTERN
+
+          def on_send(node)
+            legacy_depends?(node) do
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/deprecation/depends_omnibus_updater_cookbook.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_omnibus_updater_cookbook.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Deprecations
+        # Don't depend on the EOL `omnibus_updater` cookbook. This cookbook no longer works with newer Chef Infra Client releases and has been replaced by with the more reliable `chef_client_updater` cookbook.
+        #
+        # @example
+        #
+        #   #### incorrect
+        #   depends 'omnibus_updater'
+        #
+        #   #### correct
+        #   depends 'chef_client_updater'
+        #
+        class DependsOnOmnibusUpdaterCookbook < Base
+          extend AutoCorrector
+          include RangeHelp
+
+          MSG = "Don't depend on the EOL `omnibus_updater` cookbook. This cookbook no longer works with newer Chef Infra Client releases and has been replaced by with the more reliable `chef_client_updater` cookbook."
+          RESTRICT_ON_SEND = [:depends].freeze
+
+          def_node_matcher :legacy_depends?, <<-PATTERN
+            (send nil? :depends (str "omnibus_updater") ... )
+          PATTERN
+
+          def on_send(node)
+            legacy_depends?(node) do
+              add_offense(node, message: MSG, severity: :warning) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/modernize/depends_chef_vault_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_chef_vault_cookbook.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Modernize
+        # Don't depend on the chef-vault cookbook made obsolete by Chef Infra Client 16.0. The chef-vault gem and helpers are now included in Chef Infra Client itself.
+        #
+        # @example
+        #
+        #   #### incorrect
+        #   depends 'chef-vault'
+        #
+        class DependsOnChefVaultCookbook < Base
+          extend AutoCorrector
+          extend TargetChefVersion
+          include RangeHelp
+
+          minimum_target_chef_version '16.0'
+
+          MSG = "Don't depend on the chef-vault cookbook made obsolete by Chef Infra Client 16.0. The chef-vault gem and helpers are now included in Chef Infra Client itself."
+          RESTRICT_ON_SEND = [:depends].freeze
+
+          def_node_matcher :legacy_depends?, <<-PATTERN
+            (send nil? :depends (str "chef-vault") ... )
+          PATTERN
+
+          def on_send(node)
+            legacy_depends?(node) do
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/modernize/depends_chocolatey_cookbooks.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_chocolatey_cookbooks.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Modernize
+        # Don't depend on the chocolatey_source or chocolatey_config cookbooks made obsolete by Chef Infra Client 14.3. The chocolatey_source and chocolatey_config resources are now included in Chef Infra Client itself.
+        #
+        # @example
+        #
+        #   #### incorrect
+        #   depends 'chocolatey_source'
+        #   depends 'chocolatey_config'
+        #
+        class DependsOnChocolateyCookbooks < Base
+          extend AutoCorrector
+          extend TargetChefVersion
+          include RangeHelp
+
+          minimum_target_chef_version '14.3'
+
+          MSG = "Don't depend on the chocolatey_source or chocolatey_config cookbooks made obsolete by Chef Infra Client 14.3. The chocolatey_source and chocolatey_config resources are now included in Chef Infra Client itself."
+          RESTRICT_ON_SEND = [:depends].freeze
+
+          def_node_matcher :legacy_depends?, <<-PATTERN
+            (send nil? :depends (str {"chocolatey_source" "chocolatey_config"}) ... )
+          PATTERN
+
+          def on_send(node)
+            legacy_depends?(node) do
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/modernize/depends_openssl_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_openssl_cookbook.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Modernize
+        # Don't depend on the openssl cookbook which was made obsolete by Chef Infra Client 14.4. All openssl resource are now included directly in Chef Infra Client.
+        #
+        # @example
+        #
+        #   #### incorrect
+        #   depends 'openssl'
+        #
+        class DependsOnOpensslCookbook < Base
+          extend AutoCorrector
+          extend TargetChefVersion
+          include RangeHelp
+
+          minimum_target_chef_version '14.4'
+
+          MSG = "Don't depend on the openssl cookbook which was made obsolete by Chef Infra Client 14.4. All openssl resource are now included directly in Chef Infra Client."
+          RESTRICT_ON_SEND = [:depends].freeze
+
+          def_node_matcher :legacy_depends?, <<-PATTERN
+            (send nil? :depends (str "openssl") ... )
+          PATTERN
+
+          def on_send(node)
+            legacy_depends?(node) do
+              add_offense(node, message: MSG, severity: :refactor) do |corrector|
+                corrector.remove(range_with_surrounding_space(range: node.loc.expression, side: :left))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/powershell_file_exists_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/powershell_file_exists_spec.rb
@@ -24,14 +24,14 @@ describe RuboCop::Cop::Chef::Correctness::PowershellFileExists, :config do
   it 'registers an offense when when using powershell_out to run Test-Path' do
     expect_offense(<<~RUBY)
       powershell_out('Test-Path "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"').stdout.strip == 'True'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Ruby's built-in `File.exist?('C:\somefile') instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Ruby's built-in `File.exist?('C:\\somefile')` method instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
     RUBY
   end
 
   it 'registers an offense when when using powershell_out! to run Test-Path' do
     expect_offense(<<~RUBY)
       powershell_out!('Test-Path "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"').stdout.strip == 'True'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Ruby's built-in `File.exist?('C:\somefile') instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use Ruby's built-in `File.exist?('C:\\somefile')` method instead of executing PowerShell's `Test-Path` cmdlet, which takes longer to load.
     RUBY
   end
 

--- a/spec/rubocop/cop/chef/deprecation/depends_chef_nginx_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/depends_chef_nginx_cookbook_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Deprecations::DependsOnChefNginxCookbook, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a cookbook depends on "chef_nginx"' do
+    expect_offense(<<~RUBY)
+      depends 'chef_nginx'
+      ^^^^^^^^^^^^^^^^^^^^ Don't depend on the deprecated `chef_nginx` cookbook that was replaced by the `nginx` cookbook.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when depending on nginx cookbook" do
+    expect_no_offenses(<<~RUBY)
+      depends 'nginx'
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/depends_chef_reporting_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/depends_chef_reporting_cookbook_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Deprecations::DependsOnChefReportingCookbook, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a cookbook depends on "chef-reporting"' do
+    expect_offense(<<~RUBY)
+      depends 'chef-reporting'
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on the chef-reporting cookbook made obsolete by Chef Infra Client 11.6. This cookbook installs a gem that is not compatible with newer Chef Infra Client releases.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when depending on any old cookbook" do
+    expect_no_offenses(<<~RUBY)
+      depends 'foo'
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/depends_omnibus_updater_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/depends_omnibus_updater_cookbook_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Deprecations::DependsOnOmnibusUpdaterCookbook, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a cookbook depends on "omnibus_updater"' do
+    expect_offense(<<~RUBY)
+      depends 'omnibus_updater'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on the EOL `omnibus_updater` cookbook. This cookbook no longer works with newer Chef Infra Client releases and has been replaced by with the more reliable `chef_client_updater` cookbook.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when depending on any chef_client_updater cookbook" do
+    expect_no_offenses(<<~RUBY)
+      depends 'chef_client_updater'
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/depends_chef_vault_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/depends_chef_vault_cookbook_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Modernize::DependsOnChefVaultCookbook, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when depending on the chef-vault cookbook' do
+    expect_offense(<<~RUBY)
+      depends 'chef-vault'
+      ^^^^^^^^^^^^^^^^^^^^ Don't depend on the chef-vault cookbook made obsolete by Chef Infra Client 16.0. The chef-vault gem and helpers are now included in Chef Infra Client itself.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when depending on other cookbooks" do
+    expect_no_offenses(<<~RUBY)
+      depends 'foo'
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 15.x' do
+    let(:config) { target_chef_version(15.99) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'chef-vault'
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/depends_chocolatey_cookbooks_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/depends_chocolatey_cookbooks_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Modernize::DependsOnChocolateyCookbooks, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when depending on the chocolatey_source cookbook' do
+    expect_offense(<<~RUBY)
+      depends 'chocolatey_source'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on the chocolatey_source or chocolatey_config cookbooks made obsolete by Chef Infra Client 14.3. The chocolatey_source and chocolatey_config resources are now included in Chef Infra Client itself.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it 'registers an offense when depending on the chocolatey_config cookbook' do
+    expect_offense(<<~RUBY)
+      depends 'chocolatey_config'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't depend on the chocolatey_source or chocolatey_config cookbooks made obsolete by Chef Infra Client 14.3. The chocolatey_source and chocolatey_config resources are now included in Chef Infra Client itself.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when depending on other cookbooks" do
+    expect_no_offenses(<<~RUBY)
+      depends 'foo'
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 14.2' do
+    let(:config) { target_chef_version(14.2) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'chocolatey_config'
+        depends 'chocolatey_source'
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/depends_openssl_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/depends_openssl_cookbook_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2021, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Modernize::DependsOnOpensslCookbook, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when depending on the openssl cookbook' do
+    expect_offense(<<~RUBY)
+      depends 'openssl'
+      ^^^^^^^^^^^^^^^^^ Don't depend on the openssl cookbook which was made obsolete by Chef Infra Client 14.4. All openssl resource are now included directly in Chef Infra Client.
+    RUBY
+
+    expect_correction("\n")
+  end
+
+  it "doesn't register an offense when depending on other cookbooks" do
+    expect_no_offenses(<<~RUBY)
+      depends 'foo'
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 14.3' do
+    let(:config) { target_chef_version(14.3) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        depends 'openssl'
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Flag more deps that users can nuke from modern Chef Infra installations

Signed-off-by: Tim Smith <tsmith@chef.io>