### PR TITLE
Update to Rubocop 1.81 + enable new cop

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ## Cookstyle 8.5.0
 
-- Upgrade RuboCop to 1.80.2
+- Upgrade RuboCop to 1.81.0
+- Enable the new `Style/ArrayIntersectWithSingleElement` cop.
 
 ## Cookstyle 8.4.0
 

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -868,6 +868,10 @@ Lint/UselessDefaultValueArgument:
 Style/CollectionQuerying:
   Enabled: true
 
+# use `include?(element)` instead of `intersect?([element])`
+Style/ArrayIntersectWithSingleElement:
+  Enabled: true
+
 Chef/Deprecations/Ruby27KeywordArgumentWarnings:
   Description: Pass options to shell_out helpers without the brackets to avoid Ruby 2.7 deprecation warnings.
   Enabled: true

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -3297,3 +3297,7 @@ Lint/UselessDefaultValueArgument:
 # use helpers like .any?, .none?, and .one? instead of using count on collections which is much slower
 Style/CollectionQuerying:
   Enabled: true
+
+# use `include?(element)` instead of `intersect?([element])`
+Style/ArrayIntersectWithSingleElement:
+  Enabled: true

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Cookstyle
   VERSION = "8.4.4" # rubocop: disable Style/StringLiterals
-  RUBOCOP_VERSION = '1.80.2'
+  RUBOCOP_VERSION = '1.81.0'
 end


### PR DESCRIPTION
Enable a new cop that will probably never find anything, but is a good practice for users

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
