### PR TITLE
Upgrade RuboCop to 1.69 + enable new cops

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -696,6 +696,146 @@ Lint/DuplicateRequire:
 Lint/AmbiguousAssignment:
   Enabled: true
 
+# File.dirname(path, 2)
+# instead of
+# File.dirname(File.dirname(path))
+Style/NestedFileDirname:
+  Enabled: true
+
+# Use strings instead of regexes when possible
+Style/ExactRegexpMatch:
+  Enabled: true
+
+# Don't use redundant `any?`, `empty?`, `none?` or `one?` with `select`
+Style/RedundantFilterChain:
+  Enabled: true
+
+# Simplify creating arrays
+Style/RedundantArrayConstructor:
+  Enabled: true
+
+# Catch regex that tries to catch A-Z and a-z but fails
+Lint/MixedCaseRange:
+  Enabled: true
+
+# Use require_relative '/path'
+# not
+# require_relative './path
+Style/RedundantCurrentDirectoryInPath:
+  Enabled: true
+
+# Use strings instead of regex with common helper methods
+Style/RedundantRegexpArgument:
+  Enabled: true
+
+# Simplify loading of YAML from a file
+Style/YAMLFileRead:
+  Enabled: true
+
+# You can't have the same named group in a gemfile twice
+Bundler/DuplicatedGroup:
+  Enabled: true
+
+# Avoid creating and array and interating into it when .map can be used
+Style/MapIntoArray:
+  Enabled: true
+
+# Don't send method names when you don't need to
+Style/SendWithLiteralMethodName:
+  Enabled: true
+
+# add_runtime_dependencies is not preferred in gemspecs
+Gemspec/AddRuntimeDependency:
+  Enabled: true
+
+# Avoid numeric operators that do nothing to the value
+Lint/UselessNumericOperation:
+  Enabled: true
+
+# Don't define a set with duplicate elements since that defeats the point of a set
+Lint/DuplicateSetElement:
+  Enabled: true
+
+# Avoid calling defined twice when you don't need both
+Style/CombinableDefined:
+  Enabled: true
+
+# Catch malformed regexes
+Lint/UnescapedBracketInRegexp:
+  Enabled: true
+
+# Avoid defined calls that are always truthy
+Lint/UselessDefined:
+  Enabled: true
+
+# Call dig with multiple args instead of chaining it
+Style/DigChain:
+  Enabled: true
+
+# Catch deprecation hash creation in Ruby 3.4
+Lint/HashNewWithKeywordArgumentsAsDefault:
+  Enabled: true
+
+# Consistent magic comment formatting
+Style/MagicCommentFormat:
+  Enabled: true
+
+# Reduce duplicate comments
+Lint/DuplicateMagicComment:
+  Enabled: true
+
+# Don't escape strings when you don't need to
+Style/RedundantStringEscape:
+  Enabled: true
+
+# Don't double each something when you don't need to
+Style/RedundantEach:
+  Enabled: true
+
+# Use array.intersect? when on Ruby 3.1+
+Style/ArrayIntersect:
+  Enabled: true
+
+# Use .push to add to arrays which is much faster than .concat
+Style/ConcatArrayLiterals:
+  Enabled: true
+
+# Use .min and .max instead of rolling your own
+Style/MinMaxComparison:
+  Enabled: true
+
+# use .to_set instead of .map/.collect and then .to_set
+Style/MapToSet:
+  Enabled: true
+
+# Simplify how you check for empty files
+Style/FileEmpty:
+  Enabled: true
+
+# Simplify checking for empty directories
+Style/DirEmpty:
+  Enabled: true
+
+# Make it easier to read line continuations
+Layout/LineContinuationSpacing:
+  Enabled: true
+
+# Catch range statements that produce a Ruby warning
+Lint/RequireRangeParentheses:
+  Enabled: true
+
+# Don't attributes in the gemspec that are deprecated and/or ignored now
+Gemspec/DeprecatedAttributeAssignment:
+  Enabled: true
+
+# Don't .map and then .compact when you can use .selct or .reject instead
+Style/MapCompactWithConditionalBlock:
+  Enabled: true
+
+# Don't allow case statements with the same condition twice
+Lint/DuplicateMatchPattern:
+  Enabled: true
+
 Chef/Deprecations/Ruby27KeywordArgumentWarnings:
   Description: Pass options to shell_out helpers without the brackets to avoid Ruby 2.7 deprecation warnings.
   Enabled: true

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -7,7 +7,7 @@
 # Chef Core Ruby development.
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.0
   NewCops: disable
   DisabledByDefault: true
   SuggestExtensions: false

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -112,14 +112,12 @@ Lint/ShadowedException:
   Enabled: true
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
-Lint/RedundantStringCoercion:
-  Enabled: true
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 Lint/UnifiedInteger:
   Enabled: true
