### PR TITLE
Improve deprecation message for ChefShellout cop

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/chef_shellout.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_shellout.rb
@@ -81,3 +81,5 @@ module RuboCop
     end
   end
 end
+
+# Signed-off update for DCO compliance

--- a/lib/rubocop/cop/chef/deprecation/chef_shellout.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_shellout.rb
@@ -19,7 +19,7 @@ module RuboCop
   module Cop
     module Chef
       module Deprecations
-        # Don't use the deprecated `Chef::ShellOut` class which was removed in Chef Infra Client 13. Use the `Mixlib::ShellOut` class instead, which behaves identically or convert to the simpler `shell_out` helper.
+        # Avoid using the deprecated `Chef::ShellOut` class (removed in Chef Infra Client 13). Replace it with `Mixlib::ShellOut` or use the `shell_out` helper for simpler command execution.
         #
         # @example
         #
@@ -37,7 +37,7 @@ module RuboCop
           include RangeHelp
           extend AutoCorrector
 
-          MSG = "Don't use the deprecated `Chef::ShellOut` class which was removed in Chef Infra Client 13. Use the `Mixlib::ShellOut` class instead, which behaves identically."
+         MSG = "Avoid using the deprecated `Chef::ShellOut` class (removed in Chef Infra Client 13). Replace it with `Mixlib::ShellOut` or use the `shell_out` helper for simpler command execution."
           RESTRICT_ON_SEND = [:new, :require, :include].freeze
 
           def_node_matcher :include_shellout?, <<-PATTERN

--- a/lib/rubocop/cop/chef/deprecation/chef_shellout.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_shellout.rb
@@ -36,8 +36,7 @@ module RuboCop
         class ChefShellout < Base
           include RangeHelp
           extend AutoCorrector
-
-         MSG = "Avoid using the deprecated `Chef::ShellOut` class (removed in Chef Infra Client 13). Replace it with `Mixlib::ShellOut` or use the `shell_out` helper for simpler command execution."
+          MSG = "Avoid using the deprecated `Chef::ShellOut` class (removed in Chef Infra Client 13). Replace it with `Mixlib::ShellOut` or use the `shell_out` helper for simpler command execution."
           RESTRICT_ON_SEND = [:new, :require, :include].freeze
 
           def_node_matcher :include_shellout?, <<-PATTERN
@@ -82,4 +81,3 @@ module RuboCop
   end
 end
 
-# Signed-off update for DCO compliance


### PR DESCRIPTION
This change improves the deprecation warning message for the ChefShellout cop.

The previous message mentioned only Mixlib::ShellOut as a replacement. The updated message now clearly recommends either using Mixlib::ShellOut or the shell_out helper, which is a simpler and commonly used alternative.

This update improves clarity for users encountering the deprecation warning without changing any cop behavior or functionality.
