### PR TITLE
Fix commented out cops due to renames

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :profiling do
 end
 
 group :rubocop_gems do
-  gem 'rubocop-performance'
+  gem 'rubocop-performance', '= 1.19.0'
 end
 
 group :development do

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -112,14 +112,12 @@ Lint/ShadowedException:
   Enabled: true
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
-Lint/RedundantStringCoercion:
-  Enabled: true
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 Lint/UnifiedInteger:
   Enabled: true
-# Lint/UnneededSplatExpansion: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RedundantSplatExpansion:
+  Enabled: true
 Lint/UnreachableCode:
   Enabled: true
 Lint/UriEscapeUnescape:
@@ -476,11 +474,11 @@ Style/TrailingUnderscoreVariable:
   Enabled: true
 Layout/TrailingWhitespace:
   Enabled: true
-# Style/UnneededCapitalW: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Style/RedundantCapitalW:
+  Enabled: true
 Style/RedundantInterpolation:
   Enabled: false # buggy: https://github.com/rubocop-hq/rubocop/issues/6099
-#Style/UnneededPercentQ:  # would like to enable this one but its buggy as of 0.35.1
+#Style/RedundantPercentQ:  # would like to enable this one but its buggy as of 0.35.1
 #  Enabled: true
 Naming/VariableName:
   Enabled: true

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -126,8 +126,8 @@ Lint/UselessAccessModifier:
   Enabled: true
 Lint/UselessAssignment:
   Enabled: true
-# Lint/UselessComparison: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
 Lint/UselessElseWithoutRescue:
   Enabled: true
 Lint/UselessSetterCall:

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -53,8 +53,8 @@ Lint/DuplicateCaseCondition:
   Enabled: true
 Lint/DuplicateMethods:
   Enabled: true
-# Lint/DuplicatedKey: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/DuplicateHashKey:
+  Enabled: true
 Lint/EachWithObjectArgument:
   Enabled: true
 Lint/ElseLayout:
@@ -90,8 +90,8 @@ Lint/LiteralInInterpolation:
   Enabled: true
 Lint/Loop:
   Enabled: true
-# Lint/MultipleCompare: TODO broken with rubocop 1.25.1 move
-#  Enabled: true
+Lint/MultipleComparison:
+  Enabled: true
 Lint/NestedMethodDefinition:
   Enabled: true
 Lint/NextWithoutAccumulator:
@@ -114,8 +114,8 @@ Lint/ShadowedException:
   Enabled: true
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
-# Lint/StringConversionInInterpolation: TODO broken with rubocop 1.25.1 move
-#  Enabled: true
+Lint/RedundantStringCoercion:
+  Enabled: true
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 Lint/UnifiedInteger:
@@ -196,24 +196,23 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-
 #
 # Style/Naming/Layout
 #
 
 Layout/AccessModifierIndentation:
   Enabled: true
-# Layout/AlignArguments: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-#   EnforcedStyle: with_fixed_indentation
-# Layout/AlignParameters: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-#   EnforcedStyle: with_fixed_indentation
+Layout/ArgumentAlignment:
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
+Layout/ParameterAlignment:
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
 # the "ignore_implict" is here for keyword args in method calls which are
 # "implicit" hashes, and those should not be treated like normal hashes
-# Layout/AlignHash: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-#   EnforcedLastArgumentHashStyle: ignore_implicit
+Layout/HashAlignment:
+  Enabled: true
+  EnforcedLastArgumentHashStyle: ignore_implicit
 Style/AndOr:
   Enabled: true
 Style/ArrayJoin:
@@ -290,13 +289,13 @@ Style/IfUnlessModifierOfIfUnless:
   Enabled: true
 Style/IfWithSemicolon:
   Enabled: true
-# Layout/IndentAssignment: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-# Layout/IndentFirstArgument: TODO broken with rubocop 1.25.1 move
-#   EnforcedStyle: consistent
-#   Enabled: true
-# Layout/IndentHeredoc: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/AssignmentIndentation:
+  Enabled: true
+Layout/FirstArgumentIndentation:
+  EnforcedStyle: consistent
+  Enabled: true
+Layout/HeredocIndentation:
+  Enabled: true
 Layout/IndentationConsistency:
   Enabled: true
 Layout/IndentationWidth:
@@ -464,8 +463,8 @@ Style/SymbolProc:
   Enabled: true
 Layout/IndentationStyle:
   Enabled: true
