### PR TITLE
Avoid failures with non-string cron path values

### DIFF
--- a/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
@@ -110,7 +110,9 @@ module RuboCop
               # and check if their value contains '/etc/cron.d'
               # covers the case where the argument to the path property is provided via a method like File.join
               code_property.each_descendant do |d|
-                add_offense(node, severity: :refactor) if d.respond_to?(:value) && d.value.match?(%r{/etc/cron\.d}i)
+                add_offense(node, severity: :refactor) if d.respond_to?(:value) && 
+                                                          d.value.is_a?(String) &&
+                                                          d.value.match?(%r{/etc/cron\.d/}i)
               end
             end
           end

--- a/spec/rubocop/cop/chef/modernize/cron_d_file_or_template_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/cron_d_file_or_template_spec.rb
@@ -119,4 +119,12 @@ describe RuboCop::Cop::Chef::Modernize::CronDFileOrTemplate, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when path value has a non-string value' do
+    expect_no_offenses(<<~RUBY)
+      cookbook_file new_resource.file_name do
+        path Regexp.last_match(1)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This was causing failures on Supermarket

Signed-off-by: Tim Smith <tsmith@chef.io>