### PR TITLE
Allow departments to be enabled/disabled by users

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -12,6 +12,7 @@ AllCops:
 ###############################
 
 Chef/Style:
+  Enabled: true
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
 Chef/Style/AttributeKeys:
@@ -156,6 +157,7 @@ Chef/Style/IncludeRecipeWithParentheses:
 ###############################
 
 Chef/Correctness:
+  Enabled: true
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
 Chef/Correctness/ServiceResource:
@@ -529,6 +531,7 @@ Chef/Correctness/InvalidNotificationResource:
 ###############################
 
 Chef/Sharing:
+  Enabled: true
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
 Chef/Sharing/InsecureCookbookURL:
@@ -597,6 +600,7 @@ Chef/Sharing/IncludeResourceExamples:
 ###############################
 
 Chef/Deprecations:
+  Enabled: true
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
 Chef/Deprecations/NodeDeepFetch:
@@ -1301,6 +1305,7 @@ Chef/Deprecations/DependsOnOmnibusUpdaterCookbook:
 ###############################
 
 Chef/Modernize:
+  Enabled: true
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
 Chef/Modernize/LegacyBerksfileSource:
@@ -1973,6 +1978,7 @@ Chef/Modernize/DeclareActionClass:
 ###############################
 
 Chef/RedundantCode:
+  Enabled: true
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
 Chef/RedundantCode/ConflictsMetadata:
@@ -2195,6 +2201,7 @@ Chef/RedundantCode/DoubleCompileTime:
 ###############################
 
 Chef/Effortless:
+  Enabled: true
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
 Chef/Effortless/CookbookUsesSearch:


### PR DESCRIPTION
Over in https://github.com/rubocop/rubocop/issues/9752 we figured out
that the reason end-users can't enable/disable Cookstyle departments is
because `Enabled` isn't in the config and thus [can't be
overridden](https://github.com/rubocop/rubocop/issues/9752#issuecomment-877707141).

This change will allow a user to not only do the obvious:

```yaml
Chef/Correctness:
  Enabled: false
```

But more interestingly do something like this:

```yaml
AllCops:
  DisabledByDefault: true

Chef/Correctness:
  Enabled: true
```

CC @jonas054

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
