### PR TITLE
upgrading the rubocop version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.vscode/
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require: rubocop-performance
+plugins: rubocop-performance
 
 # enable new cops for rubocop-performance
 AllCops:

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2981,8 +2981,8 @@ Style/SymbolProc:
   Enabled: true
   # A list of method names to be ignored by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
-  IgnoredMethods:
-    - lazy
+  # IgnoredMethods:
+  #   - lazy
 
 # as much as I wish everyone would document things it's just not going to happen
 Style/Documentation:

--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -10,17 +10,17 @@ require 'rubocop'
 require_relative 'rubocop/monkey_patches/directive_comment'
 
 # monkey patches needed for the TargetChefVersion config option
-require_relative 'rubocop/monkey_patches/config'
-require_relative 'rubocop/monkey_patches/base'
-require_relative 'rubocop/monkey_patches/team'
-require_relative 'rubocop/monkey_patches/registry_cop'
+# require_relative 'rubocop/monkey_patches/config'
+# require_relative 'rubocop/monkey_patches/base'
+# require_relative 'rubocop/monkey_patches/team'
+# require_relative 'rubocop/monkey_patches/registry_cop'
 
 # Cookstyle patches the RuboCop tool to set a new default configuration that
 # is vendored in the Cookstyle codebase.
 module Cookstyle
   # @return [String] the absolute path to the main RuboCop configuration YAML file
   def self.config
-    config_file = const_defined?('CHEFSTYLE_CONFIG') ? 'chefstyle.yml' : 'default.yml'
+    config_file = const_defined?(:CHEFSTYLE_CONFIG) ? 'chefstyle.yml' : 'default.yml'
     File.realpath(File.join(__dir__, '..', 'config', config_file))
   end
 end

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Cookstyle
   VERSION = "7.32.13" # rubocop: disable Style/StringLiterals
-  RUBOCOP_VERSION = '1.25.1'
+  RUBOCOP_VERSION = '1.72.1'
 end

--- a/lib/rubocop/cop/chef/correctness/property_without_type.rb
+++ b/lib/rubocop/cop/chef/correctness/property_without_type.rb
@@ -47,7 +47,8 @@ module RuboCop
 
           def on_send(node)
             property_without_type?(node) do |hash_vals|
-              return if hash_vals&.first&.keys&.include?(s(:sym, :kind_of))
+              # return if hash_vals&.first&.keys&.include?(s(:sym, :kind_of))
+              return if hash_vals&.first&.keys?(s(:sym, :kind_of))
 
               add_offense(node, severity: :refactor)
             end

--- a/lib/rubocop/cop/chef/modernize/execute_sleep.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_sleep.rb
@@ -38,7 +38,7 @@ module RuboCop
         #   ### correct
         #   chef_sleep '60'
         #
-        class ExecuteSleep < Cop
+        class ExecuteSleep < Base
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion
 

--- a/lib/rubocop/cop/chef/modernize/sc_windows_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/sc_windows_resource.rb
@@ -35,7 +35,7 @@ module RuboCop
         #     binary_path_name "C:\\opscode\\chef\\bin"
         #   end
         #
-        class WindowsScResource < Cop
+        class WindowsScResource < Base
           extend TargetChefVersion
 
           minimum_target_chef_version '14.0'

--- a/lib/rubocop/cop/chef/style/attribute_keys.rb
+++ b/lib/rubocop/cop/chef/style/attribute_keys.rb
@@ -40,7 +40,7 @@ module RuboCop
         #   node['foo']
         #   node["foo"]
         #
-        class AttributeKeys < Cop
+        class AttributeKeys < Base
           include RuboCop::Cop::ConfigurableEnforcedStyle
 
           MSG = 'Use %s to access node attributes'

--- a/lib/rubocop/cop/chef/style/chef_whaaat.rb
+++ b/lib/rubocop/cop/chef/style/chef_whaaat.rb
@@ -31,7 +31,7 @@ module RuboCop
         #   Chef Software makes software
         #   Chef Infra configures your systems
         #
-        class ChefWhaaat < Cop
+        class ChefWhaaat < Base
           MSG = 'Do you mean Chef (the company) or a Chef product (e.g. Chef Infra, Chef InSpec, etc)?'
 
           def on_new_investigation

--- a/lib/rubocop/monkey_patches/team.rb
+++ b/lib/rubocop/monkey_patches/team.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# require "pry"
+
 module RuboCop
   module Cop
     class Team
@@ -11,6 +13,8 @@ module RuboCop
 
       ### START COOKSTYLE MODIFICATION
       def roundup_relevant_cops(filename)
+
+ #       binding.pry
         cops.reject do |cop|
           cop.excluded_file?(filename) ||
             !support_target_ruby_version?(cop) ||

--- a/lib/rubocop/monkey_patches/team.rb
+++ b/lib/rubocop/monkey_patches/team.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# require "pry"
-
 module RuboCop
   module Cop
     class Team
@@ -13,8 +11,6 @@ module RuboCop
 
       ### START COOKSTYLE MODIFICATION
       def roundup_relevant_cops(filename)
-
- #       binding.pry
         cops.reject do |cop|
           cop.excluded_file?(filename) ||
             !support_target_ruby_version?(cop) ||

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -50,7 +50,7 @@ begin
 
     def main
       require 'yaml' unless defined?(YAML)
-      all_cops = RuboCop::Cop::Cop.registry
+      all_cops = RuboCop::Cop::Base.registry
       chef_departments = all_cops.departments.select { |d| d.start_with?('Chef', 'InSpec') }.sort
       config = RuboCop::ConfigLoader.load_file('config/default.yml')
 
@@ -95,7 +95,7 @@ begin
 
     ok = true
     YARD::Registry.load!
-    cops = RuboCop::Cop::Cop.registry
+    cops = RuboCop::Cop::Base.registry
     cops.each do |cop|
       examples = YARD::Registry.all(:class).find do |code_object|
         next unless RuboCop::Cop::Badge.for(code_object.to_s) == cop.badge


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We're upgrading all the things to use cookstyle. During the upgrade for Ohai, we came across a version conflict - Cookstyle was locked to Rubocop v1.25.1 but Ohai requires Rubocop-performance which was locked to v1.72.1 of rubocop. So I am updating Cookstyle here. I nuked the monkey-patches as they were creating chaos with the new rubocop version. The other changes below are because I was getting warnings/errors when running "rake style". 


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
