### PR TITLE
[CHEF-1116] - Fixed the false positive issue with CronDFileOrTemplate and Updated the required Ruby version to 2.7

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5
+        ruby-version: 2.7
         bundler-cache: true
     - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
     - run: bundle exec cookstyle

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019, ubuntu-latest]
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.7', '3.0', '3.1']
     runs-on: ${{ matrix.os }}
     env:
-      BUNDLE_WITHOUT: profiling,debug,docs
+      BUNDLE_WITHOUT: profiling debug docs
     name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/cookstyle.gemspec
+++ b/cookstyle.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Cookstyle is a code linting tool that helps you to write better Chef Infra cookbooks by detecting and automatically correcting style, syntax, and logic mistakes in your code.'
   spec.license       = 'Apache-2.0'
   spec.homepage      = 'https://docs.chef.io/workstation/cookstyle/'
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.7'
 
   # the gemspec and Gemfile are necessary for appbundling of the gem
   spec.files = %w(LICENSE cookstyle.gemspec Gemfile) + Dir.glob('{lib,bin,config}/**/*')

--- a/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
@@ -101,7 +101,7 @@ module RuboCop
 
           def on_block(node)
             file_or_template?(node) do |file_name|
-              break unless file_name.match?(%r{/etc/cron\.d\b}i)
+              break unless file_name.start_with?(%r{/etc/cron\.d\b}i)
               add_offense(node, severity: :refactor)
             end
 

--- a/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
@@ -101,7 +101,7 @@ module RuboCop
 
           def on_block(node)
             file_or_template?(node) do |file_name|
-              break unless file_name.start_with?('/etc/cron.d')
+              break unless file_name.match?(%r{/etc/cron\.d\b}i)
               add_offense(node, severity: :refactor)
             end
 
@@ -110,7 +110,7 @@ module RuboCop
               # and check if their value contains '/etc/cron.d'
               # covers the case where the argument to the path property is provided via a method like File.join
               code_property.each_descendant do |d|
-                add_offense(node, severity: :refactor) if d.respond_to?(:value) && d.value.match?(%r{/etc/cron\.d}i)
+                add_offense(node, severity: :refactor) if d.respond_to?(:value) && d.value.match?(%r{/etc/cron\.d\b}i)
               end
             end
           end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The following recipe will raise the CronDFileOrTemplate cop due to the regex matching in the same class.

```ruby
file '/etc/cron.deny' do 
  action :delete
end
```

I've updated the regex so that `cron.deny` will no longer treated as a cron file and the current scenarios will work as it is. The samples of the regex are below.

```ruby
3.1.0 :001 > exp = %r{/etc/cron\.d\b}i
 => /\/etc\/cron\.d\b/i
3.1.0 :002 > "/etc/cron.d/".match?(exp)
 => true
3.1.0 :003 > "/etc/cron.d".match?(exp)
 => true
3.1.0 :004 > "/etc/cron.d/backup".match?(exp)
 => true
3.1.0 :005 > "/etc/cron.deny".match?(exp)
 => false
3.1.0 :006 > "/etc/cron.allow".match?(exp)
 => false
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
