### PR TITLE
bump: update rubocop version to enable support of chefstyle with ruby 3.4.x

### DIFF
--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Cookstyle
   VERSION = "7.32.13" # rubocop: disable Style/StringLiterals
-  RUBOCOP_VERSION = '1.25.1'
+  RUBOCOP_VERSION = '1.62.0'
 end

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Cookstyle
   VERSION = "7.32.13" # rubocop: disable Style/StringLiterals
-  RUBOCOP_VERSION = '1.62.0'
+  RUBOCOP_VERSION = '1.74.0'
 end

--- a/lib/rubocop/monkey_patches/team.rb
+++ b/lib/rubocop/monkey_patches/team.rb
@@ -11,6 +11,9 @@ module RuboCop
 
       ### START COOKSTYLE MODIFICATION
       def roundup_relevant_cops(filename)
+        # filename is now of class RuboCop::AST::ProcessedSource
+        # extract the filename from the AST::ProcessedSource object using the file_path method
+        filename = filename.file_path
         cops.reject do |cop|
           cop.excluded_file?(filename) ||
             !support_target_ruby_version?(cop) ||


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR updates the rubocop version to enable support of chefstyle with Ruby 3.4

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