-# Layout/TrailingBlankLines: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/TrailingEmptyLines:
+  Enabled: true
 Style/TrailingCommaInArguments:
   Enabled: true
 # rubocop's default gets this completely backwards

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -70,8 +70,6 @@ Lint/EmptyWhen:
 Layout/EndAlignment:
   Enabled: true
   AutoCorrect: true
-# Lint/EndInMethod: TODO broken with rubocop 1.25.1 move
-#  Enabled: true
 Lint/EnsureReturn:
   Enabled: true
 Lint/FloatOutOfRange:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1036,7 +1036,7 @@ Chef/Deprecations/DeprecatedPlatformMethods:
     - '**/providers/*.rb'
 
 Chef/Deprecations/DeprecatedChefSpecPlatform:
-  Description: Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
+  Description: Use currently supported platforms in ChefSpec listed at https://github.com/chef/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
   StyleGuide: 'chef_deprecations_deprecatedchefspecplatform'
   Enabled: true
   VersionAdded: '5.20.0'

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2936,8 +2936,8 @@ Style/RedundantConditional:
   Enabled: true
 
 # catches people writing a regex check wrong
-# Lint/RegexpInCondition: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RegexpAsCondition:
+  Enabled: true
 
 # Avoids pointless / complex code
 Lint/RedundantWithObject:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2747,8 +2747,8 @@ Lint/UselessAccessModifier:
   Enabled: true
 Lint/UselessAssignment:
   Enabled: true
-# Lint/UselessComparison: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
 Lint/UselessElseWithoutRescue:
   Enabled: true
 Lint/UselessSetterCall:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2536,8 +2536,8 @@ Style/Not:
   Enabled: true
 Style/OneLineConditional:
   Enabled: true
-# Naming/OpMethod: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Naming/BinaryOperatorParameterName:
+  Enabled: true
 Style/OptionalArguments:
   Enabled: true
 Style/ParallelAssignment:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2641,12 +2641,12 @@ Style/TrivialAccessors:
   Enabled: true
 Style/UnlessElse:
   Enabled: true
-# Style/UnneededCapitalW: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-# Style/UnneededInterpolation: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-# Style/UnneededPercentQ: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Style/RedundantCapitalW:
+  Enabled: true
+Style/RedundantInterpolation:
+  Enabled: true
+Style/RedundantPercentQ:
+  Enabled: true
 Style/TrailingUnderscoreVariable:
   Enabled: true
 Style/VariableInterpolation:
@@ -2735,8 +2735,8 @@ Lint/RedundantStringCoercion:
   Enabled: true
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
-# Lint/UnneededCopDisableDirective: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RedundantCopDisableDirective:
+  Enabled: true
 Lint/UnusedBlockArgument:
   Enabled: true
 Lint/UnusedMethodArgument:
@@ -2944,8 +2944,8 @@ Lint/RedundantWithObject:
   Enabled: true
 
 # avoid requiring things that come for free
-# Lint/UnneededRequireStatement: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RedundantRequireStatement:
+  Enabled: true
 
 # Avoid poorly formatted methods
 Style/TrailingBodyOnMethodDefinition:
@@ -2968,8 +2968,8 @@ Lint/BigDecimalNew:
   Enabled: true
 
 # remove bogus rubocop comments. We already enabled Disable directives
-# Lint/UnneededCopEnableDirective: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RedundantCopEnableDirective:
+  Enabled: true
 
 # get people on a much simpler ruby 2.4+ way of doing things
 Style/UnpackFirst:
@@ -3054,10 +3054,6 @@ Style/RedundantAssignment:
 
 # alert on invalid ruby
 Lint/Syntax:
-  Enabled: true
-
-# remove extra requires like 'thread'
-Lint/RedundantRequireStatement:
   Enabled: true
 
 # simplify stripping strings

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2482,12 +2482,12 @@ Layout/IndentationWidth:
   Enabled: true
 Style/IdenticalConditionalBranches:
   Enabled: true
-# Layout/IndentArray: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/IndentFirstArrayElement:
+  Enabled: true
 Layout/AssignmentIndentation:
   Enabled: true
-# Layout/IndentHash: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/IndentFirstHashElement:
+  Enabled: true
 Style/InfiniteLoop:
   Enabled: true
 Style/Lambda:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2425,8 +2425,6 @@ Naming/ConstantName:
   Enabled: true
 Style/DefWithParentheses:
   Enabled: true
