### PR TITLE
Update to RuboCop 1.86.1 + enable new cops

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Cookstyle is a [code linting](https://en.wikipedia.org/wiki/Lint_%28software%29) tool that helps you to write better Chef Infra cookbooks and InSpec profiles by detecting and automatically correcting style, syntax, logic, and security mistakes in your code.
 
-Cookstyle is powered by the [RuboCop](https://www.rubocop.org) linting engine. RuboCop ships with over three-hundred rules, or cops, designed to detect common Ruby coding mistakes and enforce a common coding style. We've customized Cookstyle with a subset of those cops that we believe are perfectly tailored for cookbook development. We also ship **260 Chef Infra specific cops** that catch common cookbook coding mistakes, clean up portions of code that are no longer necessary, and detect deprecations that prevent cookbooks from running on the latest releases of Chef Infra Client.
+Cookstyle is powered by the [RuboCop](https://www.rubocop.org) linting engine. RuboCop ships with over three-hundred rules, or cops, designed to detect common Ruby coding mistakes and enforce a common coding style. We've customized Cookstyle with a subset of those cops that we believe are perfectly tailored for cookbook development. We also ship **250+ Chef Infra specific cops** that catch common cookbook coding mistakes, clean up portions of code that are no longer necessary, and detect deprecations that prevent cookbooks from running on the latest releases of Chef Infra Client.
 
 For complete usage documentation along with documentation for all the included cops see https://docs.chef.io/workstation/cookstyle/
 
@@ -109,13 +109,13 @@ As with RuboCop, any custom settings can still be placed in a `.rubocop.yml` fil
 
 Many of the cops included in Cookstyle will autocorrect Chef Infra cookbook code in ways that will require fairly recent releases of Chef Infra Client in order to run those cookbooks. For example, the `Chef/Modernize/UnnecessaryDependsChef14` cop will remove cookbook dependencies from your `metadata.rb` which are no longer necessary with Chef Infra Client 14+. This cop would be problematic if you ran it against your cookbooks, and had yet to upgrade your fleet of systems to Chef Infra Client 14+. For this reason you may want to configure Cookstyle to skip cops that would be destructive on older versions of Chef Infra Client.
 
-Cookstyle includes a top-level configuration option TargetChefVersion. This configuration option works similarly to RuboCop's TargetRubyVersion config option and allows you to specify a Chef Infra version that you want to target in your Cookstyle analysis. By setting the target version you disable incompatible cops and autocorrect from running. This allows you to gradually update your target version to allow stepped upgrades of Chef Infra Client such as 12.something -> 12.latest -> 13.latest -> 14.latest -> 15.latest.
+Cookstyle includes a top-level configuration option TargetChefVersion. This configuration option works similarly to RuboCop's TargetRubyVersion config option and allows you to specify a Chef Infra version that you want to target in your Cookstyle analysis. By setting the target version you disable incompatible cops and autocorrect from running. This allows you to gradually update your target version to allow stepped upgrades of Chef Infra Client such as 15.something -> 15.latest -> 16.latest -> 17.latest -> 18.latest.
 
-Example .rubocop.yml config specifying a TargetChefVersion of 14.0:
+Example .rubocop.yml config specifying a TargetChefVersion of 16.0:
 
 ```yaml
 AllCops:
-  TargetChefVersion: 14.0
+  TargetChefVersion: 16.0
 ```
 
 ## Getting Involved

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -880,6 +880,42 @@ Style/ModuleMemberExistenceCheck:
 Style/NegativeArrayIndex:
   Enabled: true
 
+# avoid a map to single and then a join when just a join would do
+Style/MapJoin:
+   Enabled: true
+
+# Use .partition instead of calls to both .select and .reject
+Style/PartitionInsteadOfDoubleSelect:
+  Enabled: true
+
+# avoid unecessary blocks
+Style/PredicateWithKind:
+  Enabled: true
+
+# Use .to_h instead of rolling your own hash construction
+Style/ReduceToHash:
+  Enabled: true
+
+# Use .max and .min instead of max_by and min_by with a block
+Style/RedundantMinMaxBy:
+  Enabled: true
+
+# avoid keyword_init when it's not necessary
+Style/RedundantStructKeywordInit:
+  Enabled: true
+
+# avoid select and reject with an uncessary block to select on class
+Style/SelectByKind:
+  Enabled: true
+
+# use .grep and .grep_v for simple ranges
+Style/SelectByRange:
+  Enabled: true
+
+# Use new .tally method that is much simpler that group_by with a block
+Style/TallyMethod:
+  Enabled: true
+
 Chef/Deprecations/Ruby27KeywordArgumentWarnings:
   Description: Pass options to shell_out helpers without the brackets to avoid Ruby 2.7 deprecation warnings.
   Enabled: true

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -3309,3 +3309,39 @@ Style/ModuleMemberExistenceCheck:
 # simplify array access
 Style/NegativeArrayIndex:
   Enabled: true
+
+# avoid a map to single and then a join when just a join would do
+Style/MapJoin:
+   Enabled: true
+
+# Use .partition instead of calls to both .select and .reject
+Style/PartitionInsteadOfDoubleSelect:
+  Enabled: true
+
+# avoid unecessary blocks
+Style/PredicateWithKind:
+  Enabled: true
+
+# Use .to_h instead of rolling your own hash construction
+Style/ReduceToHash:
+  Enabled: true
+
+# Use .max and .min instead of max_by and min_by with a block
+Style/RedundantMinMaxBy:
+  Enabled: true
+
+# avoid keyword_init when it's not necessary
+Style/RedundantStructKeywordInit:
+  Enabled: true
+
+# avoid select and reject with an uncessary block to select on class
+Style/SelectByKind:
+  Enabled: true
+
+# use .grep and .grep_v for simple ranges
+Style/SelectByRange:
+  Enabled: true
+
+# Use new .tally method that is much simpler that group_by with a block
+Style/TallyMethod:
+  Enabled: true

--- a/lib/cookstyle/version.rb
+++ b/lib/cookstyle/version.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 module Cookstyle
+  # version of cookstyle
   VERSION = "8.6.13" # rubocop: disable Style/StringLiterals
-  RUBOCOP_VERSION = '1.84.2'
+
+  # version of rubocop we pin to
+  RUBOCOP_VERSION = '1.86.1'
 end

--- a/lib/rubocop/monkey_patches/registry_cop.rb
+++ b/lib/rubocop/monkey_patches/registry_cop.rb
@@ -3,12 +3,10 @@ module RuboCop
   module Cop
     class Registry
       # we monkeypatch this warning to replace rubocop with cookstyle
-      def print_warning(name, path)
-        message = "#{path}: Warning: no department given for #{name}."
-        if path.end_with?('.rb')
-          message += ' Run `cookstyle -a --only Migration/DepartmentName` to fix.'
-        end
-        warn message
+      def print_department_missing_warning(name, path)
+        message = "no department given for #{name}."
+        message += ' Run `cookstyle -a --only Migration/DepartmentName` to fix.' if path.end_with?('.rb')
+        emit_warning(path, message)
       end
     end
   end


### PR DESCRIPTION
Update RuboCop from 1.84.2 to 1.86.0 and enable the following new cops:

- Style/MapJoin
- Style/PartitionInsteadOfDoubleSelect
- Style/PredicateWithKind
- Style/RedundantToHash
- Style/RedundantMinMaxBy
- Style/RedundantStructKeywordInit
- Style/SelectByKind
- Style/SelectByRange
- Style/TallyMethod