### PR TITLE
Fix cookstyle:disable ignored by RuboCop CommentConfig fast-path

### DIFF
--- a/lib/cookstyle.rb
+++ b/lib/cookstyle.rb
@@ -8,6 +8,7 @@ require 'yaml' unless defined?(YAML)
 gem 'rubocop', "= #{Cookstyle::RUBOCOP_VERSION}"
 require 'rubocop'
 require_relative 'rubocop/monkey_patches/directive_comment'
+require_relative 'rubocop/monkey_patches/comment_config'
 
 # monkey patches needed for the TargetChefVersion config option
 require_relative 'rubocop/monkey_patches/config'

--- a/lib/rubocop/monkey_patches/comment_config.rb
+++ b/lib/rubocop/monkey_patches/comment_config.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # RuboCop >= 1.40.0 introduced a performance fast-path in CommentConfig that
+  # skips directive parsing when the raw source does not contain the literal
+  # string "rubocop".  Because Cookstyle also supports "# cookstyle:disable"
+  # directives, we must also check for "cookstyle" so that those directives
+  # are not silently ignored.
+  class CommentConfig
+    alias_method :original_initialize, :initialize
+
+    def initialize(processed_source)
+      original_initialize(processed_source)
+      # Re-evaluate @no_directives to also consider "cookstyle" comments
+      if @no_directives && processed_source.raw_source.include?('cookstyle')
+        @no_directives = false
+      end
+    end
+  end
+end

--- a/spec/rubocop/monkey_patches/cookstyle_comment_spec.rb
+++ b/spec/rubocop/monkey_patches/cookstyle_comment_spec.rb
@@ -18,6 +18,8 @@
 # this is shamelessly copied from the rubocop rspec for this class
 # since we're just monkeypatching it and we want to ensure our monkeypatch
 # continues to function when we upgrade the engine
+require 'spec_helper'
+
 RSpec.describe RuboCop::CommentConfig do
   subject(:comment_config) { described_class.new(parse_source(source)) }
 
@@ -42,6 +44,30 @@ RSpec.describe RuboCop::CommentConfig do
 
     it 'supports disabling cops with the cookstyle: disable comment' do
       expect(disabled_lines_of_cop('Chef/Correctness/Foo')).to eq([2])
+    end
+  end
+
+  describe '#cop_enabled_at_line? with only cookstyle directives (no rubocop string)' do
+    let(:source) do
+      <<~RUBY
+        node.normal[:foo] # cookstyle:disable Chef/Correctness/Foo
+        node.normal[:bar]
+      RUBY
+    end
+
+    def disabled_lines_of_cop(cop)
+      (1..source.size).each_with_object([]) do |line_number, disabled_lines|
+        enabled = comment_config.cop_enabled_at_line?(cop, line_number)
+        disabled_lines << line_number unless enabled
+      end
+    end
+
+    it 'supports disabling cops when only cookstyle directives are present' do
+      expect(disabled_lines_of_cop('Chef/Correctness/Foo')).to eq([1])
+    end
+
+    it 'does not disable cops on lines without a directive' do
+      expect(comment_config.cop_enabled_at_line?('Chef/Correctness/Foo', 2)).to be true
     end
   end
 end


### PR DESCRIPTION
https://progresssoftware.atlassian.net/browse/CHEF-35543
Summary
- What changed and why: Added a CommentConfig monkey patch so RuboCop's fast-path (@no_directives) also recognizes cookstyle directives, preventing # cookstyle:disable from being silently ignored on RuboCop >= 1.40.
- Plan: Inline summary: (1) reproduce and confirm fast-path gate behavior, (2) patch RuboCop::CommentConfig initialization logic for cookstyle directives, (3) load patch from cookstyle entrypoint, (4) add regression specs for files containing only cookstyle directives.
- Files/paths touched
  - lib/cookstyle.rb
  - lib/rubocop/monkey_patches/comment_config.rb
  - spec/rubocop/monkey_patches/cookstyle_comment_spec.rb

Evidence
- Tests/logs/metrics: bundle exec rspec spec/rubocop/monkey_patches/cookstyle_comment_spec.rb -> 4 examples, 0 failures; bundle exec cookstyle lib/rubocop/monkey_patches/comment_config.rb spec/rubocop/monkey_patches/cookstyle_comment_spec.rb lib/cookstyle.rb -> 3 files inspected, no offenses; bundle exec rake coverage -> completed successfully with test run summary ending at 967 examples, 0 failures.
- Coverage: Contract evidence: bundle exec rake coverage exited successfully; task output did not print a numeric percentage in terminal output, but full coverage task completed without failures.