-Style/PreferredHashMethods:
-  Enabled: true
 Layout/DotPosition:
   Enabled: true
 Style/EachWithObject:
@@ -2482,11 +2480,11 @@ Layout/IndentationWidth:
   Enabled: true
 Style/IdenticalConditionalBranches:
   Enabled: true
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: true
 Layout/AssignmentIndentation:
   Enabled: true
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: true
 Style/InfiniteLoop:
   Enabled: true
@@ -2746,8 +2744,6 @@ Lint/UnreachableCode:
 Lint/UselessAccessModifier:
   Enabled: true
 Lint/UselessAssignment:
-  Enabled: true
-Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 Lint/UselessElseWithoutRescue:
   Enabled: true

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2498,8 +2498,8 @@ Layout/LeadingCommentSpace:
   Enabled: true
 Style/LineEndConcatenation:
   Enabled: true
-# Style/MethodCallParentheses: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
 Style/MethodDefParentheses:
   Enabled: true
 Style/MultilineBlockChain:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2693,8 +2693,6 @@ Lint/EmptyInterpolation:
 Layout/EndAlignment:
   Enabled: true
   AutoCorrect: true
-# Lint/EndInMethod: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
 Lint/EnsureReturn:
   Enabled: true
 Security/Eval:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2425,8 +2425,8 @@ Naming/ConstantName:
   Enabled: true
 Style/DefWithParentheses:
   Enabled: true
-# Style/DeprecatedHashMethods: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Style/PreferredHashMethods:
+  Enabled: true
 Layout/DotPosition:
   Enabled: true
 Style/EachWithObject:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2373,10 +2373,10 @@ Chef/Security/SshPrivateKey:
 
 Layout/AccessModifierIndentation:
   Enabled: true
-# Layout/AlignArray: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-# Layout/AlignHash: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/ArrayAlignment:
+  Enabled: true
+Layout/HashAlignment:
+  Enabled: true
 Style/AndOr:
   Enabled: true
 Style/ArrayJoin:
@@ -2484,8 +2484,8 @@ Style/IdenticalConditionalBranches:
   Enabled: true
 # Layout/IndentArray: TODO broken with rubocop 1.25.1 move
 #   Enabled: true
-# Layout/IndentAssignment: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/AssignmentIndentation:
+  Enabled: true
 # Layout/IndentHash: TODO broken with rubocop 1.25.1 move
 #   Enabled: true
 Style/InfiniteLoop:
@@ -2680,8 +2680,8 @@ Lint/DeprecatedClassMethods:
   Enabled: true
 Lint/DuplicateMethods:
   Enabled: true
-# Lint/DuplicatedKey: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/DuplicateHashKey:
+  Enabled: true
 Lint/EachWithObjectArgument:
   Enabled: true
 Lint/ElseLayout:
@@ -2703,8 +2703,8 @@ Lint/FloatOutOfRange:
   Enabled: true
 Lint/FormatParameterMismatch:
   Enabled: true
-# Lint/HandleExceptions: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/SuppressedException:
+  Enabled: true
 Lint/ImplicitStringConcatenation:
   Enabled: true
   Exclude:
@@ -2733,8 +2733,8 @@ Lint/RescueException:
   Enabled: true
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
-# Lint/StringConversionInInterpolation: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RedundantStringCoercion:
+  Enabled: true
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 # Lint/UnneededCopDisableDirective: TODO broken with rubocop 1.25.1 move

--- a/cookstyle.gemspec
+++ b/cookstyle.gemspec
@@ -20,6 +20,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('rubocop', Cookstyle::RUBOCOP_VERSION)
 
