### PR TITLE
Add chefstyle library file for Rake backwards compatibility

### DIFF
--- a/bin/cookstyle
+++ b/bin/cookstyle
@@ -1,16 +1,14 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-if ARGV.include?('--chefstyle')
-  ARGV.delete('--chefstyle')
-  module Cookstyle
-    CHEFSTYLE_CONFIG = true
-  end
-end
-
 $LOAD_PATH.unshift File.join(__dir__, %w(.. lib))
 
-require 'cookstyle'
+if ARGV.include?('--chefstyle')
+  ARGV.delete('--chefstyle')
+  require 'cookstyle/chefstyle'
+else
+  require 'cookstyle'
+end
 
 # force the fail level to :convention so that we can set all our new rules to
 # the lowest level of :refactor without failing everyone's CI jobs

--- a/lib/cookstyle/chefstyle.rb
+++ b/lib/cookstyle/chefstyle.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+module Cookstyle
+  CHEFSTYLE_CONFIG = true
+end
+require_relative '../cookstyle'


### PR DESCRIPTION
## Description
There's a decent amount of Rake code that uses `require "chefstyle"` to set the defaults for RuboCop (eg
https://github.com/chef/ohai/blob/6d64237f9987c3bf51805e19884e6e710c3a40f6/Rakefile#L19), and rather than doing surgery on each repo's Rakefile, it'd be easier to keep that same behavior for loading the configuration and cops. With this change a migration involving Rake should only involve a Gemfile update and changing `require "chefstyle"` to `require "cookstyle/chefstyle"`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
