### PR TITLE
Add support for the `path` property in RedundantCode/UseCreateIfMissing

### DIFF
--- a/lib/rubocop/cop/chef/redundant/use_create_if_missing.rb
+++ b/lib/rubocop/cop/chef/redundant/use_create_if_missing.rb
@@ -19,7 +19,7 @@ module RuboCop
   module Cop
     module Chef
       module RedundantCode
-        # Use the :create_if_missing action instead of not_if with a ::File.exist(FOO) check.
+        # Use the `:create_if_missing` action instead of `not_if` with a `::File.exist(FOO)` check.
         #
         # @example
         #
@@ -32,9 +32,27 @@ module RuboCop
         #     not_if { ::File.exists?('/logs/foo/error.log') }
         #   end
         #
+        #   remote_file 'Download file' do
+        #     path '/foo/bar'
+        #     source 'https://foo.com/bar'
+        #     owner 'root'
+        #     group 'root'
+        #     mode '0644'
+        #     not_if { ::File.exist?('/foo/bar') }
+        #   end
+        #
         #   #### correct
         #   cookbook_file '/logs/foo/error.log' do
         #     source 'error.log'
+        #     owner 'root'
+        #     group 'root'
+        #     mode '0644'
+        #     action :create_if_missing
+        #   end
+        #
+        #   remote_file 'Download file' do
+        #     path '/foo/bar'
+        #     source 'https://foo.com/bar'
         #     owner 'root'
         #     group 'root'
         #     mode '0644'
@@ -57,11 +75,15 @@ module RuboCop
 
           def_node_search :create_action?, '(send nil? :action $sym)'
 
+          def_node_search :path_property_node, '(send nil? :path $...)'
+
           def on_block(node)
             not_if_file_exist?(node) do |props|
               file_like_resource?(node.parent.parent) do |resource_blk_name|
-                # the not_if file name is the same as the resource name and there's no action defined (it's the default)
-                return unless props == resource_blk_name && create_action?(node.parent.parent).nil?
+                # the not_if file name is the same as the resource name or the value in the path property
+                # and there's no action defined (it's the default)
+                return unless (props == resource_blk_name || path_property_node(node.parent.parent)&.first&.first == props) &&
+                              create_action?(node.parent.parent).nil?
 
                 add_offense(node, message: MSG, severity: :refactor) do |corrector|
                   corrector.replace(node, 'action :create_if_missing')


### PR DESCRIPTION
If someone uses the name_property of path we want to dig in there as well.

Signed-off-by: Tim Smith <tsmith@chef.io>