### PR TITLE
CHEF-5468 Correct heading level in output docs yaml files

### DIFF
--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_blockguardwithonlystring.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_blockguardwithonlystring.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   template '/etc/foo' do
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   template '/etc/foo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_chefapplicationfatal.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_chefapplicationfatal.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   Chef::Application.fatal!('Something horrible happened!')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   raise "Something horrible happened!"

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_conditionalrubyshellout.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_conditionalrubyshellout.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   cookbook_file '/logs/foo/error.log' do
@@ -23,7 +23,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   cookbook_file '/logs/foo/error.log' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_cookbookusesnodesave.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_cookbookusesnodesave.yml
@@ -10,7 +10,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.save

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_dnfpackageallowdowngrades.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_dnfpackageallowdowngrades.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   dnf_package 'nginx' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   dnf_package 'nginx' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_incorrectlibraryinjection.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_incorrectlibraryinjection.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   ::Chef::Recipe.send(:include, Filebeat::Helpers)
@@ -17,7 +17,7 @@ examples: |2-
   ::Chef::Provider.include Filebeat::Helpers
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   ::Chef::DSL::Recipe.send(:include, Filebeat::Helpers) # covers previous Recipe & Provider classes

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidcookbookname.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidcookbookname.yml
@@ -7,13 +7,13 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   name 'foo.bar'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   name 'foo_bar'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invaliddefaultaction.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invaliddefaultaction.yml
@@ -7,13 +7,13 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   default_action 'create'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   default_action :create

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidnotificationresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidnotificationresource.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
 
@@ -21,7 +21,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidnotificationtiming.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidnotificationtiming.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
 
