### PR TITLE
Add new Chef/Correctness/InvalidNotificationResource cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -514,6 +514,16 @@ Chef/Correctness/InvalidCookbookName:
   Include:
     - '**/metadata.rb'
 
+Chef/Correctness/InvalidNotificationResource:
+  Description: The resource to notify when calling `notifies` or `subscribes` must be a string.
+  StyleGuide: 'chef_correctness_invalidnotificationresource'
+  Enabled: true
+  VersionAdded: '7.28'
+  Exclude:
+    - '**/attributes/*.rb'
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 ###############################
 # Chef/Sharing: Issues that prevent sharing code with other teams or with the Chef community in general
 ###############################

--- a/lib/rubocop/cop/chef/correctness/invalid_notification_resource.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_notification_resource.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2022, Chef Software, Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Correctness
+        # The resource to notify when calling `notifies` or `subscribes` must be a string.
+        #
+        # @example
+        #
+        #   #### incorrect
+        #
+        #   template '/etc/www/configures-apache.conf' do
+        #     notifies :restart, service['apache'], :immediately
+        #   end
+        #
+        #   template '/etc/www/configures-apache.conf' do
+        #     notifies :restart, service[apache], :immediately
+        #   end
+        #
+        #   #### correct
+        #
+        #   template '/etc/www/configures-apache.conf' do
+        #     notifies :restart, 'service[apache]', :immediately
+        #   end
+        #
+        class InvalidNotificationResource < Base
+          MSG = 'The resource to notify when calling `notifies` or `subscribes` must be a string.'
+          RESTRICT_ON_SEND = [:notifies, :subscribes].freeze
+
+          def_node_matcher :invalid_notification?, <<-PATTERN
+            (send nil? {:notifies :subscribes} (sym _) $(send (send nil? _) :[] ...) ...)
+          PATTERN
+
+          def on_send(node)
+            invalid_notification?(node) do |resource|
+              add_offense(resource, message: MSG, severity: :refactor)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/invalid_notification_resource_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/invalid_notification_resource_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright 2022, Chef Software Inc.
+# Author:: Tim Smith (<tsmith@chef.io>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Correctness::InvalidNotificationResource do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense with an invalid resource name and timing specified' do
+    expect_offense(<<~RUBY)
+      execute 'some command' do
+        notifies :restart, service['httpd'], :now
+                           ^^^^^^^^^^^^^^^^ The resource to notify when calling `notifies` or `subscribes` must be a string.
+      end
+    RUBY
+  end
+
+  it 'registers an offense with an invalid resource name and no timing specified' do
+    expect_offense(<<~RUBY)
+      execute 'some command' do
+        notifies :restart, service['httpd']
+                           ^^^^^^^^^^^^^^^^ The resource to notify when calling `notifies` or `subscribes` must be a string.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense with a valid resource name and timing' do
+    expect_no_offenses(<<~RUBY)
+      execute 'some command' do
+        notifies :restart, 'service[httpd]', :delayed
+      end
+    RUBY
+  end
+
+  it 'does not register an offense with a valid resource name and no timing' do
+    expect_no_offenses(<<~RUBY)
+      execute 'some command' do
+        notifies :restart, 'service[httpd]'
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Detect when people put the quotes in the wrong place. This came up in a bug recently. Running it over all of Supermarket it found one I did wrong too :facepalm:

Signed-off-by: Tim Smith <tsmith@chef.io>