### PR TITLE
Add Chef target versions to existing cops

### DIFF
--- a/lib/rubocop/cop/chef/modernize/use_chef_language_cloud_helpers.rb
+++ b/lib/rubocop/cop/chef/modernize/use_chef_language_cloud_helpers.rb
@@ -49,6 +49,9 @@ module RuboCop
         #
         class UseChefLanguageCloudHelpers < Base
           extend AutoCorrector
+          extend TargetChefVersion
+
+          minimum_target_chef_version '15.5'
 
           MSG = 'Chef Infra Client 15.5 and later include cloud helpers to make detecting instances that run on public and private clouds easier.'
           RESTRICT_ON_SEND = [:==, :[]].freeze

--- a/lib/rubocop/cop/chef/modernize/use_chef_language_env_helpers.rb
+++ b/lib/rubocop/cop/chef/modernize/use_chef_language_env_helpers.rb
@@ -33,6 +33,9 @@ module RuboCop
         #
         class UseChefLanguageEnvHelpers < Base
           extend AutoCorrector
+          extend TargetChefVersion
+
+          minimum_target_chef_version '15.5'
 
           RESTRICT_ON_SEND = [:[]].freeze
 


### PR DESCRIPTION
These should be limited to 15.5+

Signed-off-by: Tim Smith <tsmith@chef.io>