### PR TITLE
[#946 and #954] Add missing tests

### DIFF
--- a/spec/rubocop/cop/chef/modernize/cron_d_file_or_template_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/cron_d_file_or_template_spec.rb
@@ -112,6 +112,24 @@ describe RuboCop::Cop::Chef::Modernize::CronDFileOrTemplate, :config do
     RUBY
   end
 
+  # https://github.com/chef/cookstyle/issues/946
+  it 'does not register an offense when path is /etc/cron.deny' do
+    expect_no_offenses(<<~RUBY)
+      file '/etc/cron.deny' do
+        action :delete
+      end
+    RUBY
+  end
+
+  # https://github.com/chef/cookstyle/issues/954
+  it 'does not register an offense when path is /etc/cron.daily/foo' do
+    expect_no_offenses(<<~RUBY)
+      file '/etc/cron.daily/foo' do
+        action :delete
+      end
+    RUBY
+  end
+
   it 'does not register an offense when the resource name is a variable or method' do
     expect_no_offenses(<<~RUBY)
       template foo do


### PR DESCRIPTION
#959 fixed the `/etc/cron.deny` bug in #946 and `/etc/cron.daily` bug in #954, but regression tests were missing

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