-# Lint/UnneededSplatExpansion: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RedundantSplatExpansion:
+  Enabled: true
 Lint/UnreachableCode:
   Enabled: true
 Lint/UriEscapeUnescape:
@@ -476,11 +474,11 @@ Style/TrailingUnderscoreVariable:
   Enabled: true
 Layout/TrailingWhitespace:
   Enabled: true
-# Style/UnneededCapitalW: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Style/RedundantCapitalW:
+  Enabled: true
 Style/RedundantInterpolation:
   Enabled: false # buggy: https://github.com/rubocop-hq/rubocop/issues/6099
-#Style/UnneededPercentQ:  # would like to enable this one but its buggy as of 0.35.1
+#Style/RedundantPercentQ:  # would like to enable this one but its buggy as of 0.35.1
 #  Enabled: true
 Naming/VariableName:
   Enabled: true

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -126,8 +126,8 @@ Lint/UselessAccessModifier:
   Enabled: true
 Lint/UselessAssignment:
   Enabled: true
-# Lint/UselessComparison: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
 Lint/UselessElseWithoutRescue:
   Enabled: true
 Lint/UselessSetterCall:

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -53,8 +53,8 @@ Lint/DuplicateCaseCondition:
   Enabled: true
 Lint/DuplicateMethods:
   Enabled: true
-# Lint/DuplicatedKey: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/DuplicateHashKey:
+  Enabled: true
 Lint/EachWithObjectArgument:
   Enabled: true
 Lint/ElseLayout:
@@ -90,8 +90,8 @@ Lint/LiteralInInterpolation:
   Enabled: true
 Lint/Loop:
   Enabled: true
-# Lint/MultipleCompare: TODO broken with rubocop 1.25.1 move
-#  Enabled: true
+Lint/MultipleComparison:
+  Enabled: true
 Lint/NestedMethodDefinition:
   Enabled: true
 Lint/NextWithoutAccumulator:
@@ -114,8 +114,8 @@ Lint/ShadowedException:
   Enabled: true
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
-# Lint/StringConversionInInterpolation: TODO broken with rubocop 1.25.1 move
-#  Enabled: true
+Lint/RedundantStringCoercion:
+  Enabled: true
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 Lint/UnifiedInteger:
@@ -196,24 +196,23 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-
 #
 # Style/Naming/Layout
 #
 
 Layout/AccessModifierIndentation:
   Enabled: true
-# Layout/AlignArguments: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-#   EnforcedStyle: with_fixed_indentation
-# Layout/AlignParameters: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-#   EnforcedStyle: with_fixed_indentation
+Layout/ArgumentAlignment:
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
+Layout/ParameterAlignment:
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
 # the "ignore_implict" is here for keyword args in method calls which are
 # "implicit" hashes, and those should not be treated like normal hashes
-# Layout/AlignHash: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-#   EnforcedLastArgumentHashStyle: ignore_implicit
+Layout/HashAlignment:
+  Enabled: true
+  EnforcedLastArgumentHashStyle: ignore_implicit
 Style/AndOr:
   Enabled: true
 Style/ArrayJoin:
@@ -290,13 +289,13 @@ Style/IfUnlessModifierOfIfUnless:
   Enabled: true
 Style/IfWithSemicolon:
   Enabled: true
