### PR TITLE
Update to RuboCop 1.80.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## Cookstyle 8.5.0
+
+- Upgrade RuboCop to 1.80.2
+
 ## Cookstyle 8.4.0
 
 - Upgrade RuboCop to 1.79.2

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Cookstyle
   VERSION = "8.4.0" # rubocop: disable Style/StringLiterals
-  RUBOCOP_VERSION = '1.79.2'
+  RUBOCOP_VERSION = '1.80.2'
 end


### PR DESCRIPTION
## Description

Update to RuboCop 1.80.2 and prep the 8.5.0 release. This release includes a very large number of bug fixes and overall improvements, but no new cops.