### PR TITLE
Add new Chef/Correctness/InvalidCookbookName cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -506,6 +506,14 @@ Chef/Correctness/MetadataMissingVersion:
   Include:
     - '**/metadata.rb'
 
+Chef/Correctness/InvalidCookbookName:
+  Description: Cookbook names should not contain invalid characters such as periods.
+  StyleGuide: 'chef_correctness_invalidcookbookname'
+  Enabled: true
+  VersionAdded: '7.27'
+  Include:
+    - '**/metadata.rb'
+
 ###############################
 # Chef/Sharing: Issues that prevent sharing code with other teams or with the Chef community in general
 ###############################

--- a/lib/rubocop/cop/chef/correctness/invalid_cookbook_name.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_cookbook_name.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2022, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Correctness
+        # Cookbook names should not contain invalid characters such as periods.
+        #
+        # @example
+        #
+        #   #### incorrect
+        #   name 'foo.bar'
+        #
+        #   #### correct
+        #   name 'foo_bar'
+        #
+        class InvalidCookbookName < Base
+          RESTRICT_ON_SEND = [:name].freeze
+          MSG = 'Cookbook names should not contain invalid characters such as periods.'
+
+          def_node_matcher :has_name?, '(send nil? :name $str)'
+
+          def on_send(node)
+            has_name?(node) do |val|
+              add_offense(node, message: MSG, severity: :refactor) if val.value.include?('.')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/invalid_cookbook_name_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/invalid_cookbook_name_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2022, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Correctness::InvalidCookbookName, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when the name has a period' do
+    expect_offense(<<~RUBY, '/foo/bar/metadata.rb')
+      name 'foo.bar'
+      ^^^^^^^^^^^^^^ Cookbook names should not contain invalid characters such as periods.
+      depends 'foo'
+    RUBY
+  end
+
+  it "doesn't register an offense when the name isn't a string" do
+    expect_no_offenses(<<~RUBY)
+      name name_variable
+    RUBY
+  end
+
+  it "doesn't register an offense when the name does not contain a period" do
+    expect_no_offenses(<<~RUBY)
+      name 'foo_bar'
+    RUBY
+  end
+end


### PR DESCRIPTION
Detect cookbook names with a period that may cause internal issues in the client and/or server

Signed-off-by: Tim Smith <tsmith@chef.io>