### PR TITLE
Update Chef/Deprecations/DeprecatedChefSpecPlatform for new fauxhai deprecations

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/deprecated_chefspec_platform.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_chefspec_platform.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2020, Chef Software Inc.
+# Copyright:: 2020-2022, Chef Software Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +34,7 @@ module RuboCop
           DEPRECATED_MAPPING = {
             'amazon' => {
               '2017.12' => '2',
+              '> 2010' => true,
             },
             'aix' => {
               '~> 6' => true,
@@ -46,15 +47,15 @@ module RuboCop
               '> 16.04, < 18.04' => true,
             },
             'fedora' => {
-              '< 31' => '31',
+              '< 32' => '32',
             },
             'freebsd' => {
-              '~> 11.0, < 11.2' => '11',
               '= 12.0' => '12',
-              '< 11' => true,
+              '< 12' => true,
             },
             'mac_os_x' => {
               '< 10.14' => '10.15',
+              ' = 11.0' => '11',
             },
             'suse' => {
               '~> 12.0, < 12.4' => '12',
@@ -67,17 +68,17 @@ module RuboCop
             },
             'debian' => {
               '< 9' => true,
-              '> 9.0, < 9.11' => '9',
+              '> 9.0, < 9.12' => '9',
             },
             'centos' => {
               '< 6.0' => true,
               '~> 6.0, < 6.10' => '6',
-              '~> 7.0, < 7.7 ' => '7',
+              '~> 7.0, < 7.8 ' => '7',
             },
             'redhat' => {
               '< 6.0' => true,
               '~> 6.0, < 6.10' => '6',
-              '~> 7.0, < 7.7' => '7',
+              '~> 7.0, < 7.8' => '7',
             },
             'oracle' => {
               '< 6.0' => true,

--- a/spec/rubocop/cop/chef/deprecation/deprecated_chefspec_platform_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/deprecated_chefspec_platform_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2020, Chef Software, Inc.
+# Copyright:: 2020-2022, Chef Software, Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,6 +55,21 @@ describe RuboCop::Cop::Chef::Deprecations::DeprecatedChefSpecPlatform, :config d
   it "doesn't register an offense with a modern platform" do
     expect_no_offenses(<<~RUBY)
       let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'centos', version: '200') }
+    RUBY
+  end
+
+  it "registers an offense when spec calls for Amazon 2018.03, but doesn't autocorrect" do
+    expect_offense(<<~RUBY)
+      let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'amazon', version: '2018.03') }
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it "doesn't register an offense with Amazon Linux 2022" do
+    expect_no_offenses(<<~RUBY)
+      let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'amazon', version: '2002') }
     RUBY
   end
 end


### PR DESCRIPTION
All Amazon 201X releases are deprecated
Fedora 31 is now deprecated
FreeBSD 11.2 is now deprecated
macOS 11.0 has been replaced with macOS 11
Debian 9.12 is now deprecated
CentOS 7.8 is now deprecated
Redhat 7.8 is now deprecated

Signed-off-by: Tim Smith <tsmith@chef.io>