### PR TITLE
Fix Base API breakage in Chef/Style/CommentSentenceSpacing

### DIFF
--- a/lib/rubocop/cop/chef/style/comment_sentence_spacing.rb
+++ b/lib/rubocop/cop/chef/style/comment_sentence_spacing.rb
@@ -30,7 +30,7 @@ module RuboCop
 
             processed_source.comments.each do |comment|
               next unless comment.text.match?(/(.|\?)\s{2}/) # https://rubular.com/r/8o3SiDrQMJSzuU
-              add_offense(comment, location: comment, severity: :refactor) do |corrector|
+              add_offense(comment, severity: :refactor) do |corrector|
                 corrector.replace(comment, comment.text.gsub('.  ', '. ').gsub('?  ', '? '))
               end
             end


### PR DESCRIPTION
## Description
See
https://github.com/rubocop/rubocop/commit/f8813e76cef5c06cfe1f3a73b032f4f06de7de6c

`location` no longer needed, in the "new" Base API (which came about in RuboCop 0.87). CommentSentenceSpacing is disabled by default, which is how it got missed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
