### PR TITLE
Flag Chef/Modernize/CronDFileOrTemplate offenses with string interpolation

### DIFF
--- a/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
@@ -48,6 +48,10 @@ module RuboCop
         #     action :delete
         #   end
         #
+        #   file "/etc/cron.d/#{job_name}" do
+        #     action :delete
+        #   end
+        #
         #   #### correct
         #   cron_d 'backup' do
         #     minute '1'
@@ -70,14 +74,14 @@ module RuboCop
           def_node_matcher :file_or_template?, <<-PATTERN
             (block
               (send nil? {:template :file :cookbook_file}
-                (str $_))
+                $(...))
               ...
             )
           PATTERN
 
           def on_block(node)
             file_or_template?(node) do |file_name|
-              return unless file_name.start_with?('/etc/cron.d/')
+              return unless file_name.value.start_with?('/etc/cron.d/')
               add_offense(node, severity: :refactor)
             end
           end

--- a/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2020, Chef Software, Inc.
+# Copyright:: 2020-2022, Chef Software, Inc.
 # Author:: Tim Smith (<tsmith@chef.io>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,7 +81,12 @@ module RuboCop
 
           def on_block(node)
             file_or_template?(node) do |file_name|
+              # weed out types we can't evaluate
+              return unless file_name.dstr_type? || file_name.str_type?
+
+              # weed out string values that aren't a cron.d file
               return unless file_name.value.start_with?('/etc/cron.d/')
+
               add_offense(node, severity: :refactor)
             end
           end

--- a/spec/rubocop/cop/chef/modernize/cron_d_file_or_template_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/cron_d_file_or_template_spec.rb
@@ -69,4 +69,12 @@ describe RuboCop::Cop::Chef::Modernize::CronDFileOrTemplate, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when the resource name is a variable or method' do
+    expect_no_offenses(<<~RUBY)
+      template foo do
+        source "thing.erb"
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/cron_d_file_or_template_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/cron_d_file_or_template_spec.rb
@@ -61,5 +61,12 @@ describe RuboCop::Cop::Chef::Modernize::CronDFileOrTemplate, :config do
         action :delete
       end
     RUBY
+
+    expect_offense(<<~'RUBY')
+      file "/etc/cron.d/#{job_name}" do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the cron_d resource that ships with Chef Infra Client 14.4+ instead of manually creating the file with template, file, or cookbook_file resources
+        action :delete
+      end
+    RUBY
   end
 end


### PR DESCRIPTION
Updates node matcher pattern for `Chef/Modernize/CronDFileOrTempalte` to capture everything in the file/template/cookbook_file resource declaration to catch offenses where the resource name is both a regular string and an interpolated string.

## Description

The existing matcher does not flag offenses if the `file`/`cookbook_file`/`template` resource is named using string interpolation

## Related Issue

https://github.com/chef/cookstyle/issues/940

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

~~since i don't use ruby outside of ChefDK, I need to put together a local dev env to run the tests in; doing so currently and will update the Checklist after I've done so and run the tests on my local machine.~~ This has since been completed. 