-# Layout/IndentAssignment: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-# Layout/IndentFirstArgument: TODO broken with rubocop 1.25.1 move
-#   EnforcedStyle: consistent
-#   Enabled: true
-# Layout/IndentHeredoc: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/AssignmentIndentation:
+  Enabled: true
+Layout/FirstArgumentIndentation:
+  EnforcedStyle: consistent
+  Enabled: true
+Layout/HeredocIndentation:
+  Enabled: true
 Layout/IndentationConsistency:
   Enabled: true
 Layout/IndentationWidth:
@@ -464,8 +463,8 @@ Style/SymbolProc:
   Enabled: true
 Layout/IndentationStyle:
   Enabled: true
-# Layout/TrailingBlankLines: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/TrailingEmptyLines:
+  Enabled: true
 Style/TrailingCommaInArguments:
   Enabled: true
 # rubocop's default gets this completely backwards

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -70,8 +70,6 @@ Lint/EmptyWhen:
 Layout/EndAlignment:
   Enabled: true
   AutoCorrect: true
-# Lint/EndInMethod: TODO broken with rubocop 1.25.1 move
-#  Enabled: true
 Lint/EnsureReturn:
   Enabled: true
 Lint/FloatOutOfRange:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2936,8 +2936,8 @@ Style/RedundantConditional:
   Enabled: true
 
 # catches people writing a regex check wrong
-# Lint/RegexpInCondition: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RegexpAsCondition:
+  Enabled: true
 
 # Avoids pointless / complex code
 Lint/RedundantWithObject:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2747,8 +2747,8 @@ Lint/UselessAccessModifier:
   Enabled: true
 Lint/UselessAssignment:
   Enabled: true
-# Lint/UselessComparison: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
 Lint/UselessElseWithoutRescue:
   Enabled: true
 Lint/UselessSetterCall:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2536,8 +2536,8 @@ Style/Not:
   Enabled: true
 Style/OneLineConditional:
   Enabled: true
-# Naming/OpMethod: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Naming/BinaryOperatorParameterName:
+  Enabled: true
 Style/OptionalArguments:
   Enabled: true
 Style/ParallelAssignment:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2641,12 +2641,12 @@ Style/TrivialAccessors:
   Enabled: true
 Style/UnlessElse:
   Enabled: true
-# Style/UnneededCapitalW: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-# Style/UnneededInterpolation: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-# Style/UnneededPercentQ: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Style/RedundantCapitalW:
+  Enabled: true
+Style/RedundantInterpolation:
+  Enabled: true
+Style/RedundantPercentQ:
+  Enabled: true
 Style/TrailingUnderscoreVariable:
   Enabled: true
 Style/VariableInterpolation:
@@ -2735,8 +2735,8 @@ Lint/RedundantStringCoercion:
   Enabled: true
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
-# Lint/UnneededCopDisableDirective: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RedundantCopDisableDirective:
+  Enabled: true
 Lint/UnusedBlockArgument:
   Enabled: true
 Lint/UnusedMethodArgument:
@@ -2944,8 +2944,8 @@ Lint/RedundantWithObject:
   Enabled: true
 
 # avoid requiring things that come for free
-# Lint/UnneededRequireStatement: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RedundantRequireStatement:
+  Enabled: true
 
 # Avoid poorly formatted methods
 Style/TrailingBodyOnMethodDefinition:
@@ -2968,8 +2968,8 @@ Lint/BigDecimalNew:
   Enabled: true
 
 # remove bogus rubocop comments. We already enabled Disable directives
-# Lint/UnneededCopEnableDirective: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RedundantCopEnableDirective:
+  Enabled: true
 
 # get people on a much simpler ruby 2.4+ way of doing things
 Style/UnpackFirst:
@@ -3054,10 +3054,6 @@ Style/RedundantAssignment:
 
 # alert on invalid ruby
 Lint/Syntax:
-  Enabled: true
-
-# remove extra requires like 'thread'
-Lint/RedundantRequireStatement:
   Enabled: true
 
 # simplify stripping strings

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2482,12 +2482,12 @@ Layout/IndentationWidth:
   Enabled: true
 Style/IdenticalConditionalBranches:
   Enabled: true
-# Layout/IndentArray: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/IndentFirstArrayElement:
+  Enabled: true
 Layout/AssignmentIndentation:
   Enabled: true