+  # remove these dependencies once we upgrade to a modern rubocop
+  spec.add_dependency('base64')
+  spec.add_dependency('ostruct')
+
   spec.metadata = {
     'homepage_uri' => 'https://github.com/chef/cookstyle',
     'changelog_uri' => 'https://github.com/chef/cookstyle/blob/main/CHANGELOG.md',

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedchefspecplatform.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_deprecatedchefspecplatform.yml
@@ -2,7 +2,7 @@
 short_name: DeprecatedChefSpecPlatform
 full_name: Chef/Deprecations/DeprecatedChefSpecPlatform
 department: Chef/Deprecations
-description: Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md.
+description: Use currently supported platforms in ChefSpec listed at https://github.com/chef/fauxhai/blob/main/PLATFORMS.md.
   Fauxhai / ChefSpec will perform fuzzy matching on platform version values so it's
   always best to be less specific ie. 10 instead of 10.3
 autocorrection: true

--- a/lib/rubocop/cop/chef/deprecation/deprecated_chefspec_platform.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_chefspec_platform.rb
@@ -19,7 +19,7 @@ module RuboCop
   module Cop
     module Chef
       module Deprecations
-        # Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version values so it's always best to be less specific ie. 10 instead of 10.3
+        # Use currently supported platforms in ChefSpec listed at https://github.com/chef/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version values so it's always best to be less specific ie. 10 instead of 10.3
         #
         # @example
         #
@@ -29,7 +29,7 @@ module RuboCop
           include RuboCop::Chef::CookbookHelpers
           extend AutoCorrector
 
-          MSG = "Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3"
+          MSG = "Use currently supported platforms in ChefSpec listed at https://github.com/chef/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3"
 
           DEPRECATED_MAPPING = {
             'amazon' => {

--- a/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
@@ -45,13 +45,13 @@ module RuboCop
 
           MSG = 'Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.'
           RESTRICT_ON_SEND = %i( shell_out_compact
-          shell_out_compact!
-          shell_out_compact_timeout
-          shell_out_compact_timeout!
-          shell_out_with_timeout
-          shell_out_with_timeout!
-          shell_out_with_systems_locale
-          shell_out_with_systems_locale!
+                                 shell_out_compact!
+                                 shell_out_compact_timeout
+                                 shell_out_compact_timeout!
+                                 shell_out_with_timeout
+                                 shell_out_with_timeout!
+                                 shell_out_with_systems_locale
+                                 shell_out_with_systems_locale!
         ).freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/security/ssh_private_key.rb
+++ b/lib/rubocop/cop/chef/security/ssh_private_key.rb
@@ -37,7 +37,7 @@ module RuboCop
             node.arguments.each do |arg|
               next unless arg.str_type? || arg.dstr_type?
 
-              if arg.value.start_with?('-----BEGIN RSA PRIVATE', '-----BEGIN EC PRIVATE') # cookstyle: disable Chef/Security/SshPrivateKey
+              if arg.value.start_with?('-----BEGIN RSA PRIVATE', '-----BEGIN EC PRIVATE')
                 add_offense(node, severity: :warning)
               end
             end

--- a/spec/rubocop/cop/chef/deprecation/deprecated_chefspec_platform_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/deprecated_chefspec_platform_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Chef::Deprecations::DeprecatedChefSpecPlatform, :config d
   it "registers an offense when spec calls for Ubuntu 14.04, but doesn't autocorrect" do
     expect_offense(<<~RUBY)
       let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04') }
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use currently supported platforms in ChefSpec listed at https://github.com/chef/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
     RUBY
 
     expect_no_corrections
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Chef::Deprecations::DeprecatedChefSpecPlatform, :config d
   it 'registers an offense when spec calls for CentOS 7.1 and autocorrects to CentOS 7' do
     expect_offense(<<~RUBY)
       let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1') }
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use currently supported platforms in ChefSpec listed at https://github.com/chef/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
     RUBY
 
     expect_correction("let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'centos', version: '7') }\n")
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Chef::Deprecations::DeprecatedChefSpecPlatform, :config d
   it 'registers an offense when using ChefSpec::SoloRunner as well' do
     expect_offense(<<~RUBY)
       let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '7.1') }
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use currently supported platforms in ChefSpec listed at https://github.com/chef/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
     RUBY
 
     expect_correction("let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '7') }\n")
@@ -61,7 +61,7 @@ describe RuboCop::Cop::Chef::Deprecations::DeprecatedChefSpecPlatform, :config d
   it "registers an offense when spec calls for Amazon 2018.03, but doesn't autocorrect" do
     expect_offense(<<~RUBY)
       let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'amazon', version: '2018.03') }
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use currently supported platforms in ChefSpec listed at https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use currently supported platforms in ChefSpec listed at https://github.com/chef/fauxhai/blob/main/PLATFORMS.md. Fauxhai / ChefSpec will perform fuzzy matching on platform version so it's always best to be less specific ie. 10 instead of 10.3
     RUBY
 
     expect_no_corrections


### PR DESCRIPTION
## Description

Fix the cops broken during one of my upgrades a long time ago. This is probably going to result in CI failures elsewhere as these cops have been disabled for a while. Test Kitchen triggered on one of the alignment cops.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
