### PR TITLE
Refactor Chef/Deprecations/Delivery to address caching issues

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2,6 +2,12 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 2.5
   TargetChefVersion: ~
+  inherit_mode:
+    merge:
+     - Include
+  Include:
+    - '**/.delivery/project.toml'      # required by Chef/Deprecations/Delivery
+    - '**/.delivery/config.json'       # required by Chef/Deprecations/Delivery
   Exclude:
     - '**/files/**/*'
     - '**/vendor/**/*'
@@ -1265,12 +1271,13 @@ Chef/Deprecations/PolicyfileCommunitySource:
     - '**/Policyfile.rb'
 
 Chef/Deprecations/Delivery:
-  Description: Do not include a `.delivery` directory for the `delivery` command in your cookbooks. Chef Delivery (Workflow) went EOL Dec 31st 2021 and the delivery command was removed from Chef Workstation Feb 2022.
+  Description: Do not include Chef Delivery (Workflow) configuration in your cookbooks. Chef Delivery (Workflow) went EOL Dec 31st 2021 and the delivery command was removed from Chef Workstation Feb 2022.
   StyleGuide: 'chef_deprecations_delivery'
   Enabled: true
   VersionAdded: '7.31.0'
   Include:
-    - '**/metadata.rb'
+    - '**/.delivery/project.toml'
+    - '**/.delivery/config.json'
 
 Chef/Deprecations/DeprecatedSudoActions:
   Description: The `sudo` resource in the sudo cookbook 5.0 (2018) or Chef Infra Client 14 and later have replaced the existing `:install` and `:remove` actions with `:create` and `:delete` actions to better match other resources in Chef Infra.
@@ -1954,7 +1961,7 @@ Chef/Modernize/UseChefLanguageCloudHelpers:
     - '**/resources/*.rb'
     - '**/providers/*.rb'
     - '**/recipes/*.rb'
-    
+
 Chef/Modernize/ClassEvalActionClass:
   Description: In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block.
   StyleGuide: 'chef_modernize_classevalactionclass'
@@ -2332,7 +2339,7 @@ Chef/Security/SshPrivateKey:
     - '**/recipes/*.rb'
     - '**/attributes/*.rb'
     - '**/definitions/*.rb'
-    
+
 #### The base rubocop 0.37 enabled.yml file we started with ####
 
 Layout/AccessModifierIndentation:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_delivery.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_delivery.yml
@@ -13,4 +13,4 @@ examples:
 version_added: 7.31.0
 enabled: true
 included_file_paths:
-- "**/metadata.rb"
+- "**/.delivery/project.toml"

--- a/lib/rubocop/cop/chef/deprecation/delivery.rb
+++ b/lib/rubocop/cop/chef/deprecation/delivery.rb
@@ -27,16 +27,20 @@ module RuboCop
         class Delivery < Base
           include RangeHelp
 
-          MSG = 'Do not include a `.delivery` directory for the `delivery` command in your cookbooks. Chef Delivery (Workflow) went EOL Dec 31st 2021 and the delivery command was removed from Chef Workstation Feb 2022.'
+          MSG = 'Do not include Chef Delivery (Workflow) configuration in your cookbooks. It went EOL Dec 31st 2021 and the delivery command was removed from Chef Workstation Feb 2022.'
 
-          def on_new_investigation
-            return unless File.exist?(File.join(File.dirname(processed_source.path) + '/.delivery'))
+          def on_other_file
+            return unless processed_source.path.end_with?('/.delivery/project.toml', '/.delivery/config.json')
 
             # Using range similar to RuboCop::Cop::Naming::Filename (file_name.rb)
             range = source_range(processed_source.buffer, 1, 0)
 
             add_offense(range, severity: :warning)
           end
+
+          # An empty / simple TOML file can also be syntatically valid Ruby, so
+          # RuboCop may start an investigation instead of calling on_other_file.
+          alias_method :on_new_investigation, :on_other_file
         end
       end
     end

--- a/lib/rubocop/monkey_patches/allow_invalid_ruby.rb
+++ b/lib/rubocop/monkey_patches/allow_invalid_ruby.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rubocop/rspec/expect_offense'
+# rubocop:disable Lint/DuplicateMethods
+
+module RuboCop
+  module RSpec
+    module ExpectOffense
+      # Yields to a block with `parse_processed_source` patched to not raise an
+      # exception.
+      #
+      # RSpec's `expect_offense` helper calls a method called
+      # `parse_processed_source` that parses source code and raises an exception
+      # if it is not valid Ruby. Raising an exception prevents RuboCop from
+      # calling the cop's `on_other_file` method for checking non-Ruby files.
+      def allow_invalid_ruby(&block)
+        alias :parse_processed_source :_parse_invalid_source
+        yield block
+        alias :parse_processed_source :_orig_parse_processed_source
+      end
+
+      alias :_orig_parse_processed_source :parse_processed_source
+
+      def _parse_invalid_source(source, file = nil)
+        parse_source(source, file)
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/deprecation/delivery_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/delivery_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2019, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'rubocop/monkey_patches/allow_invalid_ruby'
+
+describe RuboCop::Cop::Chef::Deprecations::Delivery, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when cookbook includes .delivery/project.toml' do
+    expect_offense(<<~'TOML', 'cookbook/.delivery/project.toml')
+      [delivery_local]
+      ^ Do not include Chef Delivery (Workflow) configuration [...]
+    TOML
+  end
+
+  it 'registers an offense when .delivery/config.json is not valid Ruby' do
+    allow_invalid_ruby do
+      expect_offense(<<~TOML, 'cookbook/.delivery/config.json')
+        This isn't parsable Ruby.
+        ^ Do not include Chef Delivery (Workflow) configuration [...]
+      TOML
+    end
+  end
+end


### PR DESCRIPTION
Signed-off-by: Doug Knight <doug.knight@karmix.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
RuboCop inspects files not directories.  In order to report an offense for the existence of a `.delivery` directory, the Delivery cop performs the checks and makes its report when asked to inspect the `metadata.rb` file.  On subsequent runs, RuboCop will see that the content of `metadata.rb` has not changed, and report the cached offense form the Delivery cop, even after the `.delivery` directory is removed.

This patch refactors the Delivery cop to report offenses for the existence of the files `.delivery/config.json` (Chef Delivery config) and  `.delivery/project.toml` (Chef Delivery Local config), instead of trying to check for the existence of a directory.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #942 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