-# Layout/IndentHash: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/IndentFirstHashElement:
+  Enabled: true
 Style/InfiniteLoop:
   Enabled: true
 Style/Lambda:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2425,8 +2425,6 @@ Naming/ConstantName:
   Enabled: true
 Style/DefWithParentheses:
   Enabled: true
-Style/PreferredHashMethods:
-  Enabled: true
 Layout/DotPosition:
   Enabled: true
 Style/EachWithObject:
@@ -2482,11 +2480,11 @@ Layout/IndentationWidth:
   Enabled: true
 Style/IdenticalConditionalBranches:
   Enabled: true
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: true
 Layout/AssignmentIndentation:
   Enabled: true
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: true
 Style/InfiniteLoop:
   Enabled: true
@@ -2746,8 +2744,6 @@ Lint/UnreachableCode:
 Lint/UselessAccessModifier:
   Enabled: true
 Lint/UselessAssignment:
-  Enabled: true
-Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 Lint/UselessElseWithoutRescue:
   Enabled: true

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2498,8 +2498,8 @@ Layout/LeadingCommentSpace:
   Enabled: true
 Style/LineEndConcatenation:
   Enabled: true
-# Style/MethodCallParentheses: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
 Style/MethodDefParentheses:
   Enabled: true
 Style/MultilineBlockChain:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2693,8 +2693,6 @@ Lint/EmptyInterpolation:
 Layout/EndAlignment:
   Enabled: true
   AutoCorrect: true
-# Lint/EndInMethod: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
 Lint/EnsureReturn:
   Enabled: true
 Security/Eval:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2369,8 +2369,7 @@ Chef/Security/SshPrivateKey:
     - '**/attributes/*.rb'
     - '**/definitions/*.rb'
 
-#### The base rubocop 0.37 enabled.yml file we started with ####
-
+#### The base rubocop 0.37 enabled.yml file we started with before we required backing up each new addition ####
 Layout/AccessModifierIndentation:
   Enabled: true
 Layout/ArrayAlignment:
@@ -2975,7 +2974,7 @@ Style/SymbolProc:
   Enabled: true
   # A list of method names to be ignored by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
-  IgnoredMethods:
+  AllowedMethods:
     - lazy
 
 # as much as I wish everyone would document things it's just not going to happen

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2,7 +2,7 @@ AllCops:
   SuggestExtensions: false
   NewCops: disable
   DisabledByDefault: true
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   TargetChefVersion: ~
   inherit_mode:
     merge:
@@ -3117,4 +3117,149 @@ Style/FileRead:
 
 # reduce file write complexity
 Style/FileWrite:
+  Enabled: true
+
+# Improve readability of arrays for new users
+# Prefer something.first over something[0]
+Style/ArrayFirstLast:
+  Enabled: true
+
+# File.dirname(path, 2)
+# instead of
+# File.dirname(File.dirname(path))
+Style/NestedFileDirname:
+  Enabled: true
+
+# Use strings instead of regexes when possible
+Style/ExactRegexpMatch:
+  Enabled: true
+
+# Don't use redundant `any?`, `empty?`, `none?` or `one?` with `select`
+Style/RedundantFilterChain:
+  Enabled: true
+
+# Simplify creating arrays
+Style/RedundantArrayConstructor:
+  Enabled: true
+
+# Catch regex that tries to catch A-Z and a-z but fails
+Lint/MixedCaseRange:
+  Enabled: true
+
+# Use require_relative '/path'
+# not
+# require_relative './path
+Style/RedundantCurrentDirectoryInPath:
+  Enabled: true
+
+# Use strings instead of regex with common helper methods
+Style/RedundantRegexpArgument:
+  Enabled: true
+
+# Simplify loading of YAML from a file
+Style/YAMLFileRead:
+  Enabled: true
+
+# You can't have the same named group in a gemfile twice
+Bundler/DuplicatedGroup:
+  Enabled: true
+
+# Avoid creating and array and interating into it when .map can be used
+Style/MapIntoArray:
+  Enabled: true
+
+# Don't send method names when you don't need to
+Style/SendWithLiteralMethodName:
+  Enabled: true
+
+# add_runtime_dependencies is not preferred in gemspecs
+Gemspec/AddRuntimeDependency:
+  Enabled: true
+
+# Avoid numeric operators that do nothing to the value
+Lint/UselessNumericOperation:
+  Enabled: true
+
+# Don't define a set with duplicate elements since that defeats the point of a set
+Lint/DuplicateSetElement:
+  Enabled: true
+
+# Avoid calling defined twice when you don't need both
+Style/CombinableDefined:
+  Enabled: true
+
+# Catch malformed regexes
+Lint/UnescapedBracketInRegexp:
+  Enabled: true
+
+# Avoid defined calls that are always truthy
+Lint/UselessDefined:
+  Enabled: true
+
+# Call dig with multiple args instead of chaining it
+Style/DigChain:
+  Enabled: true
+
+# Catch deprecation hash creation in Ruby 3.4
+Lint/HashNewWithKeywordArgumentsAsDefault:
+  Enabled: true
+
+# Consistent magic comment formatting
+Style/MagicCommentFormat:
+  Enabled: true
+
+# Reduce duplicate comments
+Lint/DuplicateMagicComment:
+  Enabled: true
+
+# Don't escape strings when you don't need to
+Style/RedundantStringEscape:
+  Enabled: true
+
+# Don't double each something when you don't need to
+Style/RedundantEach:
+  Enabled: true
+
+# Use array.intersect? when on Ruby 3.1+
+Style/ArrayIntersect:
+  Enabled: true
+
+# Use .push to add to arrays which is much faster than .concat
+Style/ConcatArrayLiterals:
+  Enabled: true
+
+# Use .min and .max instead of rolling your own
+Style/MinMaxComparison:
+  Enabled: true
+
+# use .to_set instead of .map/.collect and then .to_set
+Style/MapToSet:
+  Enabled: true
+
+# Simplify how you check for empty files
+Style/FileEmpty:
+  Enabled: true
+
+# Simplify checking for empty directories
+Style/DirEmpty:
+  Enabled: true
+
+# Make it easier to read line continuations
+Layout/LineContinuationSpacing:
+  Enabled: true
+
+# Catch range statements that produce a Ruby warning
+Lint/RequireRangeParentheses:
+  Enabled: true
+
+# Don't attributes in the gemspec that are deprecated and/or ignored now
+Gemspec/DeprecatedAttributeAssignment:
+  Enabled: true
+
+# Don't .map and then .compact when you can use .selct or .reject instead
+Style/MapCompactWithConditionalBlock:
+  Enabled: true
+
+# Don't allow case statements with the same condition twice
+Lint/DuplicateMatchPattern:
   Enabled: true

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2425,8 +2425,8 @@ Naming/ConstantName:
   Enabled: true
 Style/DefWithParentheses:
   Enabled: true
-# Style/DeprecatedHashMethods: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Style/PreferredHashMethods:
+  Enabled: true
 Layout/DotPosition:
   Enabled: true
 Style/EachWithObject:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2373,10 +2373,10 @@ Chef/Security/SshPrivateKey:
 
 Layout/AccessModifierIndentation:
   Enabled: true
-# Layout/AlignArray: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
-# Layout/AlignHash: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/ArrayAlignment:
+  Enabled: true
+Layout/HashAlignment:
+  Enabled: true
 Style/AndOr:
   Enabled: true
 Style/ArrayJoin:
@@ -2484,8 +2484,8 @@ Style/IdenticalConditionalBranches:
   Enabled: true
 # Layout/IndentArray: TODO broken with rubocop 1.25.1 move
 #   Enabled: true
-# Layout/IndentAssignment: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Layout/AssignmentIndentation:
+  Enabled: true
 # Layout/IndentHash: TODO broken with rubocop 1.25.1 move
 #   Enabled: true
 Style/InfiniteLoop:
@@ -2680,8 +2680,8 @@ Lint/DeprecatedClassMethods:
   Enabled: true
 Lint/DuplicateMethods:
   Enabled: true
-# Lint/DuplicatedKey: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/DuplicateHashKey:
+  Enabled: true
 Lint/EachWithObjectArgument:
   Enabled: true
 Lint/ElseLayout:
@@ -2703,8 +2703,8 @@ Lint/FloatOutOfRange:
   Enabled: true
 Lint/FormatParameterMismatch:
   Enabled: true
