### PR TITLE
Fix #970: Add extra stub to pass ConfigValidator

### DIFF
--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -39,7 +39,10 @@ Dir.glob(__dir__ + '/rubocop/cop/**/*.rb') do |file|
   require_relative file # not actually relative but require_relative is faster
 end
 
-# stub default value of TargetChefVersion to avoid STDERR noise
-RuboCop::ConfigLoader.default_configuration['AllCops']['TargetChefVersion'] = '~'
+# stub default value of TargetChefVersion to avoid STDERR noise when ConfigLoader.configuration_from_file runs
+RuboCop::ConfigLoader.default_configuration['AllCops']['TargetChefVersion'] ||= nil
 
 RuboCop::ConfigLoader.default_configuration = RuboCop::ConfigLoader.configuration_from_file(Cookstyle.config)
+
+# re-stub TargetChefVersion to avoid STDERR noise on *next* configuration load
+RuboCop::ConfigLoader.default_configuration['AllCops']['TargetChefVersion'] ||= nil


### PR DESCRIPTION
We need to pass TargetChefVersion into the default config, otherwise the [ConfigValidator#each_invalid_parameter method
complains](https://github.com/rubocop/rubocop/blob/2fee8552c6c8237950d8df7ec857c49f308a6d34/lib/rubocop/config_validator.rb#L198)

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