@@ -17,7 +17,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformfamilyhelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformfamilyhelper.yml
@@ -9,13 +9,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   platform_family?('redhat')
   platform_family?('sles')
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   platform_family?('rhel')

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformfamilyincase.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformfamilyincase.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   case node['platform_family']

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformhelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformhelper.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   platform?('darwin')
@@ -17,7 +17,7 @@ examples: |2-
   platform?('sles')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   platform?('mac_os_x')

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformincase.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformincase.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   case node['platform']

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformmetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformmetadata.yml
@@ -9,14 +9,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   supports 'darwin'
   supports 'mswin'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   supports 'mac_os_x'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformvalueforplatformfamilyhelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformvalueforplatformfamilyhelper.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   value_for_platform_family(
@@ -18,7 +18,7 @@ examples: |2-
   )
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   value_for_platform_family(

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformvalueforplatformhelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformvalueforplatformhelper.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   value_for_platform(
@@ -17,7 +17,7 @@ examples: |2-
     %w(sles) => { 'default' => 'bar' }
   )```
 
-  #### correct
+  ### correct
 
   ```ruby
   value_for_platform(

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidversionmetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidversionmetadata.yml
@@ -7,13 +7,13 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   version '1.2.3.4'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   version '1.2.3'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_lazyevalnodeattributedefaults.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_lazyevalnodeattributedefaults.yml
@@ -9,13 +9,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :Something, String, default: node['hostname']
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :Something, String, default: lazy { node['hostname'] }

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_lazyinresourceguard.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_lazyinresourceguard.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   template '/etc/foo' do
@@ -18,7 +18,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   template '/etc/foo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_macosuserdefaultsinvalidtype.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_macosuserdefaultsinvalidtype.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   macos_userdefaults 'set a value' do
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   macos_userdefaults 'set a value' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_malformedplatformvalueforplatformhelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_malformedplatformvalueforplatformhelper.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   value_for_platform(
@@ -17,7 +17,7 @@ examples: |2-
   )
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   value_for_platform(

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_metadatamalformeddepends.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_metadatamalformeddepends.yml
@@ -8,14 +8,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'some_awesome_cookbook' '= 4.5.5'
   depends 'some_other_cool_cookbook' '< 8.0'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   depends 'some_awesome_cookbook', '= 4.5.5'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_metadatamissingname.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_metadatamissingname.yml
@@ -9,7 +9,7 @@ target_chef_version: All Versions
 examples: |-
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   name 'foo'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_metadatamissingversion.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_metadatamissingversion.yml
@@ -8,7 +8,7 @@ target_chef_version: All Versions
 examples: |-
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   name 'foo'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_nodenormal.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_nodenormal.yml
@@ -10,13 +10,13 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.normal['foo'] = true
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node.default['foo'] = true

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_nodenormalunless.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_nodenormalunless.yml
@@ -10,13 +10,13 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.normal_unless['foo'] = true
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node.default_unless['foo'] = true

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_notifiesactionnotsymbol.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_notifiesactionnotsymbol.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   execute 'some command' do
@@ -21,7 +21,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   execute 'some command' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_octalmodeasstring.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_octalmodeasstring.yml
@@ -7,7 +7,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   file '/etc/some_file' do
@@ -15,7 +15,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   file '/etc/some_file' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_opensslpasswordhelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_opensslpasswordhelpers.yml
@@ -5,12 +5,12 @@ department: Chef/Correctness
 description: |-
   The OpenSSL cookbook provides a deprecated `secure_password` helper in the `Opscode::OpenSSL::Password` class, which should no longer be used. This helper would generate a random password that would be used when a data bag or attribute was no present. The practice of generating passwords to be stored on the node is bad security as it exposes the password to anyone that can view the nodes, and deleting a node deletes the password. Passwords should be retrieved from a secure source for use in cookbooks.
 
-    #### incorrect
+    ### incorrect
     ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
     basic_auth_password = secure_password
 autocorrection: false
 target_chef_version: All Versions
-examples: 
+examples:
 version_added: 6.6.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_powershellfileexists.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_powershellfileexists.yml
@@ -8,13 +8,13 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   powershell_out('Test-Path "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"').stdout.strip == 'True'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   ::File.exist?('C:\Program Files\LAPS\CSE\AdmPwd.dll')

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_powershellscriptdeletefile.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_powershellscriptdeletefile.yml
@@ -5,7 +5,7 @@ department: Chef/Correctness
 description: |-
   Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of using Remove-Item in a powershell_script resource
 
-   #### correct
+   ### correct
    file 'C:\Windows\foo\bar.txt' do
      action :delete
    end
@@ -13,7 +13,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   powershell_script 'Cleanup old files' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_propertywithouttype.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_propertywithouttype.yml
@@ -8,14 +8,14 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :size, regex: /^\d+[KMGTP]$/
   attribute :size, regex: /^\d+[KMGTP]$/
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :size, String, regex: /^\d+[KMGTP]$/

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_resourcesetsinternalproperties.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_resourcesetsinternalproperties.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   service 'foo' do
@@ -18,7 +18,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   service 'foo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_resourcesetsnameproperty.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_resourcesetsnameproperty.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   service 'foo' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   service 'foo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_resourcewithnoneaction.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_resourcewithnoneaction.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   service 'foo' do
@@ -15,7 +15,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   service 'foo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_scopedfileexist.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_scopedfileexist.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   not_if { File.exist?('/etc/foo/bar') }
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   not_if { ::File.exist?('/etc/foo/bar') }

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_serviceresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_serviceresource.yml
@@ -7,7 +7,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   command "/etc/init.d/mysql start"

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_supportsmustbefloat.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_supportsmustbefloat.yml
@@ -7,13 +7,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   supports 'redhat', '> 8'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   supports 'redhat', '> 8.0'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_tmppath.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_tmppath.yml
@@ -7,13 +7,13 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   remote_file '/tmp/large-file.tar.gz' do
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   remote_file "#{Chef::Config[:file_cache_path]}/large-file.tar.gz" do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefdkgenerators.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefdkgenerators.yml
@@ -10,7 +10,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   ChefDK::CLI
@@ -20,7 +20,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   ChefCLI::CLI

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cheffile.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cheffile.yml
@@ -8,7 +8,7 @@ description: The Librarian-Chef depsolving project is no longer maintained and a
   offers a more similar, and still supported, experience to Librarian-Chef.
 autocorrection: false
 target_chef_version: All Versions
-examples: 
+examples:
 version_added: 5.12.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefhandlerrecipe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefhandlerrecipe.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include_recipe 'chef_handler'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefhandlerusessupports.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefhandlerusessupports.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   chef_handler 'whatever' do
@@ -17,7 +17,7 @@ examples: |2-
   end0
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   chef_handler 'whatever' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefshellout.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefshellout.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include Chef::ShellOut
@@ -17,7 +17,7 @@ examples: |2-
   Chef::ShellOut.new('some_command')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   include Mixlib::ShellOut

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefspeccoveragereport.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefspeccoveragereport.yml
@@ -10,7 +10,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefspeclegacyrunner.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefspeclegacyrunner.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
 
@@ -20,7 +20,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefsugarhelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefsugarhelpers.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   vagrant_key?

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefwindowsplatformhelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefwindowsplatformhelper.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   Chef::Platform.windows?
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   platform?('windows')

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chocolateypackageuninstallaction.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chocolateypackageuninstallaction.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   chocolatey_package 'nginx' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   chocolatey_package 'nginx' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cookbookdependsoncompatresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cookbookdependsoncompatresource.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 12.19+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'compat_resource'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cookbookdependsonpartialsearch.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cookbookdependsonpartialsearch.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: 13.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'partial_search'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cookbookdependsonpoise.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cookbookdependsonpoise.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'poise'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cookbooksdependsonself.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cookbooksdependsonself.yml
@@ -8,14 +8,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   name 'foo'
   depends 'foo'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   name 'foo'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_delivery.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_delivery.yml
@@ -9,7 +9,7 @@ description: |-
   or Delivery cookbooks. The contents of this directory are now obsolete and should be removed.
 autocorrection: false
 target_chef_version: All Versions
-examples: 
+examples:
 version_added: 7.31.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_dependsonchefnginxcookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_dependsonchefnginxcookbook.yml
@@ -9,13 +9,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'chef_nginx'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   depends 'nginx'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_dependsonchefreportingcookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_dependsonchefreportingcookbook.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'chef-reporting'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_dependsonomnibusupdatercookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_dependsonomnibusupdatercookbook.yml
@@ -9,13 +9,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'omnibus_updater'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   depends 'chef_client_updater'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedplatformmethods.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedplatformmethods.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   resource = Chef::Resource::File.new("/tmp/foo.xyz", run_context)
@@ -23,7 +23,7 @@ examples: |2-
   Chef::Platform.set :platform => :mac_os_x, :resource => :package, :provider => Chef::Provider::Package::Homebrew
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   resource = Chef::Resource::File.new("/tmp/foo.xyz", run_context)

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedshelloutmethods.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedshelloutmethods.yml
@@ -10,7 +10,7 @@ autocorrection: false
 target_chef_version: 14.3+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   shell_out_compact('foo')
@@ -23,7 +23,7 @@ examples: |2-
   shell_out_compact_timeout!('foo')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   shell_out('foo')

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedsudoactions.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedsudoactions.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: 14.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   sudo 'admins' do
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   sudo 'admins' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedwindowsversioncheck.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedwindowsversioncheck.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   if older_than_win_2012_or_8?

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedyumrepositoryactions.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedyumrepositoryactions.yml
@@ -10,7 +10,7 @@ autocorrection: true
 target_chef_version: 12.14+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   yum_repository 'OurCo' do
@@ -21,7 +21,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   yum_repository 'OurCo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedyumrepositoryproperties.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedyumrepositoryproperties.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: 12.14+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   yum_repository 'OurCo' do
@@ -21,7 +21,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   yum_repository 'OurCo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_easyinstallresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_easyinstallresource.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   easy_install "my_thing" do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_eolauditmodeusage.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_eolauditmodeusage.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   control_group 'Baseline' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_epicfail.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_epicfail.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   package "foo" do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   package "foo" do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_erlcallresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_erlcallresource.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   erl_call "foo" do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_executepathproperty.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_executepathproperty.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   execute 'some_cmd' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   execute 'some_cmd' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_executerelativecreateswithoutcwd.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_executerelativecreateswithoutcwd.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   execute 'some_cmd' do
@@ -17,7 +17,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   execute 'some_cmd' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_foodcriticfile.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_foodcriticfile.yml
@@ -7,7 +7,7 @@ description: The Foodcritic cookbook linter has been deprecated and should no lo
   by Foodcritic in your cookbooks.
 autocorrection: false
 target_chef_version: All Versions
-examples: 
+examples:
 version_added: 7.32.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_foodcritictesting.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_foodcritictesting.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   gem 'foodcritic'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_hwrpwithoutprovides.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_hwrpwithoutprovides.yml
@@ -5,7 +5,7 @@ department: Chef/Deprecations
 description: |-
   Chef Infra Client 16 and later a legacy HWRP resource must use `provides` to define how the resource is called in recipes or other resources. To maintain compatibility with Chef Infra Client < 16 use both `resource_name` and `provides`.
 
-   #### correct when Chef Infra Client < 15 (but compatible with 16+ as well)
+   ### correct when Chef Infra Client < 15 (but compatible with 16+ as well)
     class Chef
       class Resource
         class UlimitRule < Chef::Resource
@@ -20,7 +20,7 @@ description: |-
       end
     end
 
-   #### correct when Chef Infra Client 16+
+   ### correct when Chef Infra Client 16+
     class Chef
       class Resource
         class UlimitRule < Chef::Resource
@@ -40,7 +40,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   class Chef
@@ -54,7 +54,7 @@ examples: |2-
     end
   end
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   class Chef

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_hwrpwithoutunifiedtrue.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_hwrpwithoutunifiedtrue.yml
@@ -13,7 +13,7 @@ autocorrection: false
 target_chef_version: 15.3+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
    class Chef
@@ -30,7 +30,7 @@ examples: |2-
    end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
    class Chef

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_includingxmlrubyrecipe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_includingxmlrubyrecipe.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include_recipe 'xml::ruby'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_includingyumdnfcompatrecipe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_includingyumdnfcompatrecipe.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include_recipe 'yum::dnf_yum_compat'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_launchddeprecatedhashproperty.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_launchddeprecatedhashproperty.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 12.19+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   launchd 'foo' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   launchd 'foo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_legacynotifysyntax.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_legacynotifysyntax.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   template '/etc/www/configures-apache.conf' do
@@ -28,7 +28,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   template '/etc/www/configures-apache.conf' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_legacyyumcookbookrecipes.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_legacyyumcookbookrecipes.yml
@@ -10,7 +10,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include_recipe 'yum::elrepo'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_librarianchefspec.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_librarianchefspec.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   require 'chefspec/librarian'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_localedeprecatedlcallproperty.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_localedeprecatedlcallproperty.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   locale 'set locale' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_logresourcenotifications.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_logresourcenotifications.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: 15.8+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   template '/etc/foo' do
@@ -22,7 +22,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   template '/etc/foo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_macosuserdefaultsglobalproperty.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_macosuserdefaultsglobalproperty.yml
@@ -10,7 +10,7 @@ autocorrection: true
 target_chef_version: 16.3+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   macos_userdefaults 'set a value' do
@@ -20,7 +20,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   macos_userdefaults 'set a value' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_namepropertywithdefaultvalue.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_namepropertywithdefaultvalue.yml
@@ -13,14 +13,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :config_file, String, default: 'foo', name_property: true
   attribute :config_file, String, default: 'foo', name_attribute: true
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :config_file, String, name_property: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_nodedeepfetch.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_nodedeepfetch.yml
@@ -8,24 +8,24 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.deep_fetch("foo")
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node.read("foo")
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.deep_fetch!("foo")
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node.read!("foo")

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_nodemethodsinsteadofattributes.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_nodemethodsinsteadofattributes.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.fqdn
@@ -18,7 +18,7 @@ examples: |2-
   node.hostname
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node['fqdn']

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_nodeset.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_nodeset.yml
@@ -10,13 +10,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.set['foo'] = true
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node.normal['foo'] = true

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_nodesetunless.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_nodesetunless.yml
@@ -10,13 +10,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.set_unless['foo'] = true
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node.normal_unless['foo'] = true

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_nodesetwithoutlevel.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_nodesetwithoutlevel.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node['foo']['bar'] = 1
@@ -17,7 +17,7 @@ examples: |2-
   node['foo']['bar'] -= 1
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node.default['foo']['bar'] = 1

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_partialsearchclassusage.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_partialsearchclassusage.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   ::Chef::PartialSearch.new.search((:node, 'role:web',
@@ -23,7 +23,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   search(:node, 'role:web',

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_partialsearchhelperusage.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_partialsearchhelperusage.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   partial_search(:node, 'role:web',
@@ -23,7 +23,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   search(:node, 'role:web',

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_poisearchiveusage.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_poisearchiveusage.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: 15.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   poise_archive 'https://example.com/myapp.tgz' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   archive_file 'https://example.com/myapp.tgz' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_policyfilecommunitysource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_policyfilecommunitysource.yml
@@ -7,13 +7,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   default_source :community
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   default_source :supermarket

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_powershellcookbookhelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_powershellcookbookhelpers.yml
@@ -9,13 +9,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   Powershell::VersionHelper.powershell_version?('4.0')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node['powershell']['version'].to_f == 4.0

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_requirerecipe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_requirerecipe.yml
@@ -7,13 +7,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   require_recipe 'foo'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   include_recipe 'foo'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceinheritsfromcompatresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceinheritsfromcompatresource.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   class AptUpdate < ChefCompat::Resource
@@ -17,7 +17,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   class AptUpdate < Chef::Resource

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceoverridesprovidesmethod.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceoverridesprovidesmethod.yml
@@ -10,7 +10,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   def provides?
@@ -18,7 +18,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   provides :SOME_PROVIDER_NAME

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesdslnamemethod.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesdslnamemethod.yml
@@ -9,13 +9,13 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   my_resource = MyResource.dsl_name
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   my_resource = MyResource.resource_name

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesonlyresourcename.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesonlyresourcename.yml
@@ -11,7 +11,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   mycookbook/resources/myresource.rb:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesproviderbasemethod.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesproviderbasemethod.yml
@@ -10,7 +10,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   provider_base ::Chef::Provider::SomethingSomething

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesupdatedmethod.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesupdatedmethod.yml
@@ -11,7 +11,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   action :foo do
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   action :foo do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourcewithoutunifiedtrue.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourcewithoutunifiedtrue.yml
@@ -13,7 +13,7 @@ autocorrection: true
 target_chef_version: 15.3+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
    resource_name :foo
@@ -24,7 +24,7 @@ examples: |2-
    end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
    resource_name :foo

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_ruby27keywordargumentwarnings.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_ruby27keywordargumentwarnings.yml
@@ -8,14 +8,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   shell_out!('hostnamectl status', { returns: [0, 1] })
   shell_out('hostnamectl status', { returns: [0, 1] })
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   shell_out!('hostnamectl status', returns: [0, 1])

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_rubyblockcreateaction.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_rubyblockcreateaction.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   ruby_block 'my special ruby block' do
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   ruby_block 'my special ruby block' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_searchusespositionalparameters.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_searchusespositionalparameters.yml
@@ -11,7 +11,7 @@ description: |-
    search(:node, '*:*', start: 0)
 autocorrection: true
 target_chef_version: All Versions
-examples: 
+examples:
 version_added: 5.11.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useautomaticresourcename.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useautomaticresourcename.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   module MyCookbook

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useinlineresourcesdefined.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useinlineresourcesdefined.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   use_inline_resources

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_userdeprecatedsupportsproperty.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_userdeprecatedsupportsproperty.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   user "betty" do
@@ -23,7 +23,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   user "betty" do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useschefresthelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useschefresthelpers.yml
@@ -7,7 +7,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   require 'chef/rest'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_usesdeprecatedmixins.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_usesdeprecatedmixins.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include Chef::Mixin::LanguageIncludeAttribute

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_usesruncommandhelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_usesruncommandhelper.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   require 'chef/mixin/command'
@@ -19,7 +19,7 @@ examples: |2-
   run_command_with_systems_locale('/bin/foo')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   shell_out!('/bin/foo')

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useyamldump.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useyamldump.yml
@@ -10,13 +10,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   {"foo" => "bar"}.to_yaml
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   YAML.dump({"foo" => "bar"})

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_verifypropertyusesfileexpansion.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_verifypropertyusesfileexpansion.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 12.5+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   file '/etc/nginx.conf' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   file '/etc/nginx.conf' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_windowsfeatureservermanagercmd.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_windowsfeatureservermanagercmd.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   windows_feature 'DHCP' do
@@ -17,7 +17,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   windows_feature 'DHCP' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_windowspackageinstallertypestring.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_windowspackageinstallertypestring.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   windows_package 'AppveyorDeploymentAgent' do
@@ -18,7 +18,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   windows_package 'AppveyorDeploymentAgent' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_windowstaskchangeaction.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_windowstaskchangeaction.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: 13.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   windows_task 'chef ad-join leave start time' do
@@ -20,7 +20,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   windows_task 'chef ad-join leave start time' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_windowsversionhelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_windowsversionhelpers.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 14.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   Windows::VersionHelper.nt_version
@@ -17,7 +17,7 @@ examples: |2-
   Windows::VersionHelper.workstation_version?
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node['platform_version'].to_f

--- a/docs-chef-io/assets/cookstyle/cops_chef_effortless_berksfile.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_effortless_berksfile.yml
@@ -6,7 +6,7 @@ description: Policyfiles should be used for cookbook dependency solving instead 
   a Berkshelf Berksfile.
 autocorrection: false
 target_chef_version: All Versions
-examples: 
+examples:
 version_added: 5.12.0
 enabled: false
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_effortless_chefvaultused.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_effortless_chefvaultused.yml
@@ -9,32 +9,32 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   require 'chef-vault'
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   ChefVault::Item
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include_recipe 'chef-vault'
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   chef_gem 'chef-vault'
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   chef_vault_item_for_environment(arg, arg1)
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   chef_vault_item(arg, arg1)

--- a/docs-chef-io/assets/cookstyle/cops_chef_effortless_cookbookusesdatabags.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_effortless_cookbookusesdatabags.yml
@@ -7,7 +7,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   data_bag_item('admins', login)

--- a/docs-chef-io/assets/cookstyle/cops_chef_effortless_cookbookusesenvironments.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_effortless_cookbookusesenvironments.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.environment == "production"

--- a/docs-chef-io/assets/cookstyle/cops_chef_effortless_cookbookusespolicygroups.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_effortless_cookbookusespolicygroups.yml
@@ -7,7 +7,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.policy_group == "foo"

--- a/docs-chef-io/assets/cookstyle/cops_chef_effortless_cookbookusesroles.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_effortless_cookbookusesroles.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node.role?('web_server')

--- a/docs-chef-io/assets/cookstyle/cops_chef_effortless_cookbookusessearch.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_effortless_cookbookusessearch.yml
@@ -7,7 +7,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   search(:node, 'run_list:recipe\[bacula\:\:server\]')

--- a/docs-chef-io/assets/cookstyle/cops_chef_effortless_dependschefvault.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_effortless_dependschefvault.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'chef-vault'

--- a/docs-chef-io/assets/cookstyle/cops_chef_effortless_searchforenvironmentsorroles.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_effortless_searchforenvironmentsorroles.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   search(:node, 'chef_environment:foo')

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_actionmethodinresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_actionmethodinresource.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   def action_create
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   action :create do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_allowedactionsfrominitialize.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_allowedactionsfrominitialize.yml
@@ -10,7 +10,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   def initialize(*args)
@@ -25,7 +25,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   allowed_actions [ :create, :add ]

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_chefgemnokogiri.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_chefgemnokogiri.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   chef_gem 'nokogiri'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_classevalactionclass.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_classevalactionclass.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 12.9+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   action_class.class_eval do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   action_class do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_conditionalusingtest.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_conditionalusingtest.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   only_if 'test -f /bin/foo'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   only_if { ::File.exist?('bin/foo') }

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_crondfileortemplate.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_crondfileortemplate.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: 14.4+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   template '/etc/cron.d/backup' do
@@ -59,7 +59,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   cron_d 'backup' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_cronmanageresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_cronmanageresource.yml
@@ -9,13 +9,13 @@ autocorrection: true
 target_chef_version: 14.4+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   cron_manage 'mike'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   cron_access 'mike'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_customresourcewithattributes.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_customresourcewithattributes.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   attribute :something, String
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :something, String

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_databaghelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_databaghelpers.yml
@@ -8,14 +8,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   plain_text_data = Chef::DataBagItem.load('foo', 'bar')
   encrypted_data = Chef::EncryptedDataBagItem.load('foo2', 'bar2')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   plain_text_data = data_bag_item('foo', 'bar')

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_declareactionclass.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_declareactionclass.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 12.9+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   declare_action_class do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   action_class do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_defaultactionfrominitialize.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_defaultactionfrominitialize.yml
@@ -5,13 +5,13 @@ department: Chef/Modernize
 description: |-
   The default actions can now be specified using the `default_action` helper instead of using the @action variable in the resource provider initialize method. In general we recommend against writing HWRPs, but if HWRPs are necessary you should utilize as much of the resource DSL as possible.
 
-   #### correct
+   ### correct
    default_action :create
 autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   def initialize(*args)
@@ -19,7 +19,7 @@ examples: |2-
     @action = :create
   end
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   def initialize(*args)

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_defineschefspecmatchers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_defineschefspecmatchers.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   if defined?(ChefSpec)

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_definitions.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_definitions.yml
@@ -9,7 +9,7 @@ description: In 2016 with Chef Infra Client 12.5 Custom Resources were introduce
   resource reporting.
 autocorrection: false
 target_chef_version: All Versions
-examples: 
+examples:
 version_added: 5.11.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonchefvaultcookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonchefvaultcookbook.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 16.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'chef-vault'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonchocolateycookbooks.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonchocolateycookbooks.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: 14.3+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'chocolatey_source'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonkernelmodulecookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonkernelmodulecookbook.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 14.3+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'kernel_module'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonlocalecookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonlocalecookbook.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 14.5+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'locale'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonopensslcookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonopensslcookbook.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: 14.4+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'openssl'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsontimezonelwrpcookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsontimezonelwrpcookbook.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 14.6+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'timezone_lwrp'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonwindowsfirewallcookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonwindowsfirewallcookbook.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: 14.7+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'windows_firewall'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonzyppercookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonzyppercookbook.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 13.3+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'zypper'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dslincludeinresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dslincludeinresource.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include Chef::DSL::Recipe

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_emptyresourceinitializemethod.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_emptyresourceinitializemethod.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   def initialize(*args)

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_executeaptupdate.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_executeaptupdate.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   execute 'apt-get update'
@@ -23,7 +23,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   apt_update

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_executescexe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_executescexe.yml
@@ -10,7 +10,7 @@ autocorrection: false
 target_chef_version: 14.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   execute "Delete chef-client service" do
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   windows_service 'chef-client' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_executesleep.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_executesleep.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: 15.5+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   execute "sleep 60" do
@@ -24,7 +24,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   chef_sleep '60'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_executesysctl.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_executesysctl.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: 14.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   file '/etc/sysctl.d/ipv4.conf' do
@@ -22,7 +22,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   sysctl 'net.ipv4.ip_local_port_range' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_executetzutil.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_executetzutil.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: 14.6+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   execute 'set tz' do
@@ -24,7 +24,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   timezone 'UTC'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_foodcriticcomments.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_foodcriticcomments.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   # ~FC013

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_ifprovidesdefaultaction.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_ifprovidesdefaultaction.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   default_action :foo if defined?(default_action)
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   default_action :foo

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingaptdefaultrecipe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingaptdefaultrecipe.yml
@@ -11,14 +11,14 @@ autocorrection: false
 target_chef_version: 12.7+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include_recipe 'apt::default'
   include_recipe 'apt'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   apt_update

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingmixinshelloutinresources.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingmixinshelloutinresources.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   require 'chef/mixin/shell_out'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingohaidefaultrecipe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingohaidefaultrecipe.yml
@@ -10,7 +10,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include_recipe 'ohai::default'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingwindowsdefaultrecipe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingwindowsdefaultrecipe.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include_recipe 'windows::default'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_legacyberksfilesource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_legacyberksfilesource.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   source 'http://community.opscode.com/api/v3'
@@ -18,7 +18,7 @@ examples: |2-
   site :opscode
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   source 'https://supermarket.chef.io'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_libarchivefileresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_libarchivefileresource.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 15.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'libarchive'
@@ -18,7 +18,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   archive_file "C:\file.zip" do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_macosxuserdefaults.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_macosxuserdefaults.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 14.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   mac_os_x_userdefaults 'full keyboard access to all controls' do
@@ -18,7 +18,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   macos_userdefaults 'full keyboard access to all controls' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_minitesthandlerusage.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_minitesthandlerusage.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'minitest-handler'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_nodeinitpackage.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_nodeinitpackage.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   ::File.open('/proc/1/comm').gets.chomp == 'systemd'
@@ -23,7 +23,7 @@ examples: |2-
   only_if 'test -f /bin/systemctl && /bin/systemctl'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node['init_package'] == 'systemd'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_noderolesinclude.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_noderolesinclude.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node['roles'].include?('foo')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node.role?('foo')

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_opensslrsakeyresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_opensslrsakeyresource.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 14.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   openssl_rsa_key '/etc/httpd/ssl/server.key' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   openssl_rsa_private_key '/etc/httpd/ssl/server.key' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_opensslx509resource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_opensslx509resource.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 14.4+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   openssl_x509 '/etc/httpd/ssl/mycert.pem' do
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   openssl_x509_certificate '/etc/httpd/ssl/mycert.pem' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_osxconfigprofileresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_osxconfigprofileresource.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   osx_config_profile 'Install screensaver profile' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   osx_profile 'Install screensaver profile' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellguardinterpreter.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellguardinterpreter.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: 13.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   powershell_script 'Create Directory' do
@@ -23,7 +23,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   powershell_script 'Create Directory' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellinstallpackage.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellinstallpackage.yml
@@ -5,13 +5,13 @@ department: Chef/Modernize
 description: |-
   Use the powershell_package resource built into Chef Infra Client instead of the powershell_script resource to run Install-Package
 
-   #### correct
+   ### correct
    powershell_package 'docker'
 autocorrection: false
 target_chef_version: 12.16+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   powershell_script 'Expand website' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellinstallwindowsfeature.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellinstallwindowsfeature.yml
@@ -5,7 +5,7 @@ department: Chef/Modernize
 description: |-
   Use the windows_feature resource built into Chef Infra Client 14+ instead of the powershell_script resource to run Install-WindowsFeature or Add-WindowsFeature
 
-   #### correct
+   ### correct
    windows_feature 'Net-framework-Core' do
      action :install
      install_method :windows_feature_powershell
@@ -14,7 +14,7 @@ autocorrection: false
 target_chef_version: 14.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   powershell_script 'Install Feature' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellscriptexpandarchive.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellscriptexpandarchive.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: 15.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   powershell_script 'Expand website' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_propertywithnameattribute.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_propertywithnameattribute.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :bob, String, name_attribute: true
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :bob, String, name_property: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_providesfrominitialize.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_providesfrominitialize.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   def initialize(*args)
@@ -17,7 +17,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   provides :foo

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_resourceforcingcompiletime.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_resourceforcingcompiletime.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   build_essential 'install build tools' do
@@ -17,7 +17,7 @@ examples: |2-
   end.run_action(:install)
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   build_essential 'install build tools' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_resourcenamefrominitialize.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_resourcenamefrominitialize.yml
@@ -5,13 +5,13 @@ department: Chef/Modernize
 description: |-
   The resource name can now be specified using the `resource_name` helper instead of using the @resource_name variable in the resource provider initialize method. In general we recommend against writing HWRPs, but if HWRPs are necessary you should utilize as much of the resource DSL as possible.
 
-   #### correct
+   ### correct
    resource_name :create
 autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   def initialize(*args)

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_respondtocompiletime.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_respondtocompiletime.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 12.1+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   chef_gem 'ultradns-sdk' do
@@ -27,7 +27,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   chef_gem 'ultradns-sdk' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_respondtoinmetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_respondtoinmetadata.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: 12.15+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   chef_version '>= 13' if respond_to?(:chef_version)
@@ -20,7 +20,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   chef_version '>= 13'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_respondtoprovides.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_respondtoprovides.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   provides :foo if respond_to?(:provides)
@@ -17,7 +17,7 @@ examples: |2-
   provides :foo if defined? provides
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   provides :foo

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_respondtoresourcename.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_respondtoresourcename.yml
@@ -9,13 +9,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   resource_name :foo if respond_to?(:resource_name)
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   resource_name :foo

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_setorreturninresources.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_setorreturninresources.yml
@@ -10,7 +10,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
    def severity(arg = nil)
@@ -22,7 +22,7 @@ examples: |2-
    end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :severity, String

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_sevenziparchiveresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_sevenziparchiveresource.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: 15.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   seven_zip_archive "C:\file.zip" do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_shellouthelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_shellouthelper.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: 12.11+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   Mixlib::ShellOut.new('foo').run_command
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   shell_out('foo')

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_shellouttochocolatey.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_shellouttochocolatey.yml
@@ -13,7 +13,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   execute 'install package foo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_simplifyaptppasetup.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_simplifyaptppasetup.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
     apt_repository 'atom-ppa' do
@@ -20,7 +20,7 @@ examples: |2-
     end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
     apt_repository 'atom-ppa' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_sysctlparamresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_sysctlparamresource.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 14.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   sysctl_param 'fs.aio-max-nr' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   sysctl 'fs.aio-max-nr' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_unnecessarydependschef14.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_unnecessarydependschef14.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: 14.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'build-essential'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_unnecessarydependschef15.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_unnecessarydependschef15.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: 15.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'libarchive'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_unnecessarymixlibshelloutrequire.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_unnecessarymixlibshelloutrequire.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   require 'mixlib/shellout'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_usebuildessentialresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_usebuildessentialresource.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   depends 'build-essential'
@@ -16,7 +16,7 @@ examples: |2-
   include_recipe 'build-essential'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   build_essential 'install compilation tools'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_usecheflanguagecloudhelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_usecheflanguagecloudhelpers.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 15.5+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node['cloud']['provider'] == 'alibaba'
@@ -23,7 +23,7 @@ examples: |2-
   node['cloud']['provider'] == 'softlayer'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   alibaba?

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_usecheflanguageenvhelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_usecheflanguageenvhelpers.yml
@@ -10,14 +10,14 @@ autocorrection: true
 target_chef_version: 15.5+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   ENV['CI']
   ENV['TEST_KITCHEN']
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   ci?

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_usecheflanguagesystemdhelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_usecheflanguagesystemdhelper.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: 15.5+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node['init_package'] == 'systemd'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   systemd?

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_usemultipackageinstalls.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_usemultipackageinstalls.yml
@@ -10,7 +10,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   %w(bmon htop vim curl).each do |pkg|
@@ -20,7 +20,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   package %w(bmon htop vim curl)

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_userequirerelative.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_userequirerelative.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   require File.expand_path('../../libraries/helpers', __FILE__)
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   require_relative '../libraries/helpers'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_useszypperrepo.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_useszypperrepo.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 13.3+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   zypper_repo 'apache' do
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   zypper_repository 'apache' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_whyrunsupportedtrue.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_whyrunsupportedtrue.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: 13.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   def whyrun_supported?

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowsregistryuac.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowsregistryuac.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: 15.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   registry_key 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' do
@@ -20,7 +20,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   windows_uac 'Set Windows UAC settings' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowsscresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowsscresource.yml
@@ -11,7 +11,7 @@ autocorrection: false
 target_chef_version: 14.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   sc_windows 'chef-client' do
@@ -20,7 +20,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   windows_service 'chef-client' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowszipfileusage.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowszipfileusage.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: 15.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   windows_zipfile 'C:\\files\\' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_zipfileresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_zipfileresource.yml
@@ -8,7 +8,7 @@ autocorrection: false
 target_chef_version: 15.0+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   zipfile "C:\file.zip" do

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_aptrepositorydistributiondefault.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_aptrepositorydistributiondefault.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   apt_repository 'my repo' do
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   apt_repository 'my repo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_aptrepositorynotifiesaptupdate.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_aptrepositorynotifiesaptupdate.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   apt_repository 'my repo' do
@@ -19,7 +19,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   apt_repository 'my repo' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_attributemetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_attributemetadata.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby in metadata.rb:
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_conflictsmetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_conflictsmetadata.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby in metadata.rb:
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_customresourcewithallowedactions.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_customresourcewithallowedactions.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   allowed_actions [:create, :remove]

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_doublecompiletime.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_doublecompiletime.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   chef_gem 'deep_merge' do
@@ -17,7 +17,7 @@ examples: |2-
   end.run_action(:install)
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   chef_gem 'deep_merge' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_groupingmetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_groupingmetadata.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   grouping 'windows_log_rotate', title: 'Demonstration cookbook with code to switch loggers'

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_longdescriptionmetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_longdescriptionmetadata.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   long_description 'this is my cookbook and this description will never be seen'

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_multipleplatformchecks.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_multipleplatformchecks.yml
@@ -8,14 +8,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   platform?('redhat') || platform?('ubuntu')
   platform_family?('debian') || platform_family?('rhel')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   platform?('redhat', 'ubuntu')

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_namepropertyisrequired.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_namepropertyisrequired.yml
@@ -35,14 +35,14 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :config_file, String, required: true, name_property: true
   attribute :config_file, String, required: true, name_attribute: true
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :config_file, String, required: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_ohaiattributetostring.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_ohaiattributetostring.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node['platform'].to_s
@@ -20,7 +20,7 @@ examples: |2-
   node['name'].to_s
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node['platform']

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_propertysplatregex.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_propertysplatregex.yml
@@ -8,14 +8,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :config_file, String, regex: /.*/
   attribute :config_file, String, regex: /.*/
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :config_file, String

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_propertywithrequiredanddefault.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_propertywithrequiredanddefault.yml
@@ -11,13 +11,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :bob, String, required: true, default: 'foo'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :bob, String, required: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_providesmetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_providesmetadata.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby in metadata.rb:
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_recipemetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_recipemetadata.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   recipe 'openldap::default', 'Install and configure OpenLDAP'

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_replacesmetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_replacesmetadata.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby in metadata.rb:
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_resourcewithnothingaction.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_resourcewithnothingaction.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   action :nothing

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_sensitivepropertyinresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_sensitivepropertyinresource.yml
@@ -5,11 +5,11 @@ department: Chef/RedundantCode
 description: |-
   Every Chef Infra resource already includes a sensitive property with a default value of false.
 
-  #### incorrect
+  ### incorrect
   property :sensitive, [true, false], default: false
 autocorrection: true
 target_chef_version: All Versions
-examples: 
+examples:
 version_added: 5.16.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_stringpropertywithnildefault.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_stringpropertywithnildefault.yml
@@ -8,14 +8,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :config_file, String, default: nil
   property :config_file, [String, NilClass], default: nil
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :config_file, String

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_suggestsmetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_suggestsmetadata.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby in metadata.rb:
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_unnecessarydesiredstate.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_unnecessarydesiredstate.yml
@@ -8,14 +8,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :foo, String, desired_state: true
   attribute :foo, String, desired_state: true
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :foo, String

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_unnecessarynameproperty.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_unnecessarynameproperty.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :name, String

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_usecreateifmissing.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_usecreateifmissing.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   cookbook_file '/logs/foo/error.log' do
@@ -29,7 +29,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   cookbook_file '/logs/foo/error.log' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_security_sshprivatekey.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_security_sshprivatekey.yml
@@ -10,7 +10,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   file '/Users/bob_bobberson/.ssh/id_rsa' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_sharing_defaultmetadatamaintainer.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_sharing_defaultmetadatamaintainer.yml
@@ -9,7 +9,7 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   maintainer 'YOUR_COMPANY_NAME'
@@ -17,7 +17,7 @@ examples: |2-
   maintainer 'The Authors'
   maintainer_email 'you@example.com'```
 
-  #### correct
+  ### correct
 
   ```ruby
   maintainer 'Bob Bobberson'

--- a/docs-chef-io/assets/cookstyle/cops_chef_sharing_emptymetadatafield.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_sharing_emptymetadatafield.yml
@@ -8,13 +8,13 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   license ''
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   license 'Apache-2.0'

--- a/docs-chef-io/assets/cookstyle/cops_chef_sharing_includepropertydescriptions.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_sharing_includepropertydescriptions.yml
@@ -8,13 +8,13 @@ autocorrection: false
 target_chef_version: 13.9+
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :foo, String
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :foo, String, description: "Set the important thing to..."

--- a/docs-chef-io/assets/cookstyle/cops_chef_sharing_includeresourcedescriptions.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_sharing_includeresourcedescriptions.yml
@@ -9,7 +9,7 @@ target_chef_version: 13.9+
 examples: |-
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   resource_name :foo

--- a/docs-chef-io/assets/cookstyle/cops_chef_sharing_includeresourceexamples.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_sharing_includeresourceexamples.yml
@@ -9,7 +9,7 @@ target_chef_version: 13.9+
 examples: |-
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   examples <<~DOC

--- a/docs-chef-io/assets/cookstyle/cops_chef_sharing_insecurecookbookurl.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_sharing_insecurecookbookurl.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   source_url 'http://github.com/something/something'
@@ -16,7 +16,7 @@ examples: |2-
   source_url 'http://gitlab.com/something/something'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   source_url 'http://github.com/something/something'

--- a/docs-chef-io/assets/cookstyle/cops_chef_sharing_invalidlicensestring.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_sharing_invalidlicensestring.yml
@@ -16,13 +16,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   license 'Apache 2.0'
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   license 'Apache-2.0'

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_attributekeys.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_attributekeys.yml
@@ -10,14 +10,14 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node['foo']
   node["foo"]
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   node[:foo]

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_chefwhaaat.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_chefwhaaat.yml
@@ -8,14 +8,14 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   Chef makes software
   Chef configures your systems
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   Chef Software makes software

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_commentformat.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_commentformat.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   Copyright 2013-2016 Chef Software, Inc.
@@ -19,7 +19,7 @@ examples: |2-
   Attributes File:: default
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   Copyright:: 2013-2016 Chef Software, Inc.

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_commentsentencespacing.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_commentsentencespacing.yml
@@ -7,6 +7,6 @@ description: |-
   Note: This is DISABLED by default.
 autocorrection: true
 target_chef_version: All Versions
-examples: 
+examples:
 version_added: 5.1.0
 enabled: false

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_copyrightcommentformat.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_copyrightcommentformat.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   Copyright:: 2013-2022 Opscode, Inc.
@@ -19,7 +19,7 @@ examples: |2-
   Copyright:: Copyright (c) 2015-2022 Chef Software, Inc.
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   Copyright:: 2013-2022 Chef Software, Inc.

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_defaultcopyrightcomments.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_defaultcopyrightcomments.yml
@@ -8,14 +8,14 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   Copyright:: 2019 YOUR_NAME
   Copyright:: 2019 YOUR_COMPANY_NAME
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   Copyright:: 2019 Tim Smith

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_filemode.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_filemode.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   remote_directory '/etc/my.conf' do
@@ -25,7 +25,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   remote_directory '/etc/my.conf' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_immediatenotificationtiming.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_immediatenotificationtiming.yml
@@ -7,7 +7,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
 
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_includerecipewithparentheses.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_includerecipewithparentheses.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   include_recipe('foo::bar')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   include_recipe 'foo::bar'

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_negatingonlyif.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_negatingonlyif.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   package 'legacy-sysv-deps' do
@@ -16,7 +16,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   package 'legacy-sysv-deps' do

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_overlycomplexsupportsdependsmetadata.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_overlycomplexsupportsdependsmetadata.yml
@@ -9,7 +9,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
 
@@ -22,7 +22,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_simplifyplatformmajorversioncheck.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_simplifyplatformmajorversioncheck.yml
@@ -11,7 +11,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node['platform_version'].split('.').first
@@ -20,7 +20,7 @@ examples: |2-
   node['platform_version'].split('.')[0].to_i
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_trueclassfalseclassresourceproperties.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_trueclassfalseclassresourceproperties.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   property :foo, [TrueClass, FalseClass]
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   property :foo, [true, false]

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_unnecessaryoscheck.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_unnecessaryoscheck.yml
@@ -11,7 +11,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node['os'] == 'darwin'
@@ -20,7 +20,7 @@ examples: |2-
   %w(netbsd openbsd freebsd).include?(node['os'])
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   platform_family?('mac_os_x')

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_unnecessaryplatformcasestatement.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_unnecessaryplatformcasestatement.yml
@@ -8,7 +8,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   case node['platform']
@@ -23,7 +23,7 @@ examples: |2-
   end
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   if platform?('ubuntu')

--- a/docs-chef-io/assets/cookstyle/cops_chef_style_useplatformhelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_style_useplatformhelpers.yml
@@ -10,7 +10,7 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   node['platform'] == 'ubuntu'
@@ -21,7 +21,7 @@ examples: |2-
   node['platform'].eql?('ubuntu')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   platform?('ubuntu')

--- a/docs-chef-io/assets/cookstyle/cops_inspec_deprecations_attributedefault.yml
+++ b/docs-chef-io/assets/cookstyle/cops_inspec_deprecations_attributedefault.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   login_defs_umask = input('login_defs_umask', default: '077', description: 'Default umask to set in login.defs')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   login_defs_umask = input('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')

--- a/docs-chef-io/assets/cookstyle/cops_inspec_deprecations_attributehelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_inspec_deprecations_attributehelper.yml
@@ -8,13 +8,13 @@ autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
-  #### incorrect
+  ### incorrect
 
   ```ruby
   login_defs_umask = attribute('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
   ```
 
-  #### correct
+  ### correct
 
   ```ruby
   login_defs_umask = input('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')

--- a/lib/rubocop/cop/chef/correctness/block_guard_clause_string_only.rb
+++ b/lib/rubocop/cop/chef/correctness/block_guard_clause_string_only.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   template '/etc/foo' do
         #     mode '0644'
         #     source 'foo.erb'
         #     only_if { 'test -f /etc/foo' }
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   template '/etc/foo' do
         #     mode '0644'
         #     source 'foo.erb'

--- a/lib/rubocop/cop/chef/correctness/chef_application_fatal.rb
+++ b/lib/rubocop/cop/chef/correctness/chef_application_fatal.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   Chef::Application.fatal!('Something horrible happened!')
         #
-        #   #### correct
+        #   ### correct
         #   raise "Something horrible happened!"
         #
         class ChefApplicationFatal < Base

--- a/lib/rubocop/cop/chef/correctness/conditional_ruby_shellout.rb
+++ b/lib/rubocop/cop/chef/correctness/conditional_ruby_shellout.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   cookbook_file '/logs/foo/error.log' do
         #     source 'error.log'
         #     only_if { system('wget https://www.bar.com/foobar.txt -O /dev/null') }
@@ -34,7 +34,7 @@ module RuboCop
         #     only_if { shell_out('wget https://www.bar.com/foobar.txt -O /dev/null').exitstatus == 0 }
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   cookbook_file '/logs/foo/error.log' do
         #     source 'error.log'
         #     only_if 'wget https://www.bar.com/foobar.txt -O /dev/null'

--- a/lib/rubocop/cop/chef/correctness/dnf_package_allow_downgrades.rb
+++ b/lib/rubocop/cop/chef/correctness/dnf_package_allow_downgrades.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   dnf_package 'nginx' do
         #     version '1.2.3'
         #     allow_downgrades true
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   dnf_package 'nginx' do
         #     version '1.2.3'
         #   end

--- a/lib/rubocop/cop/chef/correctness/incorrect_library_injection.rb
+++ b/lib/rubocop/cop/chef/correctness/incorrect_library_injection.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   ::Chef::Recipe.send(:include, Filebeat::Helpers)
         #   ::Chef::Provider.send(:include, Filebeat::Helpers)
         #   ::Chef::Recipe.include Filebeat::Helpers
         #   ::Chef::Provider.include Filebeat::Helpers
         #
-        #   #### correct
+        #   ### correct
         #   ::Chef::DSL::Recipe.send(:include, Filebeat::Helpers) # covers previous Recipe & Provider classes
         #
         class IncorrectLibraryInjection < Base

--- a/lib/rubocop/cop/chef/correctness/invalid_cookbook_name.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_cookbook_name.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   name 'foo.bar'
         #
-        #   #### correct
+        #   ### correct
         #   name 'foo_bar'
         #
         class InvalidCookbookName < Base

--- a/lib/rubocop/cop/chef/correctness/invalid_default_action.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_default_action.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   default_action 'create'
         #
-        #   #### correct
+        #   ### correct
         #   default_action :create
         #
         class InvalidDefaultAction < Base

--- a/lib/rubocop/cop/chef/correctness/invalid_notification_resource.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_notification_resource.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, service['apache'], :immediately
@@ -33,7 +33,7 @@ module RuboCop
         #     notifies :restart, service[apache], :immediately
         #   end
         #
-        #   #### correct
+        #   ### correct
         #
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, 'service[apache]', :immediately

--- a/lib/rubocop/cop/chef/correctness/invalid_notification_timing.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_notification_timing.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, 'service[apache]', :nope
         #   end
         #
-        #   #### correct
+        #   ### correct
         #
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, 'service[apache]', :immediately

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_family_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_family_helper.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   platform_family?('redhat')
         #   platform_family?('sles')
         #
-        #   #### incorrect
+        #   ### incorrect
         #   platform_family?('rhel')
         #   platform_family?('suse')
         #

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   case node['platform_family']
         #   when 'redhat'
         #     puts "I'm on a RHEL-like system"

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_helper.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   platform?('darwin')
         #   platform?('rhel')
         #   platform?('sles')
         #
-        #   #### correct
+        #   ### correct
         #   platform?('mac_os_x')
         #   platform?('redhat')
         #   platform?('suse')

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_metadata.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_metadata.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   supports 'darwin'
         #   supports 'mswin'
         #
-        #   #### correct
+        #   ### correct
         #   supports 'mac_os_x'
         #   supports 'windows'
         #

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_values_in_case.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_values_in_case.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   case node['platform']
         #   when 'rhel'
         #     puts "I'm on a Red Hat system!"

--- a/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_family_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_family_helper.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   value_for_platform_family(
         #     %w(rhel sles) => 'foo',
         #     %w(mac) => 'foo'
         #   )
         #
-        #   #### correct
+        #   ### correct
         #   value_for_platform_family(
         #     %w(rhel suse) => 'foo',
         #     %w(mac_os_x) => 'foo'

--- a/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_helper.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   value_for_platform(
         #     %w(rhel mac_os_x_server) => { 'default' => 'foo' },
         #     %w(sles) => { 'default' => 'bar' }
         #   )
-        #   #### correct
+        #   ### correct
         #   value_for_platform(
         #     %w(redhat mac_os_x) => { 'default' => 'foo' },
         #     %w(opensuseleap) => { 'default' => 'bar' }

--- a/lib/rubocop/cop/chef/correctness/invalid_version_metadata.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_version_metadata.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   version '1.2.3.4'
         #
-        #   #### correct
+        #   ### correct
         #   version '1.2.3'
         #
         class InvalidVersionMetadata < Base

--- a/lib/rubocop/cop/chef/correctness/lazy_eval_node_attribute_defaults.rb
+++ b/lib/rubocop/cop/chef/correctness/lazy_eval_node_attribute_defaults.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :Something, String, default: node['hostname']
         #
-        #   #### correct
+        #   ### correct
         #   property :Something, String, default: lazy { node['hostname'] }
         #
         class LazyEvalNodeAttributeDefaults < Base

--- a/lib/rubocop/cop/chef/correctness/lazy_in_resource_guard.rb
+++ b/lib/rubocop/cop/chef/correctness/lazy_in_resource_guard.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   template '/etc/foo' do
         #     mode '0644'
         #     source 'foo.erb'
         #     only_if { lazy { ::File.exist?('/etc/foo')} }
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   template '/etc/foo' do
         #     mode '0644'
         #     source 'foo.erb'

--- a/lib/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type.rb
+++ b/lib/rubocop/cop/chef/correctness/macos_userdefaults_invalid_type.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   macos_userdefaults 'set a value' do
         #     global true
         #     key 'key'
         #     type 'boolean'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   macos_userdefaults 'set a value' do
         #     global true
         #     key 'key'

--- a/lib/rubocop/cop/chef/correctness/malformed_value_for_platform.rb
+++ b/lib/rubocop/cop/chef/correctness/malformed_value_for_platform.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   value_for_platform(
         #     %w(redhat oracle) => 'baz'
         #   )
         #
-        #   #### correct
+        #   ### correct
         #   value_for_platform(
         #     %w(redhat oracle) => {
         #       '5' => 'foo',

--- a/lib/rubocop/cop/chef/correctness/metadata_malformed_version.rb
+++ b/lib/rubocop/cop/chef/correctness/metadata_malformed_version.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'some_awesome_cookbook' '= 4.5.5'
         #   depends 'some_other_cool_cookbook' '< 8.0'
         #
-        #   #### correct
+        #   ### correct
         #   depends 'some_awesome_cookbook', '= 4.5.5'
         #   depends 'some_other_cool_cookbook', '< 8.0'
         #

--- a/lib/rubocop/cop/chef/correctness/metadata_missing_name.rb
+++ b/lib/rubocop/cop/chef/correctness/metadata_missing_name.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### correct
+        #   ### correct
         #   name 'foo'
         #
         class MetadataMissingName < Base

--- a/lib/rubocop/cop/chef/correctness/metadata_missing_version.rb
+++ b/lib/rubocop/cop/chef/correctness/metadata_missing_version.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### correct
+        #   ### correct
         #   name 'foo'
         #   version '1.0.0'
         #

--- a/lib/rubocop/cop/chef/correctness/node_normal.rb
+++ b/lib/rubocop/cop/chef/correctness/node_normal.rb
@@ -24,10 +24,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.normal['foo'] = true
         #
-        #   #### correct
+        #   ### correct
         #   node.default['foo'] = true
         #   node.override['foo'] = true
         #   node.force_default['foo'] = true

--- a/lib/rubocop/cop/chef/correctness/node_normal_unless.rb
+++ b/lib/rubocop/cop/chef/correctness/node_normal_unless.rb
@@ -24,10 +24,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.normal_unless['foo'] = true
         #
-        #   #### correct
+        #   ### correct
         #   node.default_unless['foo'] = true
         #   node.override_unless['foo'] = true
         #   node.force_default_unless['foo'] = true

--- a/lib/rubocop/cop/chef/correctness/node_save.rb
+++ b/lib/rubocop/cop/chef/correctness/node_save.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.save
         #
         class CookbookUsesNodeSave < Base

--- a/lib/rubocop/cop/chef/correctness/notifies_action_not_symbol.rb
+++ b/lib/rubocop/cop/chef/correctness/notifies_action_not_symbol.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   execute 'some command' do
         #     notifies 'restart', 'service[httpd]', 'delayed'
         #   end
@@ -32,7 +32,7 @@ module RuboCop
         #     subscribes 'restart', 'service[httpd]', 'delayed'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   execute 'some command' do
         #     notifies :restart, 'service[httpd]', 'delayed'
         #   end

--- a/lib/rubocop/cop/chef/correctness/octal_mode_as_string.rb
+++ b/lib/rubocop/cop/chef/correctness/octal_mode_as_string.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   file '/etc/some_file' do
         #     mode '0o755'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   file '/etc/some_file' do
         #     mode '0755'
         #   end

--- a/lib/rubocop/cop/chef/correctness/openssl_password_helpers.rb
+++ b/lib/rubocop/cop/chef/correctness/openssl_password_helpers.rb
@@ -21,7 +21,7 @@ module RuboCop
       module Correctness
         # The OpenSSL cookbook provides a deprecated `secure_password` helper in the `Opscode::OpenSSL::Password` class, which should no longer be used. This helper would generate a random password that would be used when a data bag or attribute was no present. The practice of generating passwords to be stored on the node is bad security as it exposes the password to anyone that can view the nodes, and deleting a node deletes the password. Passwords should be retrieved from a secure source for use in cookbooks.
         #
-        #   #### incorrect
+        #   ### incorrect
         #   ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
         #   basic_auth_password = secure_password
         #

--- a/lib/rubocop/cop/chef/correctness/powershell_delete_file.rb
+++ b/lib/rubocop/cop/chef/correctness/powershell_delete_file.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   powershell_script 'Cleanup old files' do
         #     code 'Remove-Item C:\Windows\foo\bar.txt'
         #     only_if { ::File.exist?('C:\\Windows\\foo\\bar.txt') }
         #   end
         #
-        #  #### correct
+        #  ### correct
         #  file 'C:\Windows\foo\bar.txt' do
         #    action :delete
         #  end

--- a/lib/rubocop/cop/chef/correctness/powershell_file_exists.rb
+++ b/lib/rubocop/cop/chef/correctness/powershell_file_exists.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #  #### incorrect
+        #  ### incorrect
         #  powershell_out('Test-Path "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"').stdout.strip == 'True'
         #
-        #  #### correct
+        #  ### correct
         #  ::File.exist?('C:\Program Files\LAPS\CSE\AdmPwd.dll')
         #
         class PowershellFileExists < Base

--- a/lib/rubocop/cop/chef/correctness/property_without_type.rb
+++ b/lib/rubocop/cop/chef/correctness/property_without_type.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :size, regex: /^\d+[KMGTP]$/
         #   attribute :size, regex: /^\d+[KMGTP]$/
         #
-        #   #### correct
+        #   ### correct
         #   property :size, String, regex: /^\d+[KMGTP]$/
         #   attribute :size, kind_of: String, regex: /^\d+[KMGTP]$/
         #

--- a/lib/rubocop/cop/chef/correctness/resource_sets_internal_properties.rb
+++ b/lib/rubocop/cop/chef/correctness/resource_sets_internal_properties.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   service 'foo' do
         #     running true
         #     action [:start, :enable]
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   service 'foo' do
         #     action [:start, :enable]
         #   end

--- a/lib/rubocop/cop/chef/correctness/resource_sets_name_property.rb
+++ b/lib/rubocop/cop/chef/correctness/resource_sets_name_property.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   service 'foo' do
         #    name 'bar'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   service 'foo' do
         #    service_name 'bar'
         #   end

--- a/lib/rubocop/cop/chef/correctness/resource_with_none_action.rb
+++ b/lib/rubocop/cop/chef/correctness/resource_with_none_action.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   service 'foo' do
         #    action :none
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   service 'foo' do
         #    action :nothing
         #   end

--- a/lib/rubocop/cop/chef/correctness/scoped_file_exist.rb
+++ b/lib/rubocop/cop/chef/correctness/scoped_file_exist.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   not_if { File.exist?('/etc/foo/bar') }
         #
-        #   #### correct
+        #   ### correct
         #   not_if { ::File.exist?('/etc/foo/bar') }
         #
         class ScopedFileExist < Base

--- a/lib/rubocop/cop/chef/correctness/service_resource.rb
+++ b/lib/rubocop/cop/chef/correctness/service_resource.rb
@@ -22,7 +22,7 @@ module RuboCop
         #
         # @example when command starts a service
         #
-        #   #### incorrect
+        #   ### incorrect
         #   command "/etc/init.d/mysql start"
         #   command "/sbin/service/memcached start"
         #

--- a/lib/rubocop/cop/chef/correctness/supports_must_be_float.rb
+++ b/lib/rubocop/cop/chef/correctness/supports_must_be_float.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   supports 'redhat', '> 8'
         #
-        #   #### correct
+        #   ### correct
         #   supports 'redhat', '> 8.0'
         #
         class SupportsMustBeFloat < Base

--- a/lib/rubocop/cop/chef/correctness/tmp_path.rb
+++ b/lib/rubocop/cop/chef/correctness/tmp_path.rb
@@ -22,10 +22,10 @@ module RuboCop
         #
         # @example downloading a large file into /tmp/
         #
-        #   #### incorrect
+        #   ### incorrect
         #   remote_file '/tmp/large-file.tar.gz' do
         #
-        #   #### correct
+        #   ### correct
         #   remote_file "#{Chef::Config[:file_cache_path]}/large-file.tar.gz" do
         #
         class TmpPath < Base

--- a/lib/rubocop/cop/chef/deprecation/cb_depends_on_self.rb
+++ b/lib/rubocop/cop/chef/deprecation/cb_depends_on_self.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   name 'foo'
         #   depends 'foo'
         #
-        #   #### correct
+        #   ### correct
         #   name 'foo'
         #
         class CookbooksDependsOnSelf < Base

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include_recipe 'chef_handler'
         #   include_recipe 'chef_handler::default'
         #

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_supports.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   chef_handler 'whatever' do
         #     supports start: true, report: true, exception: true
         #   end0
         #
-        #   #### correct
+        #   ### correct
         #   chef_handler 'whatever' do
         #     type start: true, report: true, exception: true
         #   end

--- a/lib/rubocop/cop/chef/deprecation/chef_rest.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rest.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   require 'chef/rest'
         #   Chef::REST::RESTRequest.new(:GET, FOO, nil).call
         #

--- a/lib/rubocop/cop/chef/deprecation/chef_shellout.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_shellout.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include Chef::ShellOut
         #   require 'chef/shellout'
         #   Chef::ShellOut.new('some_command')
         #
-        #   #### correct
+        #   ### correct
         #   include Mixlib::ShellOut
         #   require 'mixlib/shellout'
         #   Mixlib::ShellOut.new('some_command')

--- a/lib/rubocop/cop/chef/deprecation/chef_sugar_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_sugar_helpers.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   vagrant_key?
         #   vagrant_domain?
         #   vagrant_user?

--- a/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   Chef::Platform.windows?
         #
-        #   #### correct
+        #   ### correct
         #   platform?('windows')
         #   platform_family?('windows')
         #

--- a/lib/rubocop/cop/chef/deprecation/chefdk_generators.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefdk_generators.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   ChefDK::CLI
         #   ChefDK::Generator::TemplateHelper
         #   module ChefDK
         #     # some additional code
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   ChefCLI::CLI
         #   ChefCLI::Generator::TemplateHelper
         #   module ChefCLI

--- a/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_coverage_report.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #
         #   at_exit { ChefSpec::Coverage.report! }
         #

--- a/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
+++ b/lib/rubocop/cop/chef/deprecation/chefspec_legacy_runner.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #
         #   describe 'foo::default' do
         #     subject { ChefSpec::Runner.new.converge(described_recipe) }
@@ -31,7 +31,7 @@ module RuboCop
         #     # some spec code
         #   end
         #
-        #   #### correct
+        #   ### correct
         #
         #   describe 'foo::default' do
         #     subject { ChefSpec::ServerRunner.new.converge(described_recipe) }

--- a/lib/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   chocolatey_package 'nginx' do
         #     action :uninstall
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   chocolatey_package 'nginx' do
         #     action :remove
         #   end

--- a/lib/rubocop/cop/chef/deprecation/depends_chef_nginx_cookbook.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_chef_nginx_cookbook.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'chef_nginx'
         #
-        #   #### correct
+        #   ### correct
         #   depends 'nginx'
         #
         class DependsOnChefNginxCookbook < Base

--- a/lib/rubocop/cop/chef/deprecation/depends_chef_reporting_cookbook.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_chef_reporting_cookbook.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'chef-reporting'
         #
         class DependsOnChefReportingCookbook < Base

--- a/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_compat_resource.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'compat_resource'
         #
         class CookbookDependsOnCompatResource < Base

--- a/lib/rubocop/cop/chef/deprecation/depends_omnibus_updater_cookbook.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_omnibus_updater_cookbook.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'omnibus_updater'
         #
-        #   #### correct
+        #   ### correct
         #   depends 'chef_client_updater'
         #
         class DependsOnOmnibusUpdaterCookbook < Base

--- a/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'partial_search'
         #
         class CookbookDependsOnPartialSearch < Base

--- a/lib/rubocop/cop/chef/deprecation/depends_poise.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_poise.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'poise'
         #   depends 'poise-service'
         #   depends 'poise-hoist'

--- a/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include Chef::Mixin::LanguageIncludeAttribute
         #   include Chef::Mixin::RecipeDefinitionDSLCore
         #   include Chef::Mixin::LanguageIncludeRecipe

--- a/lib/rubocop/cop/chef/deprecation/deprecated_platform_methods.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_platform_methods.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   resource = Chef::Resource::File.new("/tmp/foo.xyz", run_context)
         #   provider = Chef::Platform.provider_for_resource(resource, :create)
         #
@@ -35,7 +35,7 @@ module RuboCop
         #
         #   Chef::Platform.set :platform => :mac_os_x, :resource => :package, :provider => Chef::Provider::Package::Homebrew
         #
-        #   #### correct
+        #   ### correct
         #   resource = Chef::Resource::File.new("/tmp/foo.xyz", run_context)
         #   provider = resource.provider_for_action(:create)
         #

--- a/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   shell_out_compact('foo')
         #   shell_out_compact!('foo')
         #   shell_out_with_timeout('foo')
@@ -33,7 +33,7 @@ module RuboCop
         #   shell_out_compact_timeout('foo')
         #   shell_out_compact_timeout!('foo')
         #
-        #   #### correct
+        #   ### correct
         #   shell_out('foo')
         #   shell_out!('foo')
         #   shell_out!('foo', default_env: false) # replaces shell_out_with_systems_locale

--- a/lib/rubocop/cop/chef/deprecation/deprecated_sudo_actions.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_sudo_actions.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   sudo 'admins' do
         #     users 'bob'
         #     groups 'sysadmins, superusers'
         #     action :remove
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   sudo 'admins' do
         #     users 'bob'
         #     groups 'sysadmins, superusers'

--- a/lib/rubocop/cop/chef/deprecation/deprecated_windows_version_check.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_windows_version_check.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   if older_than_win_2012_or_8?
         #     # do some legacy things
         #   end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_actions.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_actions.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   yum_repository 'OurCo' do
         #     description 'OurCo yum repository'
         #     baseurl 'http://artifacts.ourco.org/foo/bar'
@@ -31,7 +31,7 @@ module RuboCop
         #     action :add
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   yum_repository 'OurCo' do
         #     description 'OurCo yum repository'
         #     baseurl 'http://artifacts.ourco.org/foo/bar'

--- a/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_properties.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_yum_repository_properties.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   yum_repository 'OurCo' do
         #     description 'OurCo yum repository'
         #     url 'http://artifacts.ourco.org/foo/bar'
@@ -32,7 +32,7 @@ module RuboCop
         #     action :create
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   yum_repository 'OurCo' do
         #     description 'OurCo yum repository'
         #     baseurl 'http://artifacts.ourco.org/foo/bar'

--- a/lib/rubocop/cop/chef/deprecation/easy_install.rb
+++ b/lib/rubocop/cop/chef/deprecation/easy_install.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   easy_install "my_thing" do
         #     bar
         #   end

--- a/lib/rubocop/cop/chef/deprecation/eol_audit_mode.rb
+++ b/lib/rubocop/cop/chef/deprecation/eol_audit_mode.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   control_group 'Baseline' do
         #     control 'SSH' do
         #       it 'should be listening on port 22' do

--- a/lib/rubocop/cop/chef/deprecation/epic_fail.rb
+++ b/lib/rubocop/cop/chef/deprecation/epic_fail.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   package "foo" do
         #     epic_fail true
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   package "foo" do
         #     ignore_failure true
         #   end

--- a/lib/rubocop/cop/chef/deprecation/erl_call.rb
+++ b/lib/rubocop/cop/chef/deprecation/erl_call.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   erl_call "foo" do
         #     bar
         #   end

--- a/lib/rubocop/cop/chef/deprecation/execute_path_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/execute_path_property.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   execute 'some_cmd' do
         #     path '/foo/bar'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   execute 'some_cmd' do
         #     environment {path: '/foo/bar'}
         #   end

--- a/lib/rubocop/cop/chef/deprecation/execute_relative_creates_without_cwd.rb
+++ b/lib/rubocop/cop/chef/deprecation/execute_relative_creates_without_cwd.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   execute 'some_cmd' do
         #     creates 'something'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   execute 'some_cmd' do
         #     creates '/tmp/something'
         #   end

--- a/lib/rubocop/cop/chef/deprecation/foodcritic_testing.rb
+++ b/lib/rubocop/cop/chef/deprecation/foodcritic_testing.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   gem 'foodcritic'
         #   require 'foodcritic'
         #

--- a/lib/rubocop/cop/chef/deprecation/hwrp_without_provides.rb
+++ b/lib/rubocop/cop/chef/deprecation/hwrp_without_provides.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   class Chef
         #     class Resource
         #       class UlimitRule < Chef::Resource
@@ -35,7 +35,7 @@ module RuboCop
         #     end
         #   end
         #
-        #   #### incorrect
+        #   ### incorrect
         #   class Chef
         #     class Resource
         #       class UlimitRule < Chef::Resource
@@ -49,7 +49,7 @@ module RuboCop
         #     end
         #   end
         #
-        #  #### correct when Chef Infra Client < 15 (but compatible with 16+ as well)
+        #  ### correct when Chef Infra Client < 15 (but compatible with 16+ as well)
         #   class Chef
         #     class Resource
         #       class UlimitRule < Chef::Resource
@@ -64,7 +64,7 @@ module RuboCop
         #     end
         #   end
         #
-        #  #### correct when Chef Infra Client 16+
+        #  ### correct when Chef Infra Client 16+
         #   class Chef
         #     class Resource
         #       class UlimitRule < Chef::Resource

--- a/lib/rubocop/cop/chef/deprecation/hwrp_without_unified_mode_true.rb
+++ b/lib/rubocop/cop/chef/deprecation/hwrp_without_unified_mode_true.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #  #### incorrect
+        #  ### incorrect
         #   class Chef
         #     class Resource
         #       class UlimitRule < Chef::Resource
@@ -37,7 +37,7 @@ module RuboCop
         #     end
         #   end
         #
-        #  #### correct
+        #  ### correct
         #   class Chef
         #     class Resource
         #       class UlimitRule < Chef::Resource

--- a/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #  #### incorrect
+        #  ### incorrect
         #  class AptUpdate < ChefCompat::Resource
         #    # some resource code
         #  end
         #
-        #  #### correct
+        #  ### correct
         #  class AptUpdate < Chef::Resource
         #    # some resource code
         #  end

--- a/lib/rubocop/cop/chef/deprecation/launchd_deprecated_hash_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/launchd_deprecated_hash_property.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   launchd 'foo' do
         #     hash foo: 'bar'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   launchd 'foo' do
         #     plist_hash foo: 'bar'
         #   end

--- a/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_notify_syntax.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, resources(service: 'apache')
         #   end
@@ -40,7 +40,7 @@ module RuboCop
         #     subscribes :restart, resources(service: service_name_variable), :immediately
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, 'service[apache]'
         #   end

--- a/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
@@ -25,7 +25,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include_recipe 'yum::elrepo'
         #   include_recipe 'yum::epel'
         #   include_recipe 'yum::ius'

--- a/lib/rubocop/cop/chef/deprecation/librarian_chefspec.rb
+++ b/lib/rubocop/cop/chef/deprecation/librarian_chefspec.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   require 'chefspec/librarian'
         #
         class LibrarianChefSpec < Base

--- a/lib/rubocop/cop/chef/deprecation/locale_lc_all_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/locale_lc_all_property.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   locale 'set locale' do
         #     lang 'en_gb.utf-8'
         #     lc_all 'en_gb.utf-8'

--- a/lib/rubocop/cop/chef/deprecation/log_resource_notifications.rb
+++ b/lib/rubocop/cop/chef/deprecation/log_resource_notifications.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   template '/etc/foo' do
         #     source 'bar.erb'
         #     notifies :write, 'log[Aggregate notifications using a single log resource]', :immediately
@@ -33,7 +33,7 @@ module RuboCop
         #     notifies :restart, 'service[foo]', :delayed
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   template '/etc/foo' do
         #     source 'bar.erb'
         #     notifies :run, 'notify_group[Aggregate notifications using a single notify_group resource]', :immediately

--- a/lib/rubocop/cop/chef/deprecation/macos_userdefaults_global_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/macos_userdefaults_global_property.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   macos_userdefaults 'set a value' do
         #     global true
         #     key 'key'
         #     value 'value'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   macos_userdefaults 'set a value' do
         #     key 'key'
         #     value 'value'

--- a/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
+++ b/lib/rubocop/cop/chef/deprecation/name_property_and_default.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :config_file, String, default: 'foo', name_property: true
         #   attribute :config_file, String, default: 'foo', name_attribute: true
         #
-        #   #### correct
+        #   ### correct
         #   property :config_file, String, name_property: true
         #   attribute :config_file, String, name_attribute: true
         #

--- a/lib/rubocop/cop/chef/deprecation/node_deep_fetch.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_deep_fetch.rb
@@ -22,16 +22,16 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.deep_fetch("foo")
         #
-        #   #### correct
+        #   ### correct
         #   node.read("foo")
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.deep_fetch!("foo")
         #
-        #   #### correct
+        #   ### correct
         #   node.read!("foo")
         #
         class NodeDeepFetch < Base

--- a/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_methods_not_attributes.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.fqdn
         #   node.platform
         #   node.platform_family
         #   node.platform_version
         #   node.hostname
         #
-        #   #### correct
+        #   ### correct
         #   node['fqdn']
         #   node['platform']
         #   node['platform_family']

--- a/lib/rubocop/cop/chef/deprecation/node_set.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set.rb
@@ -24,10 +24,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.set['foo'] = true
         #
-        #   #### correct
+        #   ### correct
         #   node.normal['foo'] = true
         #
         class NodeSet < Base

--- a/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set_unless.rb
@@ -24,10 +24,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.set_unless['foo'] = true
         #
-        #   #### correct
+        #   ### correct
         #   node.normal_unless['foo'] = true
         #
         class NodeSetUnless < Base

--- a/lib/rubocop/cop/chef/deprecation/node_set_without_level.rb
+++ b/lib/rubocop/cop/chef/deprecation/node_set_without_level.rb
@@ -22,13 +22,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node['foo']['bar'] = 1
         #   node['foo']['bar'] << 1
         #   node['foo']['bar'] += 1
         #   node['foo']['bar'] -= 1
         #
-        #   #### correct
+        #   ### correct
         #   node.default['foo']['bar'] = 1
         #   node.default['foo']['bar'] << 1
         #   node.default['foo']['bar'] += 1

--- a/lib/rubocop/cop/chef/deprecation/partial_search_class_usage.rb
+++ b/lib/rubocop/cop/chef/deprecation/partial_search_class_usage.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   ::Chef::PartialSearch.new.search((:node, 'role:web',
         #     keys: { 'name' => [ 'name' ],
         #             'ip' => [ 'ipaddress' ],
@@ -35,7 +35,7 @@ module RuboCop
         #     puts result['kernel_version']
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   search(:node, 'role:web',
         #     filter_result: { 'name' => [ 'name' ],
         #                      'ip' => [ 'ipaddress' ],

--- a/lib/rubocop/cop/chef/deprecation/partial_search_helper_usage.rb
+++ b/lib/rubocop/cop/chef/deprecation/partial_search_helper_usage.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   partial_search(:node, 'role:web',
         #     keys: { 'name' => [ 'name' ],
         #             'ip' => [ 'ipaddress' ],
@@ -35,7 +35,7 @@ module RuboCop
         #     puts result['kernel_version']
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   search(:node, 'role:web',
         #     filter_result: { 'name' => [ 'name' ],
         #                      'ip' => [ 'ipaddress' ],

--- a/lib/rubocop/cop/chef/deprecation/poise_archive.rb
+++ b/lib/rubocop/cop/chef/deprecation/poise_archive.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   poise_archive 'https://example.com/myapp.tgz' do
         #     destination '/opt/my_app'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   archive_file 'https://example.com/myapp.tgz' do
         #     destination '/opt/my_app'
         #   end

--- a/lib/rubocop/cop/chef/deprecation/policyfile_community_source.rb
+++ b/lib/rubocop/cop/chef/deprecation/policyfile_community_source.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   default_source :community
         #
-        #   #### correct
+        #   ### correct
         #   default_source :supermarket
         #
         class PolicyfileCommunitySource < Base

--- a/lib/rubocop/cop/chef/deprecation/powershell_cookbook_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/powershell_cookbook_helpers.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   Powershell::VersionHelper.powershell_version?('4.0')
         #
-        #   #### correct
+        #   ### correct
         #   node['powershell']['version'].to_f == 4.0
         #
         #   # better (Chef Infra Client 15.8+)

--- a/lib/rubocop/cop/chef/deprecation/require_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/require_recipe.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   require_recipe 'foo'
         #
-        #   #### correct
+        #   ### correct
         #   include_recipe 'foo'
         #
         class RequireRecipe < Base

--- a/lib/rubocop/cop/chef/deprecation/resource_overrides_provides_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_overrides_provides_method.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   def provides?
         #    true
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   provides :SOME_PROVIDER_NAME
         #
         class ResourceOverridesProvidesMethod < Base

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_dsl_name_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_dsl_name_method.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   my_resource = MyResource.dsl_name
         #
-        #   #### correct
+        #   ### correct
         #   my_resource = MyResource.resource_name
         #
         class ResourceUsesDslNameMethod < Base

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   mycookbook/resources/myresource.rb:
         #   resource_name :mycookbook_myresource
         #

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_provider_base_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_provider_base_method.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   provider_base ::Chef::Provider::SomethingSomething
         #
         class ResourceUsesProviderBaseMethod < Base

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_updated_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_updated_method.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   action :foo do
         #     updated = true
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   action :foo do
         #     converge_by('resource did something') do
         #       # code that causes the resource to converge

--- a/lib/rubocop/cop/chef/deprecation/resource_without_unified_mode_true.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_without_unified_mode_true.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #  #### incorrect
+        #  ### incorrect
         #   resource_name :foo
         #   provides :foo
         #
@@ -31,7 +31,7 @@ module RuboCop
         #     # some action code
         #   end
         #
-        #  #### correct
+        #  ### correct
         #   resource_name :foo
         #   provides :foo
         #   unified_mode true

--- a/lib/rubocop/cop/chef/deprecation/ruby_27_keyword_argument_warnings.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_27_keyword_argument_warnings.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   shell_out!('hostnamectl status', { returns: [0, 1] })
         #   shell_out('hostnamectl status', { returns: [0, 1] })
         #
-        #   #### correct
+        #   ### correct
         #   shell_out!('hostnamectl status', returns: [0, 1])
         #   shell_out('hostnamectl status', returns: [0, 1])
         #

--- a/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   ruby_block 'my special ruby block' do
         #     block do
         #       puts 'running'
@@ -31,7 +31,7 @@ module RuboCop
         #     action :create
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   ruby_block 'my special ruby block' do
         #     block do
         #       puts 'running'

--- a/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/run_command_helper.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   require 'chef/mixin/command'
         #   include Chef::Mixin::Command
         #
         #   run_command('/bin/foo')
         #   run_command_with_systems_locale('/bin/foo')
         #
-        #   #### correct
+        #   ### correct
         #   shell_out!('/bin/foo')
         #
         class UsesRunCommandHelper < Base

--- a/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
+++ b/lib/rubocop/cop/chef/deprecation/search_uses_positional_parameters.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #### incorrect:
+        ### incorrect:
         #  search(:node, '*:*', 0, 1000, { :ip_address => ["ipaddress"] })
         #  search(:node, '*:*', 0, 1000)
         #  search(:node, '*:*', 0)
 
-        #### correct
+        ### correct
         #
         # query(:node, '*:*')
         #  search(:node, '*:*', start: 0, rows: 1000, filter_result: { :ip_address => ["ipaddress"] })

--- a/lib/rubocop/cop/chef/deprecation/use_automatic_resource_name.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_automatic_resource_name.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   module MyCookbook
         #     class MyCookbookService < Chef::Resource
         #       use_automatic_resource_name

--- a/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_inline_resources.rb
@@ -24,7 +24,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   use_inline_resources
         #   use_inline_resources if defined?(use_inline_resources)
         #   use_inline_resources if respond_to?(:use_inline_resources)

--- a/lib/rubocop/cop/chef/deprecation/use_yaml_dump.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_yaml_dump.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   {"foo" => "bar"}.to_yaml
         #
-        #   #### correct
+        #   ### correct
         #   YAML.dump({"foo" => "bar"})
         #
         class UseYamlDump < Base

--- a/lib/rubocop/cop/chef/deprecation/user_supports_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/user_supports_property.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   user "betty" do
         #     supports({
         #       manage_home: true,
@@ -35,7 +35,7 @@ module RuboCop
         #     supports :manage_home => true
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   user "betty" do
         #     manage_home true
         #     non_unique true

--- a/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
+++ b/lib/rubocop/cop/chef/deprecation/verify_property_file_expansion.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   file '/etc/nginx.conf' do
         #     verify 'nginx -t -c %{file}'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   file '/etc/nginx.conf' do
         #     verify 'nginx -t -c %{path}'
         #   end

--- a/lib/rubocop/cop/chef/deprecation/windows_feature_servermanagercmd.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_feature_servermanagercmd.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   windows_feature 'DHCP' do
         #     install_method :servermanagercmd
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   windows_feature 'DHCP' do
         #     install_method :windows_feature_dism
         #   end

--- a/lib/rubocop/cop/chef/deprecation/windows_package_installer_type_string.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_package_installer_type_string.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   windows_package 'AppveyorDeploymentAgent' do
         #     source 'https://www.example.com/appveyor.msi'
         #     installer_type 'msi'
         #     options "/quiet /qn /norestart /log install.log"
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   windows_package 'AppveyorDeploymentAgent' do
         #     source 'https://www.example.com/appveyor.msi'
         #     installer_type :msi

--- a/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_task_change_action.rb
@@ -24,7 +24,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   windows_task 'chef ad-join leave start time' do
         #     task_name 'chef ad-join leave'
         #     start_day '06/09/2016'
@@ -32,7 +32,7 @@ module RuboCop
         #     action [:change, :create]
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   windows_task 'chef ad-join leave start time' do
         #     task_name 'chef ad-join leave'
         #     start_day '06/09/2016'

--- a/lib/rubocop/cop/chef/deprecation/windows_version_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/windows_version_helpers.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   Windows::VersionHelper.nt_version
         #   Windows::VersionHelper.server_version?
         #   Windows::VersionHelper.core_version?
         #   Windows::VersionHelper.workstation_version?
         #
-        #   #### correct
+        #   ### correct
         #   node['platform_version'].to_f
         #   node['kernel']['product_type'] == 'Server'
         #   node['kernel']['server_core']

--- a/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include_recipe 'xml::ruby'
         #
         class IncludingXMLRubyRecipe < Base

--- a/lib/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/yum_dnf_compat_recipe.rb
@@ -24,7 +24,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include_recipe 'yum::dnf_yum_compat'
         #
         class IncludingYumDNFCompatRecipe < Base

--- a/lib/rubocop/cop/chef/effortless/chef_vault_used.rb
+++ b/lib/rubocop/cop/chef/effortless/chef_vault_used.rb
@@ -23,22 +23,22 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   require 'chef-vault'
         #
-        #   #### incorrect
+        #   ### incorrect
         #   ChefVault::Item
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include_recipe 'chef-vault'
         #
-        #   #### incorrect
+        #   ### incorrect
         #   chef_gem 'chef-vault'
         #
-        #   #### incorrect
+        #   ### incorrect
         #   chef_vault_item_for_environment(arg, arg1)
         #
-        #   #### incorrect
+        #   ### incorrect
         #   chef_vault_item(arg, arg1)
         #
         class ChefVaultUsed < Base

--- a/lib/rubocop/cop/chef/effortless/data_bags.rb
+++ b/lib/rubocop/cop/chef/effortless/data_bags.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   data_bag_item('admins', login)
         #   data_bag(data_bag_name)
         class CookbookUsesDatabags < Base

--- a/lib/rubocop/cop/chef/effortless/depends_chef_vault.rb
+++ b/lib/rubocop/cop/chef/effortless/depends_chef_vault.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'chef-vault'
         #
         class DependsChefVault < Base

--- a/lib/rubocop/cop/chef/effortless/node_environment.rb
+++ b/lib/rubocop/cop/chef/effortless/node_environment.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.environment == "production"
         #   node.chef_environment == "production"
         #

--- a/lib/rubocop/cop/chef/effortless/node_policygroup.rb
+++ b/lib/rubocop/cop/chef/effortless/node_policygroup.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.policy_group == "foo"
         #
         class CookbookUsesPolicygroups < Base

--- a/lib/rubocop/cop/chef/effortless/node_roles.rb
+++ b/lib/rubocop/cop/chef/effortless/node_roles.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node.role?('web_server')
         #   node.roles.include?('web_server')
         #

--- a/lib/rubocop/cop/chef/effortless/search_for_environments_or_roles.rb
+++ b/lib/rubocop/cop/chef/effortless/search_for_environments_or_roles.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   search(:node, 'chef_environment:foo')
         #   search(:node, 'role:bar')
         #

--- a/lib/rubocop/cop/chef/effortless/search_used.rb
+++ b/lib/rubocop/cop/chef/effortless/search_used.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   search(:node, 'run_list:recipe\[bacula\:\:server\]')
         #
         class CookbookUsesSearch < Base

--- a/lib/rubocop/cop/chef/modernize/action_method_in_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/action_method_in_resource.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   def action_create
         #    # :create action code here
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   action :create do
         #    # :create action code here
         #   end

--- a/lib/rubocop/cop/chef/modernize/allowed_actions_initializer.rb
+++ b/lib/rubocop/cop/chef/modernize/allowed_actions_initializer.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   def initialize(*args)
         #     super
         #     @actions = [ :create, :add ]
@@ -35,7 +35,7 @@ module RuboCop
         #     @allowed_actions = [ :create, :add ]
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   allowed_actions [ :create, :add ]
         #
         class AllowedActionsFromInitialize < Base

--- a/lib/rubocop/cop/chef/modernize/apt_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/apt_default_recipe.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include_recipe 'apt::default'
         #   include_recipe 'apt'
         #
-        #   #### correct
+        #   ### correct
         #   apt_update
         #
         class IncludingAptDefaultRecipe < Base

--- a/lib/rubocop/cop/chef/modernize/berksfile_source.rb
+++ b/lib/rubocop/cop/chef/modernize/berksfile_source.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   source 'http://community.opscode.com/api/v3'
         #   source 'https://supermarket.getchef.com'
         #   source 'https://api.berkshelf.com'
         #   site :opscode
         #
-        #   #### correct
+        #   ### correct
         #   source 'https://supermarket.chef.io'
         #
         class LegacyBerksfileSource < Base

--- a/lib/rubocop/cop/chef/modernize/build_essential.rb
+++ b/lib/rubocop/cop/chef/modernize/build_essential.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'build-essential'
         #   include_recipe 'build-essential::default'
         #   include_recipe 'build-essential'
         #
-        #   #### correct
+        #   ### correct
         #   build_essential 'install compilation tools'
         #
         class UseBuildEssentialResource < Base

--- a/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'build-essential'
         #   depends 'chef_handler'
         #   depends 'chef_hostname'

--- a/lib/rubocop/cop/chef/modernize/chef_15_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_15_resources.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'libarchive'
         #   depends 'windows_dns'
         #   depends 'windows_uac'

--- a/lib/rubocop/cop/chef/modernize/chef_gem_nokogiri.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_gem_nokogiri.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   chef_gem 'nokogiri'
         #
         class ChefGemNokogiri < Base

--- a/lib/rubocop/cop/chef/modernize/class_eval_action_class.rb
+++ b/lib/rubocop/cop/chef/modernize/class_eval_action_class.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   action_class.class_eval do
         #     foo
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   action_class do
         #     foo
         #   end

--- a/lib/rubocop/cop/chef/modernize/compile_time_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/compile_time_resources.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   build_essential 'install build tools' do
         #    action :nothing
         #   end.run_action(:install)
         #
-        #   #### correct
+        #   ### correct
         #   build_essential 'install build tools' do
         #    compile_time true
         #   end

--- a/lib/rubocop/cop/chef/modernize/conditional_using_test.rb
+++ b/lib/rubocop/cop/chef/modernize/conditional_using_test.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   only_if 'test -f /bin/foo'
         #
-        #   #### correct
+        #   ### correct
         #   only_if { ::File.exist?('bin/foo') }
         #
         class ConditionalUsingTest < Base

--- a/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   template '/etc/cron.d/backup' do
         #     source 'cron_backup_job.erb'
         #     owner 'root'
@@ -71,7 +71,7 @@ module RuboCop
         #     action :delete
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   cron_d 'backup' do
         #     minute '1'
         #     hour '1'

--- a/lib/rubocop/cop/chef/modernize/cron_manage_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_manage_resource.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   cron_manage 'mike'
         #
-        #   #### correct
+        #   ### correct
         #   cron_access 'mike'
         #
         class CronManageResource < Base

--- a/lib/rubocop/cop/chef/modernize/databag_helpers.rb
+++ b/lib/rubocop/cop/chef/modernize/databag_helpers.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   plain_text_data = Chef::DataBagItem.load('foo', 'bar')
         #   encrypted_data = Chef::EncryptedDataBagItem.load('foo2', 'bar2')
         #
-        #   #### correct
+        #   ### correct
         #   plain_text_data = data_bag_item('foo', 'bar')
         #   encrypted_data = data_bag_item('foo2', 'bar2')
         #

--- a/lib/rubocop/cop/chef/modernize/declare_action_class.rb
+++ b/lib/rubocop/cop/chef/modernize/declare_action_class.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   declare_action_class do
         #     foo
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   action_class do
         #     foo
         #   end

--- a/lib/rubocop/cop/chef/modernize/default_action_initializer.rb
+++ b/lib/rubocop/cop/chef/modernize/default_action_initializer.rb
@@ -23,19 +23,19 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   def initialize(*args)
         #     super
         #     @action = :create
         #   end
         #
-        #   #### incorrect
+        #   ### incorrect
         #   def initialize(*args)
         #     super
         #     @default_action = :create
         #   end
         #
-        #  #### correct
+        #  ### correct
         #  default_action :create
 
         class DefaultActionFromInitialize < Base

--- a/lib/rubocop/cop/chef/modernize/defines_chefspec_matchers.rb
+++ b/lib/rubocop/cop/chef/modernize/defines_chefspec_matchers.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   if defined?(ChefSpec)
         #     def create_yum_repository(resource_name)
         #       ChefSpec::Matchers::ResourceMatcher.new(:yum_repository, :create, resource_name)

--- a/lib/rubocop/cop/chef/modernize/depends_chef_vault_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_chef_vault_cookbook.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'chef-vault'
         #
         class DependsOnChefVaultCookbook < Base

--- a/lib/rubocop/cop/chef/modernize/depends_chocolatey_cookbooks.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_chocolatey_cookbooks.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'chocolatey_source'
         #   depends 'chocolatey_config'
         #

--- a/lib/rubocop/cop/chef/modernize/depends_kernel_module_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_kernel_module_cookbook.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'kernel_module'
         #
         class DependsOnKernelModuleCookbook < Base

--- a/lib/rubocop/cop/chef/modernize/depends_locale_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_locale_cookbook.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'locale'
         #
         class DependsOnLocaleCookbook < Base

--- a/lib/rubocop/cop/chef/modernize/depends_openssl_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_openssl_cookbook.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'openssl'
         #
         class DependsOnOpensslCookbook < Base

--- a/lib/rubocop/cop/chef/modernize/depends_timezone_lwrp_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_timezone_lwrp_cookbook.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'timezone_lwrp'
         #
         class DependsOnTimezoneLwrpCookbook < Base

--- a/lib/rubocop/cop/chef/modernize/depends_windows_firewall_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_windows_firewall_cookbook.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'windows_firewall'
         #
         class DependsOnWindowsFirewallCookbook < Base

--- a/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'zypper'
         #
         class DependsOnZypperCookbook < Base

--- a/lib/rubocop/cop/chef/modernize/dsl_include_in_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/dsl_include_in_resource.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include Chef::DSL::Recipe
         #   include Chef::DSL::IncludeRecipe
         #

--- a/lib/rubocop/cop/chef/modernize/empty_resource_initialize.rb
+++ b/lib/rubocop/cop/chef/modernize/empty_resource_initialize.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   def initialize(*args)
         #     super
         #   end

--- a/lib/rubocop/cop/chef/modernize/execute_apt_update.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_apt_update.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   execute 'apt-get update'
         #
         #   execute 'Apt all the apt cache' do
@@ -34,7 +34,7 @@ module RuboCop
         #     notifies :run, 'execute[apt-get update]', :immediately
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   apt_update
         #
         #   apt_update 'update apt cache'

--- a/lib/rubocop/cop/chef/modernize/execute_sc_exe.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_sc_exe.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   execute "Delete chef-client service" do
         #     command "sc.exe delete chef-client"
         #     action :run
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   windows_service 'chef-client' do
         #     action :delete
         #   end

--- a/lib/rubocop/cop/chef/modernize/execute_sleep.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_sleep.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   execute "sleep 60" do
         #     command "sleep 60"
         #     action :run
@@ -35,7 +35,7 @@ module RuboCop
         #     code 'sleep 60'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   chef_sleep '60'
         #
         class ExecuteSleep < Cop

--- a/lib/rubocop/cop/chef/modernize/execute_sysctl.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_sysctl.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   file '/etc/sysctl.d/ipv4.conf' do
         #     notifies :run, 'execute[sysctl -p /etc/sysctl.d/ipv4.conf]', :immediately
         #     content '9000 65500'
@@ -33,7 +33,7 @@ module RuboCop
         #     action :nothing
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   sysctl 'net.ipv4.ip_local_port_range' do
         #     value '9000 65500'
         #   end

--- a/lib/rubocop/cop/chef/modernize/execute_tzutil.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_tzutil.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   execute 'set tz' do
         #     command 'tzutil.exe /s UTC'
         #   end
@@ -35,7 +35,7 @@ module RuboCop
         #     not_if { shell_out('tzutil.exe /g').stdout.include?('UTC') }
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   timezone 'UTC'
         #
         class ExecuteTzUtil < Base

--- a/lib/rubocop/cop/chef/modernize/foodcritic_comments.rb
+++ b/lib/rubocop/cop/chef/modernize/foodcritic_comments.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   # ~FC013
         #
         class FoodcriticComments < Base

--- a/lib/rubocop/cop/chef/modernize/if_provides_default_action.rb
+++ b/lib/rubocop/cop/chef/modernize/if_provides_default_action.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   default_action :foo if defined?(default_action)
         #
-        #   #### correct
+        #   ### correct
         #   default_action :foo
         #
         class IfProvidesDefaultAction < Base

--- a/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
+++ b/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   require 'chef/mixin/shell_out'
         #   include Chef::Mixin::ShellOut
         #   require 'chef/mixin/powershell_out'

--- a/lib/rubocop/cop/chef/modernize/libarchive_file.rb
+++ b/lib/rubocop/cop/chef/modernize/libarchive_file.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'libarchive'
         #
         #   libarchive_file "C:\file.zip" do
         #     path 'C:\expand_here'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   archive_file "C:\file.zip" do
         #     path 'C:\expand_here'
         #   end

--- a/lib/rubocop/cop/chef/modernize/macos_user_defaults.rb
+++ b/lib/rubocop/cop/chef/modernize/macos_user_defaults.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   mac_os_x_userdefaults 'full keyboard access to all controls' do
         #     domain 'AppleKeyboardUIMode'
         #     global true
         #     value '2'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   macos_userdefaults 'full keyboard access to all controls' do
         #     domain 'AppleKeyboardUIMode'
         #     global true

--- a/lib/rubocop/cop/chef/modernize/minitest_handler_usage.rb
+++ b/lib/rubocop/cop/chef/modernize/minitest_handler_usage.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   depends 'minitest-handler'
         #
         class MinitestHandlerUsage < Base

--- a/lib/rubocop/cop/chef/modernize/node_init_package.rb
+++ b/lib/rubocop/cop/chef/modernize/node_init_package.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   ::File.open('/proc/1/comm').gets.chomp == 'systemd'
         #   ::File.open('/proc/1/comm').chomp == 'systemd'
         #   File.open('/proc/1/comm').gets.chomp == 'systemd'
@@ -35,7 +35,7 @@ module RuboCop
         #   File.exist?('/proc/1/comm') && File.open('/proc/1/comm').chomp == 'systemd'
         #   only_if 'test -f /bin/systemctl && /bin/systemctl'
         #
-        #   #### correct
+        #   ### correct
         #   node['init_package'] == 'systemd'
         #   only_if { node['init_package'] == 'systemd' }
         #

--- a/lib/rubocop/cop/chef/modernize/node_roles_include.rb
+++ b/lib/rubocop/cop/chef/modernize/node_roles_include.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node['roles'].include?('foo')
         #
-        #   #### correct
+        #   ### correct
         #   node.role?('foo')
         #
         class NodeRolesInclude < Base

--- a/lib/rubocop/cop/chef/modernize/ohai_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/ohai_default_recipe.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include_recipe 'ohai::default'
         #   include_recipe 'ohai'
         #

--- a/lib/rubocop/cop/chef/modernize/openssl_rsa_key_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/openssl_rsa_key_resource.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   openssl_rsa_key '/etc/httpd/ssl/server.key' do
         #     key_length 2048
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   openssl_rsa_private_key '/etc/httpd/ssl/server.key' do
         #     key_length 2048
         #   end

--- a/lib/rubocop/cop/chef/modernize/openssl_x509_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/openssl_x509_resource.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   openssl_x509 '/etc/httpd/ssl/mycert.pem' do
         #     common_name 'www.f00bar.com'
         #     org 'Foo Bar'
@@ -31,7 +31,7 @@ module RuboCop
         #     country 'US'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   openssl_x509_certificate '/etc/httpd/ssl/mycert.pem' do
         #     common_name 'www.f00bar.com'
         #     org 'Foo Bar'

--- a/lib/rubocop/cop/chef/modernize/osx_config_profile_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/osx_config_profile_resource.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   osx_config_profile 'Install screensaver profile' do
         #     profile 'screensaver/com.company.screensaver.mobileconfig'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   osx_profile 'Install screensaver profile' do
         #     profile 'screensaver/com.company.screensaver.mobileconfig'
         #   end

--- a/lib/rubocop/cop/chef/modernize/powershell_expand_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_expand_archive.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   powershell_script 'Expand website' do
         #     code 'Expand-Archive "C:\\file.zip" -DestinationPath "C:\\inetpub\\wwwroot\\" -Force'
         #   end

--- a/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   powershell_script 'Create Directory' do
         #     code "New-Item -ItemType Directory -Force -Path C:\mydir"
         #     guard_interpreter :powershell_script
@@ -34,7 +34,7 @@ module RuboCop
         #     guard_interpreter :powershell_script
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   powershell_script 'Create Directory' do
         #     code "New-Item -ItemType Directory -Force -Path C:\mydir"
         #   end

--- a/lib/rubocop/cop/chef/modernize/powershell_install_package.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_install_package.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   powershell_script 'Expand website' do
         #     code 'Install-Package -Name docker'
         #   end
         #
-        #  #### correct
+        #  ### correct
         #  powershell_package 'docker'
         #
         class PowershellInstallPackage < Base

--- a/lib/rubocop/cop/chef/modernize/powershell_install_windowsfeature.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_install_windowsfeature.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   powershell_script 'Install Feature' do
         #     code 'Install-WindowsFeature -Name "Net-framework-Core"'
         #   end
         #
-        #  #### correct
+        #  ### correct
         #  windows_feature 'Net-framework-Core' do
         #    action :install
         #    install_method :windows_feature_powershell

--- a/lib/rubocop/cop/chef/modernize/property_with_name_attribute.rb
+++ b/lib/rubocop/cop/chef/modernize/property_with_name_attribute.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :bob, String, name_attribute: true
         #
-        #   #### correct
+        #   ### correct
         #   property :bob, String, name_property: true
         #
         class PropertyWithNameAttribute < Base

--- a/lib/rubocop/cop/chef/modernize/provides_initializer.rb
+++ b/lib/rubocop/cop/chef/modernize/provides_initializer.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   def initialize(*args)
         #     super
         #     @provides = :foo
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   provides :foo
         #
         class ProvidesFromInitialize < Base

--- a/lib/rubocop/cop/chef/modernize/resource_name_initializer.rb
+++ b/lib/rubocop/cop/chef/modernize/resource_name_initializer.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   def initialize(*args)
         #     super
         #     @resource_name = :foo
         #   end
         #
-        #  #### correct
+        #  ### correct
         #  resource_name :create
 
         class ResourceNameFromInitialize < Base

--- a/lib/rubocop/cop/chef/modernize/resource_set_or_return.rb
+++ b/lib/rubocop/cop/chef/modernize/resource_set_or_return.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #    def severity(arg = nil)
         #      set_or_return(
         #        :severity, arg,
@@ -32,7 +32,7 @@ module RuboCop
         #      )
         #    end
         #
-        #   #### correct
+        #   ### correct
         #   property :severity, String
         #
         class SetOrReturnInResources < Base

--- a/lib/rubocop/cop/chef/modernize/resource_with_attributes.rb
+++ b/lib/rubocop/cop/chef/modernize/resource_with_attributes.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   attribute :something, String
         #
         #   action :create do
         #     # some action code because we're in a custom resource
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   property :something, String
         #
         #   action :create do

--- a/lib/rubocop/cop/chef/modernize/respond_to_compile_time.rb
+++ b/lib/rubocop/cop/chef/modernize/respond_to_compile_time.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   chef_gem 'ultradns-sdk' do
         #     compile_time true if Chef::Resource::ChefGem.method_defined?(:compile_time)
         #     action :nothing
@@ -39,7 +39,7 @@ module RuboCop
         #     action :nothing
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   chef_gem 'ultradns-sdk' do
         #     compile_time true
         #     action :nothing

--- a/lib/rubocop/cop/chef/modernize/respond_to_metadata.rb
+++ b/lib/rubocop/cop/chef/modernize/respond_to_metadata.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   chef_version '>= 13' if respond_to?(:chef_version)
         #   chef_version '>= 13' if defined?(chef_version)
         #   chef_version '>= 13' unless defined?(Ridley::Chef::Cookbook::Metadata)
@@ -31,7 +31,7 @@ module RuboCop
         #     chef_version '>= 13'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   chef_version '>= 13'
         #
         class RespondToInMetadata < Base

--- a/lib/rubocop/cop/chef/modernize/respond_to_provides.rb
+++ b/lib/rubocop/cop/chef/modernize/respond_to_provides.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   provides :foo if respond_to?(:provides)
         #
         #   provides :foo if defined? provides
         #
-        #   #### correct
+        #   ### correct
         #   provides :foo
         #
         class RespondToProvides < Base

--- a/lib/rubocop/cop/chef/modernize/respond_to_resource_name.rb
+++ b/lib/rubocop/cop/chef/modernize/respond_to_resource_name.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   resource_name :foo if respond_to?(:resource_name)
         #
-        #   #### correct
+        #   ### correct
         #   resource_name :foo
         #
         class RespondToResourceName < Base

--- a/lib/rubocop/cop/chef/modernize/sc_windows_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/sc_windows_resource.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   sc_windows 'chef-client' do
         #     path "C:\\opscode\\chef\\bin"
         #     action :create
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   windows_service 'chef-client' do
         #     action :create
         #     binary_path_name "C:\\opscode\\chef\\bin"

--- a/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   seven_zip_archive "C:\file.zip" do
         #     path 'C:\expand_here'
         #   end

--- a/lib/rubocop/cop/chef/modernize/shell_out_helper.rb
+++ b/lib/rubocop/cop/chef/modernize/shell_out_helper.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   Mixlib::ShellOut.new('foo').run_command
         #
-        #   #### correct
+        #   ### correct
         #   shell_out('foo')
         #
         class ShellOutHelper < Base

--- a/lib/rubocop/cop/chef/modernize/shellouts_to_chocolatey.rb
+++ b/lib/rubocop/cop/chef/modernize/shellouts_to_chocolatey.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   execute 'install package foo' do
         #     command "choco install --source=artifactory \"foo\" -y --no-progress --ignore-package-exit-codes"
         #   end

--- a/lib/rubocop/cop/chef/modernize/simplify_apt_ppa_setup.rb
+++ b/lib/rubocop/cop/chef/modernize/simplify_apt_ppa_setup.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #  #### incorrect
+        #  ### incorrect
         #    apt_repository 'atom-ppa' do
         #      uri 'http://ppa.launchpad.net/webupd8team/atom/ubuntu'
         #      components ['main']
@@ -31,7 +31,7 @@ module RuboCop
         #      key 'C2518248EEA14886'
         #    end
         #
-        #  #### correct
+        #  ### correct
         #    apt_repository 'atom-ppa' do
         #      uri 'ppa:webupd8team/atom'
         #      components ['main']

--- a/lib/rubocop/cop/chef/modernize/sysctl_param_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/sysctl_param_resource.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   sysctl_param 'fs.aio-max-nr' do
         #     value '1048576'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   sysctl 'fs.aio-max-nr' do
         #     value '1048576'
         #   end

--- a/lib/rubocop/cop/chef/modernize/unnecessary_mixlib_shellout_require.rb
+++ b/lib/rubocop/cop/chef/modernize/unnecessary_mixlib_shellout_require.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   require 'mixlib/shellout'
         #
         class UnnecessaryMixlibShelloutRequire < Base

--- a/lib/rubocop/cop/chef/modernize/use_chef_language_cloud_helpers.rb
+++ b/lib/rubocop/cop/chef/modernize/use_chef_language_cloud_helpers.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node['cloud']['provider'] == 'alibaba'
         #   node['cloud']['provider'] == 'ec2'
         #   node['cloud']['provider'] == 'gce'
@@ -35,7 +35,7 @@ module RuboCop
         #   node['cloud']['provider'] == 'digital_ocean'
         #   node['cloud']['provider'] == 'softlayer'
         #
-        #   #### correct
+        #   ### correct
         #   alibaba?
         #   ec2?
         #   gce?

--- a/lib/rubocop/cop/chef/modernize/use_chef_language_env_helpers.rb
+++ b/lib/rubocop/cop/chef/modernize/use_chef_language_env_helpers.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   ENV['CI']
         #   ENV['TEST_KITCHEN']
         #
-        #   #### correct
+        #   ### correct
         #   ci?
         #   kitchen?
         #

--- a/lib/rubocop/cop/chef/modernize/use_chef_language_systemd_helper.rb
+++ b/lib/rubocop/cop/chef/modernize/use_chef_language_systemd_helper.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node['init_package'] == 'systemd'
         #
-        #   #### correct
+        #   ### correct
         #   systemd?
         #
         class UseChefLanguageSystemdHelper < Base

--- a/lib/rubocop/cop/chef/modernize/use_multipackage_installs.rb
+++ b/lib/rubocop/cop/chef/modernize/use_multipackage_installs.rb
@@ -23,14 +23,14 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   %w(bmon htop vim curl).each do |pkg|
         #     package pkg do
         #       action :install
         #     end
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   package %w(bmon htop vim curl)
         #
         class UseMultipackageInstalls < Base

--- a/lib/rubocop/cop/chef/modernize/use_require_relative.rb
+++ b/lib/rubocop/cop/chef/modernize/use_require_relative.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   require File.expand_path('../../libraries/helpers', __FILE__)
         #
-        #   #### correct
+        #   ### correct
         #   require_relative '../libraries/helpers'
         #
         class UseRequireRelative < Base

--- a/lib/rubocop/cop/chef/modernize/whyrun_supported_true.rb
+++ b/lib/rubocop/cop/chef/modernize/whyrun_supported_true.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   def whyrun_supported?
         #    true
         #   end

--- a/lib/rubocop/cop/chef/modernize/windows_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_default_recipe.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include_recipe 'windows::default'
         #   include_recipe 'windows'
         #

--- a/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_registry_uac.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   registry_key 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' do
         #     values [{ name: 'EnableLUA', type: :dword, data: 0 },
         #             { name: 'PromptOnSecureDesktop', type: :dword, data: 0 },
@@ -32,7 +32,7 @@ module RuboCop
         #     action :create
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   windows_uac 'Set Windows UAC settings' do
         #     enable_uac false
         #     prompt_on_secure_desktop true

--- a/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   windows_zipfile 'C:\\files\\' do
         #     source 'C:\\Temp\\file.zip'
         #   end

--- a/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   zipfile "C:\file.zip" do
         #     path 'C:\expand_here'
         #   end

--- a/lib/rubocop/cop/chef/modernize/zypper_repo.rb
+++ b/lib/rubocop/cop/chef/modernize/zypper_repo.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   zypper_repo 'apache' do
         #     baseurl 'http://download.opensuse.org/repositories/Apache'
         #     path '/openSUSE_Leap_42.2'
@@ -31,7 +31,7 @@ module RuboCop
         #     priority '100'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   zypper_repository 'apache' do
         #     baseurl 'http://download.opensuse.org/repositories/Apache'
         #     path '/openSUSE_Leap_42.2'

--- a/lib/rubocop/cop/chef/redundant/apt_repository_distribution_default.rb
+++ b/lib/rubocop/cop/chef/redundant/apt_repository_distribution_default.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   apt_repository 'my repo' do
         #     uri 'http://packages.example.com/debian'
         #     components %w(stable main)
@@ -31,7 +31,7 @@ module RuboCop
         #     distribution node['lsb']['codename']
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   apt_repository 'my repo' do
         #     uri 'http://packages.example.com/debian'
         #     components %w(stable main)

--- a/lib/rubocop/cop/chef/redundant/apt_repository_notifies_apt_update.rb
+++ b/lib/rubocop/cop/chef/redundant/apt_repository_notifies_apt_update.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   apt_repository 'my repo' do
         #     uri 'http://packages.example.com/debian'
         #     components %w(stable main)
@@ -31,7 +31,7 @@ module RuboCop
         #     notifies :run, 'execute[apt-get update]', :immediately
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   apt_repository 'my repo' do
         #     uri 'http://packages.example.com/debian'
         #     components %w(stable main)

--- a/lib/rubocop/cop/chef/redundant/attribute_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/attribute_metadata.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect in metadata.rb:
+        #   ### incorrect in metadata.rb:
         #
         #    attribute 'zookeeper_bridge/server',
         #              display_name: 'zookeeper server',

--- a/lib/rubocop/cop/chef/redundant/conflicts_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/conflicts_metadata.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect in metadata.rb:
+        #   ### incorrect in metadata.rb:
         #
         #   conflicts "another_cookbook"
         #

--- a/lib/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions.rb
+++ b/lib/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   allowed_actions [:create, :remove]
         #
         #   # also bad

--- a/lib/rubocop/cop/chef/redundant/double_compile_time.rb
+++ b/lib/rubocop/cop/chef/redundant/double_compile_time.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   chef_gem 'deep_merge' do
         #     action :nothing
         #     compile_time true
         #   end.run_action(:install)
         #
-        #   #### correct
+        #   ### correct
         #   chef_gem 'deep_merge' do
         #     action :install
         #     compile_time true

--- a/lib/rubocop/cop/chef/redundant/grouping_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/grouping_metadata.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   grouping 'windows_log_rotate', title: 'Demonstration cookbook with code to switch loggers'
         #
         class GroupingMetadata < Base

--- a/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/long_description_metadata.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   long_description 'this is my cookbook and this description will never be seen'
         #
         class LongDescriptionMetadata < Base

--- a/lib/rubocop/cop/chef/redundant/multiple_platform_checks.rb
+++ b/lib/rubocop/cop/chef/redundant/multiple_platform_checks.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   platform?('redhat') || platform?('ubuntu')
         #   platform_family?('debian') || platform_family?('rhel')
         #
-        #   #### correct
+        #   ### correct
         #   platform?('redhat', 'ubuntu')
         #   platform_family?('debian', 'rhel')
         #

--- a/lib/rubocop/cop/chef/redundant/name_property_and_required.rb
+++ b/lib/rubocop/cop/chef/redundant/name_property_and_required.rb
@@ -51,11 +51,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :config_file, String, required: true, name_property: true
         #   attribute :config_file, String, required: true, name_attribute: true
         #
-        #   #### correct
+        #   ### correct
         #   property :config_file, String, required: true
         #
         class NamePropertyIsRequired < Base

--- a/lib/rubocop/cop/chef/redundant/ohai_attribute_to_string.rb
+++ b/lib/rubocop/cop/chef/redundant/ohai_attribute_to_string.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node['platform'].to_s
         #   node['platform_family'].to_s
         #   node['platform_version'].to_s
@@ -32,7 +32,7 @@ module RuboCop
         #   node['os'].to_s
         #   node['name'].to_s
         #
-        #   #### correct
+        #   ### correct
         #   node['platform']
         #   node['platform_family']
         #   node['platform_version']

--- a/lib/rubocop/cop/chef/redundant/property_splat_regex.rb
+++ b/lib/rubocop/cop/chef/redundant/property_splat_regex.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :config_file, String, regex: /.*/
         #   attribute :config_file, String, regex: /.*/
         #
-        #   #### correct
+        #   ### correct
         #   property :config_file, String
         #   attribute :config_file, String
         #

--- a/lib/rubocop/cop/chef/redundant/property_with_default_and_required.rb
+++ b/lib/rubocop/cop/chef/redundant/property_with_default_and_required.rb
@@ -26,10 +26,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :bob, String, required: true, default: 'foo'
         #
-        #   #### correct
+        #   ### correct
         #   property :bob, String, required: true
         #
         class PropertyWithRequiredAndDefault < Base

--- a/lib/rubocop/cop/chef/redundant/provides_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/provides_metadata.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect in metadata.rb:
+        #   ### incorrect in metadata.rb:
         #
         #   provides "some_thing"
         #

--- a/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/recipe_metadata.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   recipe 'openldap::default', 'Install and configure OpenLDAP'
         #
         #

--- a/lib/rubocop/cop/chef/redundant/replaces_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/replaces_metadata.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect in metadata.rb:
+        #   ### incorrect in metadata.rb:
         #
         #   replaces "another_cookbook"
         #

--- a/lib/rubocop/cop/chef/redundant/resource_with_nothing_action.rb
+++ b/lib/rubocop/cop/chef/redundant/resource_with_nothing_action.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   action :nothing
         #     # let's do nothing
         #   end

--- a/lib/rubocop/cop/chef/redundant/sensitive_property_in_resource.rb
+++ b/lib/rubocop/cop/chef/redundant/sensitive_property_in_resource.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        # #### incorrect
+        # ### incorrect
         # property :sensitive, [true, false], default: false
         #
         class SensitivePropertyInResource < Base

--- a/lib/rubocop/cop/chef/redundant/string_property_with_nil_default.rb
+++ b/lib/rubocop/cop/chef/redundant/string_property_with_nil_default.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :config_file, String, default: nil
         #   property :config_file, [String, NilClass], default: nil
         #
-        #   #### correct
+        #   ### correct
         #   property :config_file, String
         #   property :config_file, [String, NilClass]
         #

--- a/lib/rubocop/cop/chef/redundant/suggests_metadata.rb
+++ b/lib/rubocop/cop/chef/redundant/suggests_metadata.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect in metadata.rb:
+        #   ### incorrect in metadata.rb:
         #
         #   suggests "another_cookbook"
         #

--- a/lib/rubocop/cop/chef/redundant/unnecessary_desired_state.rb
+++ b/lib/rubocop/cop/chef/redundant/unnecessary_desired_state.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :foo, String, desired_state: true
         #   attribute :foo, String, desired_state: true
         #
-        #   #### correct
+        #   ### correct
         #   property :foo, String
         #   attribute :foo, String
         #

--- a/lib/rubocop/cop/chef/redundant/unnecessary_name_property.rb
+++ b/lib/rubocop/cop/chef/redundant/unnecessary_name_property.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :name, String
         #   property :name, String, name_property: true
         #   attribute :name, kind_of: String

--- a/lib/rubocop/cop/chef/redundant/use_create_if_missing.rb
+++ b/lib/rubocop/cop/chef/redundant/use_create_if_missing.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   cookbook_file '/logs/foo/error.log' do
         #     source 'error.log'
         #     owner 'root'
@@ -41,7 +41,7 @@ module RuboCop
         #     not_if { ::File.exist?('/foo/bar') }
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   cookbook_file '/logs/foo/error.log' do
         #     source 'error.log'
         #     owner 'root'

--- a/lib/rubocop/cop/chef/security/ssh_private_key.rb
+++ b/lib/rubocop/cop/chef/security/ssh_private_key.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   file '/Users/bob_bobberson/.ssh/id_rsa' do
         #     content '-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----'
         #     mode '600'

--- a/lib/rubocop/cop/chef/sharing/default_maintainer_metadata.rb
+++ b/lib/rubocop/cop/chef/sharing/default_maintainer_metadata.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   maintainer 'YOUR_COMPANY_NAME'
         #   maintainer_email 'YOUR_EMAIL'
         #   maintainer 'The Authors'
         #   maintainer_email 'you@example.com'
-        #   #### correct
+        #   ### correct
         #   maintainer 'Bob Bobberson'
         #   maintainer_email 'bob@bobberson.com'
         #

--- a/lib/rubocop/cop/chef/sharing/empty_metadata_field.rb
+++ b/lib/rubocop/cop/chef/sharing/empty_metadata_field.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   license ''
         #
-        #   #### correct
+        #   ### correct
         #   license 'Apache-2.0'
         #
         class EmptyMetadataField < Base

--- a/lib/rubocop/cop/chef/sharing/include_property_descriptions.rb
+++ b/lib/rubocop/cop/chef/sharing/include_property_descriptions.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :foo, String
         #
-        #   #### correct
+        #   ### correct
         #   property :foo, String, description: "Set the important thing to..."
         #
         class IncludePropertyDescriptions < Base

--- a/lib/rubocop/cop/chef/sharing/include_resource_descriptions.rb
+++ b/lib/rubocop/cop/chef/sharing/include_resource_descriptions.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### correct
+        #   ### correct
         #   resource_name :foo
         #   description "The foo resource is used to do..."
         #

--- a/lib/rubocop/cop/chef/sharing/include_resource_examples.rb
+++ b/lib/rubocop/cop/chef/sharing/include_resource_examples.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### correct
+        #   ### correct
         #   examples <<~DOC
         #     **Specify a global domain value**
         #

--- a/lib/rubocop/cop/chef/sharing/insecure_cookbook_url.rb
+++ b/lib/rubocop/cop/chef/sharing/insecure_cookbook_url.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   source_url 'http://github.com/something/something'
         #   source_url 'http://www.github.com/something/something'
         #   source_url 'http://www.gitlab.com/something/something'
         #   source_url 'http://gitlab.com/something/something'
         #
-        #   #### correct
+        #   ### correct
         #   source_url 'http://github.com/something/something'
         #   source_url 'http://gitlab.com/something/something'
         #

--- a/lib/rubocop/cop/chef/sharing/invalid_license_string.rb
+++ b/lib/rubocop/cop/chef/sharing/invalid_license_string.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   license 'Apache 2.0'
         #
-        #   #### correct
+        #   ### correct
         #   license 'Apache-2.0'
         #   license 'all rights reserved'
         #

--- a/lib/rubocop/cop/chef/style/attribute_keys.rb
+++ b/lib/rubocop/cop/chef/style/attribute_keys.rb
@@ -24,19 +24,19 @@ module RuboCop
         #
         # @example when configuration is `EnforcedStyle: symbols`
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node['foo']
         #   node["foo"]
         #
-        #   #### correct
+        #   ### correct
         #   node[:foo]
         #
         # @example when configuration is `EnforcedStyle: strings`
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node[:foo]
         #
-        #   #### correct
+        #   ### correct
         #   node['foo']
         #   node["foo"]
         #

--- a/lib/rubocop/cop/chef/style/chef_whaaat.rb
+++ b/lib/rubocop/cop/chef/style/chef_whaaat.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   Chef makes software
         #   Chef configures your systems
         #
-        #   #### correct
+        #   ### correct
         #   Chef Software makes software
         #   Chef Infra configures your systems
         #

--- a/lib/rubocop/cop/chef/style/comments_copyright_format.rb
+++ b/lib/rubocop/cop/chef/style/comments_copyright_format.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   Copyright:: 2013-2022 Opscode, Inc.
         #   Copyright:: 2013-2022 Chef Inc.
         #   Copyright:: 2013-2022 Chef Software Inc.
@@ -32,7 +32,7 @@ module RuboCop
         #   Copyright:: Tim Smith
         #   Copyright:: Copyright (c) 2015-2022 Chef Software, Inc.
         #
-        #   #### correct
+        #   ### correct
         #   Copyright:: 2013-2022 Chef Software, Inc.
         #   Copyright:: 2013-2022 Tim Smith
         #   Copyright:: 2019 37Signals, Inc.

--- a/lib/rubocop/cop/chef/style/comments_default_copyright.rb
+++ b/lib/rubocop/cop/chef/style/comments_default_copyright.rb
@@ -23,11 +23,11 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   Copyright:: 2019 YOUR_NAME
         #   Copyright:: 2019 YOUR_COMPANY_NAME
         #
-        #   #### correct
+        #   ### correct
         #   Copyright:: 2019 Tim Smith
         #   Copyright:: 2019 Chef Software, Inc.
         #

--- a/lib/rubocop/cop/chef/style/comments_format.rb
+++ b/lib/rubocop/cop/chef/style/comments_format.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   Copyright 2013-2016 Chef Software, Inc.
         #   Recipe default.rb
         #   Attributes default.rb
@@ -32,7 +32,7 @@ module RuboCop
         #   Cookbook Name:: Tomcat
         #   Attributes File:: default
         #
-        #   #### correct
+        #   ### correct
         #   Copyright:: 2013-2016 Chef Software, Inc.
         #   Recipe:: default.rb
         #   Attributes:: default.rb

--- a/lib/rubocop/cop/chef/style/file_mode.rb
+++ b/lib/rubocop/cop/chef/style/file_mode.rb
@@ -22,7 +22,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   remote_directory '/etc/my.conf' do
         #     content 'some content'
         #     mode 0600
@@ -36,7 +36,7 @@ module RuboCop
         #     action :create
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   remote_directory '/etc/my.conf' do
         #     content 'some content'
         #     mode '600'

--- a/lib/rubocop/cop/chef/style/immediate_notification_timing.rb
+++ b/lib/rubocop/cop/chef/style/immediate_notification_timing.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, 'service[apache]', :immediate
         #   end
         #
-        #   #### correct
+        #   ### correct
         #
         #   template '/etc/www/configures-apache.conf' do
         #     notifies :restart, 'service[apache]', :immediately

--- a/lib/rubocop/cop/chef/style/include_recipe_with_parentheses.rb
+++ b/lib/rubocop/cop/chef/style/include_recipe_with_parentheses.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   include_recipe('foo::bar')
         #
-        #   #### correct
+        #   ### correct
         #   include_recipe 'foo::bar'
         #
         class IncludeRecipeWithParentheses < Base

--- a/lib/rubocop/cop/chef/style/negating_only_if.rb
+++ b/lib/rubocop/cop/chef/style/negating_only_if.rb
@@ -23,12 +23,12 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   package 'legacy-sysv-deps' do
         #     only_if { !systemd }
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   package 'legacy-sysv-deps' do
         #     not_if { systemd }
         #   end

--- a/lib/rubocop/cop/chef/style/overly_complex_supports_depends_metadata.rb
+++ b/lib/rubocop/cop/chef/style/overly_complex_supports_depends_metadata.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #
         #   %w( debian ubuntu ).each do |os|
         #     supports os
@@ -33,7 +33,7 @@ module RuboCop
         #     depends cb
         #   end
         #
-        #   #### correct
+        #   ### correct
         #
         #   supports 'debian'
         #   supports 'ubuntu'

--- a/lib/rubocop/cop/chef/style/simplify_platform_major_version_check.rb
+++ b/lib/rubocop/cop/chef/style/simplify_platform_major_version_check.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node['platform_version'].split('.').first
         #   node['platform_version'].split('.')[0]
         #   node['platform_version'].split('.').first.to_i
         #   node['platform_version'].split('.')[0].to_i
         #
-        #   #### correct
+        #   ### correct
         #
         #   # check to see if we're on RHEL 7 on a RHEL 7.6 node where node['platform_version] is 7.6.1810
         #   if node['platform_version'].to_i == 7

--- a/lib/rubocop/cop/chef/style/true_false_resource_properties.rb
+++ b/lib/rubocop/cop/chef/style/true_false_resource_properties.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   property :foo, [TrueClass, FalseClass]
         #
-        #   #### correct
+        #   ### correct
         #   property :foo, [true, false]
         #
         class TrueClassFalseClassResourceProperties < Base

--- a/lib/rubocop/cop/chef/style/unnecessary_os_check.rb
+++ b/lib/rubocop/cop/chef/style/unnecessary_os_check.rb
@@ -23,13 +23,13 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node['os'] == 'darwin'
         #   node['os'] == 'windows'
         #   node['os'].eql?('aix')
         #   %w(netbsd openbsd freebsd).include?(node['os'])
         #
-        #   #### correct
+        #   ### correct
         #   platform_family?('mac_os_x')
         #   platform_family?('windows')
         #   platform_family?('aix')

--- a/lib/rubocop/cop/chef/style/unnecessary_platform_case_statement.rb
+++ b/lib/rubocop/cop/chef/style/unnecessary_platform_case_statement.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   case node['platform']
         #   when 'ubuntu'
         #     log "We're on Ubuntu"
@@ -35,7 +35,7 @@ module RuboCop
         #     include_recipe 'yum'
         #   end
         #
-        #   #### correct
+        #   ### correct
         #   if platform?('ubuntu')
         #     log "We're on Ubuntu"
         #     apt_update

--- a/lib/rubocop/cop/chef/style/use_platform_helpers.rb
+++ b/lib/rubocop/cop/chef/style/use_platform_helpers.rb
@@ -23,7 +23,7 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   node['platform'] == 'ubuntu'
         #   node['platform_family'] == 'debian'
         #   node['platform'] != 'ubuntu'
@@ -31,7 +31,7 @@ module RuboCop
         #   %w(rhel suse).include?(node['platform_family'])
         #   node['platform'].eql?('ubuntu')
         #
-        #   #### correct
+        #   ### correct
         #   platform?('ubuntu')
         #   !platform?('ubuntu')
         #   platform_family?('debian')

--- a/lib/rubocop/cop/inspec/deprecation/attribute_default.rb
+++ b/lib/rubocop/cop/inspec/deprecation/attribute_default.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   login_defs_umask = input('login_defs_umask', default: '077', description: 'Default umask to set in login.defs')
         #
-        #   #### correct
+        #   ### correct
         #   login_defs_umask = input('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
         #
         class AttributeDefault < Base

--- a/lib/rubocop/cop/inspec/deprecation/attribute_helper.rb
+++ b/lib/rubocop/cop/inspec/deprecation/attribute_helper.rb
@@ -23,10 +23,10 @@ module RuboCop
         #
         # @example
         #
-        #   #### incorrect
+        #   ### incorrect
         #   login_defs_umask = attribute('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
         #
-        #   #### correct
+        #   ### correct
         #   login_defs_umask = input('login_defs_umask', value: '077', description: 'Default umask to set in login.defs')
         #
         class AttributeHelper < Base

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -41,8 +41,8 @@ begin
 
     def examples(code_object)
       ex = code_object.tags('example').first.text
-      ex.gsub!('#### incorrect', "#### incorrect\n\n```ruby")
-      ex.gsub!("\n#### correct", "```\n\n#### correct\n\n```ruby")
+      ex.gsub!('### incorrect', "### incorrect\n\n```ruby")
+      ex.gsub!("\n### correct", "```\n\n### correct\n\n```ruby")
       ex << "\n```"
     rescue NoMethodError
       nil


### PR DESCRIPTION
Correct the heading levels in examples in the output yaml files for documentation.

## Description

Currently the YAML files output from the `generate_cops_yml_documentation` rake task have H4 headings in the **correct** and **incorrect** example headings (for example https://docs.chef.io/workstation/cookstyle/chef_correctness_blockguardwithonlystring/#examples), but they should be H3. This changes them from H4 --> H3.

- update the heading levels in the cop ruby files
- update the rake task
- update the output yaml files

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