-# Lint/HandleExceptions: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/SuppressedException:
+  Enabled: true
 Lint/ImplicitStringConcatenation:
   Enabled: true
   Exclude:
@@ -2733,8 +2733,8 @@ Lint/RescueException:
   Enabled: true
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
-# Lint/StringConversionInInterpolation: TODO broken with rubocop 1.25.1 move
-#   Enabled: true
+Lint/RedundantStringCoercion:
+  Enabled: true
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 # Lint/UnneededCopDisableDirective: TODO broken with rubocop 1.25.1 move

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Cookstyle
   VERSION = "7.32.12" # rubocop: disable Style/StringLiterals
-  RUBOCOP_VERSION = '1.25.1'
+  RUBOCOP_VERSION = '1.69.1'
 end

--- a/lib/rubocop/chef/cookbook_helpers.rb
+++ b/lib/rubocop/chef/cookbook_helpers.rb
@@ -72,7 +72,7 @@ module RuboCop
         return if ast.children[2].nil?
         # https://rubular.com/r/6uzOMd6WCHewOu
         m = ast.children[2].source.match(/^("|')(.*)("|')$/)
-        return m[2] unless m.nil?
+        m[2] unless m.nil?
       end
 
       private

--- a/lib/rubocop/cop/chef/correctness/tmp_path.rb
+++ b/lib/rubocop/cop/chef/correctness/tmp_path.rb
@@ -50,7 +50,7 @@ module RuboCop
 
           def file_cache_path?(path)
             path_str = path.to_s.scan(/"(.*)"/)[0][0]
-            path_str.start_with?("\#\{Chef::Config[:file_cache_path]\}")
+            path_str.start_with?("\#{Chef::Config[:file_cache_path]}")
           end
         end
       end

--- a/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_shellout_methods.rb
@@ -45,13 +45,13 @@ module RuboCop
 
           MSG = 'Many legacy specialized shell_out methods were replaced in Chef Infra Client 14.3 and removed in Chef Infra Client 15. Use shell_out and any additional options if necessary.'
           RESTRICT_ON_SEND = %i( shell_out_compact
-          shell_out_compact!
-          shell_out_compact_timeout
-          shell_out_compact_timeout!
-          shell_out_with_timeout
-          shell_out_with_timeout!
-          shell_out_with_systems_locale
-          shell_out_with_systems_locale!
+                                 shell_out_compact!
+                                 shell_out_compact_timeout
+                                 shell_out_compact_timeout!
+                                 shell_out_with_timeout
+                                 shell_out_with_timeout!
+                                 shell_out_with_systems_locale
+                                 shell_out_with_systems_locale!
         ).freeze
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/execute_sleep.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_sleep.rb
@@ -38,7 +38,7 @@ module RuboCop
         #   ### correct
         #   chef_sleep '60'
         #
-        class ExecuteSleep < Cop
+        class ExecuteSleep < Base
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
 

--- a/lib/rubocop/cop/chef/modernize/execute_tzutil.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_tzutil.rb
@@ -74,7 +74,7 @@ module RuboCop
 
           def calls_tzutil?(ast_obj)
             property_data = method_arg_ast_to_string(ast_obj)
-            return true if property_data && property_data.match?(/^tzutil/i)
+            true if property_data && property_data.match?(/^tzutil/i)
           end
         end
       end

--- a/lib/rubocop/cop/chef/modernize/sc_windows_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/sc_windows_resource.rb
@@ -35,7 +35,7 @@ module RuboCop
         #     binary_path_name "C:\\opscode\\chef\\bin"
         #   end
         #
-        class WindowsScResource < Cop
+        class WindowsScResource < Base
           extend TargetChefVersion
 
           minimum_target_chef_version '14.0'

--- a/lib/rubocop/cop/chef/security/ssh_private_key.rb
+++ b/lib/rubocop/cop/chef/security/ssh_private_key.rb
@@ -37,7 +37,7 @@ module RuboCop
             node.arguments.each do |arg|
               next unless arg.str_type? || arg.dstr_type?
 
-              if arg.value.start_with?('-----BEGIN RSA PRIVATE', '-----BEGIN EC PRIVATE') # cookstyle: disable Chef/Security/SshPrivateKey
+              if arg.value.start_with?('-----BEGIN RSA PRIVATE', '-----BEGIN EC PRIVATE')
                 add_offense(node, severity: :warning)
               end
             end

--- a/lib/rubocop/cop/chef/style/attribute_keys.rb
+++ b/lib/rubocop/cop/chef/style/attribute_keys.rb
@@ -40,7 +40,7 @@ module RuboCop
         #   node['foo']
         #   node["foo"]
         #
-        class AttributeKeys < Cop
+        class AttributeKeys < Base
           include RuboCop::Cop::ConfigurableEnforcedStyle
 
           MSG = 'Use %s to access node attributes'

--- a/lib/rubocop/cop/chef/style/chef_whaaat.rb
+++ b/lib/rubocop/cop/chef/style/chef_whaaat.rb
@@ -31,7 +31,7 @@ module RuboCop
         #   Chef Software makes software
         #   Chef Infra configures your systems
         #
-        class ChefWhaaat < Cop
+        class ChefWhaaat < Base
           MSG = 'Do you mean Chef (the company) or a Chef product (e.g. Chef Infra, Chef InSpec, etc)?'
 
           def on_new_investigation

--- a/lib/rubocop/cop/chef/style/comments_copyright_format.rb
+++ b/lib/rubocop/cop/chef/style/comments_copyright_format.rb
@@ -92,7 +92,7 @@ module RuboCop
             current_text = match.captures[0]
             desired_text = "#{copyright_date_range(comment)}, #{copyright_holder(comment)}"
 
-            return true unless current_text == desired_text
+            true unless current_text == desired_text
           end
         end
       end

--- a/lib/rubocop/cop/chef/style/comments_default_copyright.rb
+++ b/lib/rubocop/cop/chef/style/comments_default_copyright.rb
@@ -38,7 +38,7 @@ module RuboCop
             return unless processed_source.ast
 
             processed_source.comments.each do |comment|
-              next unless comment.inline? &&  # headers aren't in blocks
+              next unless comment.inline? && # headers aren't in blocks
                           /# (?:Copyright\W*).*YOUR_(NAME|COMPANY_NAME)/.match?(comment.text)
               add_offense(comment, severity: :refactor)
             end

--- a/lib/rubocop/cop/chef/style/file_mode.rb
+++ b/lib/rubocop/cop/chef/style/file_mode.rb
@@ -69,7 +69,7 @@ module RuboCop
 
                 # we build our own escaped string instead of using .inspect because that way
                 # we can use single quotes instead of the double quotes that .inspect adds
-                corrector.replace(mode_int, "\'#{replacement_mode}\'")
+                corrector.replace(mode_int, "'#{replacement_mode}'")
               end
             end
           end

--- a/lib/rubocop/monkey_patches/team.rb
+++ b/lib/rubocop/monkey_patches/team.rb
@@ -10,12 +10,13 @@ module RuboCop
       end
 
       ### START COOKSTYLE MODIFICATION
-      def roundup_relevant_cops(filename)
-        cops.reject do |cop|
-          cop.excluded_file?(filename) ||
-            !support_target_ruby_version?(cop) ||
-            !support_target_chef_version?(cop) ||
-            !support_target_rails_version?(cop)
+      def roundup_relevant_cops(processed_source)
+        cops.select do |cop|
+          next true if processed_source.comment_config.cop_opted_in?(cop)
+          next false if cop.excluded_file?(processed_source.file_path)
+          next false unless @registry.enabled?(cop, @config)
+      
+          support_target_ruby_version?(cop) && support_target_rails_version?(cop) && support_target_chef_version?(cop)
         end
       end
       ### END COOKSTYLE MODIFICATION

--- a/lib/rubocop/monkey_patches/team.rb
+++ b/lib/rubocop/monkey_patches/team.rb
@@ -15,7 +15,7 @@ module RuboCop
           next true if processed_source.comment_config.cop_opted_in?(cop)
           next false if cop.excluded_file?(processed_source.file_path)
           next false unless @registry.enabled?(cop, @config)
-      
+
           support_target_ruby_version?(cop) && support_target_rails_version?(cop) && support_target_chef_version?(cop)
         end
       end

--- a/spec/rubocop/cop/chef/correctness/invalid_platform_metadata_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/invalid_platform_metadata_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Chef::Correctness::InvalidPlatformMetadata, :config do
   it 'registers an offense when a cookbook contains an invalid supports platform' do
     expect_offense(<<~RUBY)
       supports 'darwin'
-               ^^^^^^^^ metadata.rb \"supports\" platform is invalid
+               ^^^^^^^^ metadata.rb "supports" platform is invalid
       depends 'foo'
     RUBY
 
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Chef::Correctness::InvalidPlatformMetadata, :config do
   it 'registers offenses for invalid platforms defined in a loop' do
     expect_offense(<<~RUBY)
       %w(ubuntu centos redhat fedora amazon rhel).each do |os|
-                                            ^^^^ metadata.rb \"supports\" platform is invalid
+                                            ^^^^ metadata.rb "supports" platform is invalid
         supports os
       end
     RUBY

--- a/spec/rubocop/cop/chef/correctness/tmp_path_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/tmp_path_spec.rb
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Chef::Correctness::TmpPath, :config do
 
   it "doesn't register an offense when using file_cache_path" do
     expect_no_offenses(<<~RUBY)
-      remote_file "\#\{Chef::Config[:file_cache_path]\}/large-file.tar.gz" do
+      remote_file "\#{Chef::Config[:file_cache_path]}/large-file.tar.gz" do
         source 'http://www.example.org/large-file.tar.gz'
       end
     RUBY

--- a/spec/rubocop/cop/chef/effortless/search_used_spec.rb
+++ b/spec/rubocop/cop/chef/effortless/search_used_spec.rb
@@ -20,7 +20,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Chef::Effortless::CookbookUsesSearch, :config do
   it 'registers an offense when search is used' do
     expect_offense(<<~RUBY)
-      search(:node, 'run_list:recipe\[bacula\:\:server\]')
+      search(:node, 'run_list:recipe[bacula::server]')
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cookbook uses search, which cannot be used in the Effortless Infra pattern
     RUBY
   end

--- a/spec/rubocop/cop/chef/sharing/invalid_license_string_spec.rb
+++ b/spec/rubocop/cop/chef/sharing/invalid_license_string_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Chef::Sharing::InvalidLicenseString, :config do
   it 'registers an offense when a cookbook sets its license to a non-standard form of the the Apache 2.0 license' do
     expect_offense(<<~RUBY)
       license 'Apache 2.0'
-              ^^^^^^^^^^^^ Cookbook metadata.rb does not use a SPDX compliant license string or \"all rights reserved\". See https://spdx.org/licenses/ for a complete list of license identifiers.
+              ^^^^^^^^^^^^ Cookbook metadata.rb does not use a SPDX compliant license string or "all rights reserved". See https://spdx.org/licenses/ for a complete list of license identifiers.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -32,7 +32,7 @@ describe RuboCop::Cop::Chef::Sharing::InvalidLicenseString, :config do
   it 'registers an offense when a cookbook sets its license to bogus junk' do
     expect_offense(<<~RUBY)
       license 'I am not a license'
-              ^^^^^^^^^^^^^^^^^^^^ Cookbook metadata.rb does not use a SPDX compliant license string or \"all rights reserved\". See https://spdx.org/licenses/ for a complete list of license identifiers.
+              ^^^^^^^^^^^^^^^^^^^^ Cookbook metadata.rb does not use a SPDX compliant license string or "all rights reserved". See https://spdx.org/licenses/ for a complete list of license identifiers.
     RUBY
   end
 


### PR DESCRIPTION
This picks up from https://github.com/chef/cookstyle/pull/981 so that needs to get merged first

- Upgrade to RuboCop 1.69.1
- Enable Ruby 3.0 by default for chefstyle and Ruby 2.6 by default for cookstyle (allows upgrades from old clients)
- Fix deprecation warnings from some cops that inherited from Cop instead of Base
- Correct style issues within cookstyle itself
- Enable new cops available between 1.25 -> 1.69 which made sense
- Update monkeypatch code to work with modern RuboCop