### PR TITLE
Update UseCreateIfMissing to support non-string path values

### DIFF
--- a/lib/rubocop/chef/cookbook_helpers.rb
+++ b/lib/rubocop/chef/cookbook_helpers.rb
@@ -111,6 +111,8 @@ module RuboCop
         case node.type
         when :send
           yield(node) if node.receiver.nil? # if it's not nil then we're not in a property foo we're in bar.foo
+        when :block # ie: not_if { ruby_foo }
+          yield(node)
         when :while
           extract_send_types(node.body) { |t| yield(t) }
         when :if


### PR DESCRIPTION
Also modernize the resource to use the helpers and make sure the helpers support properties with a block. This change identified 150 new offenses on the Supermarket.

Signed-off-by: Tim Smith <tsmith@chef.io>