### PR TITLE
Add Chef/RedundantCode/ServiceGuardOnStopDisable cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2260,6 +2260,16 @@ Chef/RedundantCode/DoubleCompileTime:
     - '**/attributes/*.rb'
     - '**/Berksfile'
 
+Chef/RedundantCode/ServiceGuardOnStopDisable:
+  Description: "The `:stop` and `:disable` actions of the `service` resource are already no-ops when the service isn't installed, so guarding them with a check for the init script or unit file is redundant. It's also fragile, since the guard hardcodes a single path while the provider searches several."
+  StyleGuide: 'chef_redundantcode_serviceguardonstopdisable'
+  Enabled: true
+  VersionAdded: '8.8.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 ###############################
 # Chef/Effortless: Migrating to new patterns
 ###############################

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_serviceguardonstopdisable.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_serviceguardonstopdisable.yml
@@ -1,0 +1,38 @@
+---
+short_name: ServiceGuardOnStopDisable
+full_name: Chef/RedundantCode/ServiceGuardOnStopDisable
+department: Chef/RedundantCode
+description: |-
+  The `:stop` and `:disable` actions of the `service` resource are already no-ops when the service
+  isn't installed, so guarding them with a check for the init script or unit file adds nothing. The
+  base provider only converges these actions when `current_resource.running`/`current_resource.enabled`
+  is set, and the platform providers never set that state for a service they can't find.
+
+  The guard is also actively harmful because it hardcodes a single path while the provider searches
+  several. A guard on `/usr/local/etc/rc.d/snmpd` skips a FreeBSD host running the service out of
+  `/etc/rc.d`, and the run then reports success while leaving the service enabled.
+
+  This cop only fires when every action is `:stop` or `:disable`. Actions like `:start`, `:enable`,
+  `:restart`, and `:reload` are asserted against the init script, so a guard there is meaningful. The
+  `systemd_unit` resource shells out unconditionally, so its guards are meaningful as well and are
+  never flagged.
+autocorrection: true
+target_chef_version: All Versions
+examples: |2-
+
+  # bad
+  service 'snmpd' do
+    action %i(stop disable)
+    only_if { ::File.exist?('/usr/local/etc/rc.d/snmpd') }
+  end
+
+  # good
+  service 'snmpd' do
+    action %i(stop disable)
+  end
+version_added: 8.8.0
+enabled: true
+excluded_file_paths:
+- "**/metadata.rb"
+- "**/attributes/*.rb"
+- "**/Berksfile"

--- a/lib/rubocop/cop/chef/redundant/service_guard_on_stop_disable.rb
+++ b/lib/rubocop/cop/chef/redundant/service_guard_on_stop_disable.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module RedundantCode
+        # The `:stop` and `:disable` actions of the `service` resource are already no-ops when the service
+        # isn't installed, so guarding them with a check for the init script or unit file adds nothing. The
+        # base provider only converges these actions when `current_resource.running`/`current_resource.enabled`
+        # is set, and the platform providers never set that state for a service they can't find.
+        #
+        # The guard is also actively harmful because it hardcodes a single path while the provider searches
+        # several. A guard on `/usr/local/etc/rc.d/snmpd` skips a FreeBSD host running the service out of
+        # `/etc/rc.d`, and the run then reports success while leaving the service enabled.
+        #
+        # This cop only fires when every action is `:stop` or `:disable`. Actions like `:start`, `:enable`,
+        # `:restart`, and `:reload` are asserted against the init script, so a guard there is meaningful. The
+        # `systemd_unit` resource shells out unconditionally, so its guards are meaningful as well and are
+        # never flagged.
+        #
+        # @example
+        #
+        #   # bad
+        #   service 'snmpd' do
+        #     action %i(stop disable)
+        #     only_if { ::File.exist?('/usr/local/etc/rc.d/snmpd') }
+        #   end
+        #
+        #   # good
+        #   service 'snmpd' do
+        #     action %i(stop disable)
+        #   end
+        #
+        class ServiceGuardOnStopDisable < Base
+          include RuboCop::Chef::CookbookHelpers
+          include RangeHelp
+          extend AutoCorrector
+
+          MSG = 'A service resource that only stops or disables a service does not need a guard checking for the init script or unit file. Chef Infra Client already skips these actions when the service does not exist, and hardcoding a single path can silently skip services installed elsewhere.'
+
+          # actions that Chef Infra Client treats as no-ops when the service can't be found
+          NO_OP_ACTIONS = %i(stop disable).freeze
+
+          # the directories the various service providers search for init scripts and unit files
+          INIT_SCRIPT_PATH = %r{/(?:etc/init\.d|etc/rc\.d|usr/local/etc/rc\.d|etc/sv|systemd/system)/}.freeze
+
+          def_node_matcher :file_exist_check, <<~PATTERN
+            (send (const {nil? cbase} :File) {:exist? :exists? :executable? :file? :readable?} $_)
+          PATTERN
+
+          def_node_search :action_nodes, '(send nil? :action $...)'
+
+          def on_block(node)
+            match_property_in_resource?(:service, %i(only_if not_if), node) do |guard|
+              # a string guard like `only_if 'test -f /etc/init.d/foo'` isn't a Ruby block
+              next unless guard.block_type?
+              next unless only_no_op_actions?(node)
+
+              # `guard.body` is only a bare send when the block does nothing but the existence check.
+              # Anything more (a `&&`, a second statement) is a guard we shouldn't touch.
+              path = file_exist_check(guard.body)
+              next unless path && INIT_SCRIPT_PATH.match?(path.source)
+
+              add_offense(guard, severity: :refactor) do |corrector|
+                corrector.remove(range_by_whole_lines(guard.source_range, include_final_newline: true))
+              end
+            end
+          end
+
+          private
+
+          # @param [RuboCop::AST::BlockNode] node the resource block
+          #
+          # @return [Boolean] the resource declares at least one action and all of them are no-ops
+          #                   for a service that isn't installed
+          def only_no_op_actions?(node)
+            actions = action_nodes(node).flat_map { |args| args.flat_map { |arg| action_symbols(arg) } }
+            !actions.empty? && actions.all? { |action| NO_OP_ACTIONS.include?(action) }
+          end
+
+          # Unwrap the ways an action can be written: `action :stop`, `action %i(stop disable)`,
+          # and `action [:stop, :disable]`. Anything else (a variable, a node attribute) yields nil,
+          # which fails the NO_OP_ACTIONS check and leaves the resource alone.
+          #
+          # @param [RuboCop::AST::Node] node
+          #
+          # @return [Array<Symbol, nil>]
+          def action_symbols(node)
+            case node.type
+            when :sym
+              [node.value]
+            when :array
+              node.values.flat_map { |value| action_symbols(value) }
+            else
+              [nil]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/redundant/service_guard_on_stop_disable_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/service_guard_on_stop_disable_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::RedundantCode::ServiceGuardOnStopDisable, :config do
+  it 'registers an offense when a service that stops and disables guards on the rc.d script' do
+    expect_offense(<<~RUBY)
+      service 'snmpd' do
+        action %i(stop disable)
+        only_if { ::File.exist?('/usr/local/etc/rc.d/snmpd') }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A service resource that only stops or disables a service does not need a guard checking for the init script or unit file. Chef Infra Client already skips these actions when the service does not exist, and hardcoding a single path can silently skip services installed elsewhere.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      service 'snmpd' do
+        action %i(stop disable)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a service only stops and guards on the init.d script' do
+    expect_offense(<<~RUBY)
+      service 'apache2' do
+        action :stop
+        only_if { File.exist?('/etc/init.d/apache2') }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A service resource that only stops or disables a service does not need a guard checking for the init script or unit file. Chef Infra Client already skips these actions when the service does not exist, and hardcoding a single path can silently skip services installed elsewhere.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      service 'apache2' do
+        action :stop
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a service only disables and guards on a systemd unit file' do
+    expect_offense(<<~RUBY)
+      service 'chronyd' do
+        action :disable
+        only_if { ::File.exist?('/usr/lib/systemd/system/chronyd.service') }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A service resource that only stops or disables a service does not need a guard checking for the init script or unit file. Chef Infra Client already skips these actions when the service does not exist, and hardcoding a single path can silently skip services installed elsewhere.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      service 'chronyd' do
+        action :disable
+      end
+    RUBY
+  end
+
+  it 'registers an offense with a not_if guard' do
+    expect_offense(<<~RUBY)
+      service 'snmpd' do
+        action [:stop, :disable]
+        not_if { ::File.exist?('/etc/rc.d/snmpd') }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A service resource that only stops or disables a service does not need a guard checking for the init script or unit file. Chef Infra Client already skips these actions when the service does not exist, and hardcoding a single path can silently skip services installed elsewhere.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      service 'snmpd' do
+        action [:stop, :disable]
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the guarded path is interpolated' do
+    expect_offense(<<~'RUBY')
+      service 'snmpd' do
+        action %i(stop disable)
+        only_if { ::File.exist?("/etc/init.d/#{node['snmpd']['service_name']}") }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A service resource that only stops or disables a service does not need a guard checking for the init script or unit file. Chef Infra Client already skips these actions when the service does not exist, and hardcoding a single path can silently skip services installed elsewhere.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      service 'snmpd' do
+        action %i(stop disable)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the guard uses ::File.exists? or ::File.executable?' do
+    expect_offense(<<~RUBY)
+      service 'snmpd' do
+        action :stop
+        only_if { ::File.exists?('/etc/init.d/snmpd') }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A service resource that only stops or disables a service does not need a guard checking for the init script or unit file. Chef Infra Client already skips these actions when the service does not exist, and hardcoding a single path can silently skip services installed elsewhere.
+      end
+
+      service 'sshd' do
+        action :disable
+        only_if { ::File.executable?('/usr/local/etc/rc.d/sshd') }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A service resource that only stops or disables a service does not need a guard checking for the init script or unit file. Chef Infra Client already skips these actions when the service does not exist, and hardcoding a single path can silently skip services installed elsewhere.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      service 'snmpd' do
+        action :stop
+      end
+
+      service 'sshd' do
+        action :disable
+      end
+    RUBY
+  end
+
+  it 'removes only the guard and leaves the other properties alone' do
+    expect_offense(<<~RUBY)
+      service 'snmpd' do
+        service_name 'snmpd'
+        supports status: true
+        action %i(stop disable)
+        only_if { ::File.exist?('/usr/local/etc/rc.d/snmpd') }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A service resource that only stops or disables a service does not need a guard checking for the init script or unit file. Chef Infra Client already skips these actions when the service does not exist, and hardcoding a single path can silently skip services installed elsewhere.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      service 'snmpd' do
+        service_name 'snmpd'
+        supports status: true
+        action %i(stop disable)
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the actions include :start" do
+    expect_no_offenses(<<~RUBY)
+      service 'snmpd' do
+        action %i(enable start)
+        only_if { ::File.exist?('/usr/local/etc/rc.d/snmpd') }
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the actions include :restart alongside :stop" do
+    expect_no_offenses(<<~RUBY)
+      service 'snmpd' do
+        action %i(stop restart)
+        only_if { ::File.exist?('/usr/local/etc/rc.d/snmpd') }
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense on a systemd_unit resource" do
+    expect_no_offenses(<<~RUBY)
+      systemd_unit 'snmpd.service' do
+        action %i(stop disable)
+        only_if { ::File.exist?('/etc/systemd/system/snmpd.service') }
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when no action is specified" do
+    expect_no_offenses(<<~RUBY)
+      service 'snmpd' do
+        only_if { ::File.exist?('/usr/local/etc/rc.d/snmpd') }
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard checks something other than an init script" do
+    expect_no_offenses(<<~RUBY)
+      service 'snmpd' do
+        action %i(stop disable)
+        only_if { ::File.exist?('/etc/snmp/snmpd.conf') }
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard is a shell command" do
+    expect_no_offenses(<<~RUBY)
+      service 'snmpd' do
+        action %i(stop disable)
+        only_if 'test -f /usr/local/etc/rc.d/snmpd'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard does more than check for the init script" do
+    expect_no_offenses(<<~RUBY)
+      service 'snmpd' do
+        action %i(stop disable)
+        only_if do
+          ::File.exist?('/usr/local/etc/rc.d/snmpd') && node['snmpd']['manage']
+        end
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard checks the service with a shell_out" do
+    expect_no_offenses(<<~RUBY)
+      service 'snmpd' do
+        action %i(stop disable)
+        only_if { shell_out('service snmpd status').exitstatus == 0 }
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Closes #1082

Flags a `service` resource whose actions are limited to `:stop` and/or `:disable` and which carries an `only_if`/`not_if` guard that merely tests for the existence of the init script or unit file.

```ruby
# bad
service 'snmpd' do
  action %i(stop disable)
  only_if { ::File.exist?('/usr/local/etc/rc.d/snmpd') }
end

# good
service 'snmpd' do
  action %i(stop disable)
end
```

## Why it's redundant

Both actions are already no-ops for a service that isn't installed. The base provider only converges them when the current state says otherwise:

```ruby
# chef/provider/service.rb
action :disable do
  if current_resource.enabled
    converge_by("disable service #{new_resource}") { disable_service }
  else
    logger.debug("#{new_resource} already disabled - nothing to do")
  end
end
```

And the platform providers never populate that state when the service is absent. FreeBSD's `load_current_resource` returns early when no rc.d script is found, and `define_resource_requirements` deliberately excludes `:stop` and `:disable` from the assertion that requires an rc script. On systemd, `systemctl show` exits 0 for an unknown unit with an empty `UnitFileState`, so `is_enabled?` and `is_active?` both return false.

## Why it's worse than redundant

The guard hardcodes one path while the provider searches several:

```ruby
# chef/provider/service/freebsd.rb
if ::TargetIO::File.exist?("/etc/rc.d/#{new_resource.service_name}")
  @init_command = "/etc/rc.d/#{new_resource.service_name}"
elsif ::TargetIO::File.exist?("/usr/local/etc/rc.d/#{new_resource.service_name}")
  @init_command = "/usr/local/etc/rc.d/#{new_resource.service_name}"
end
```

A guard on `/usr/local/etc/rc.d/snmpd` skips a host running base `bsnmpd` out of `/etc/rc.d`, and vice versa. The converge then reports success while leaving the daemon enabled — the failure mode you least want from a hardening recipe.

## Scope

The cop fails closed. It's deliberately narrow about what it will delete:

- **Only `service`.** `systemd_unit` shells out unconditionally, so `systemctl disable` on a missing unit really does fail and the guard is required. It's never flagged.
- **Only when every action is `:stop` or `:disable`.** `:start`, `:enable`, `:restart`, and `:reload` are asserted against `init_command`, so a guard there is meaningful. Handles `action :stop`, `action %i(stop disable)`, and `action [:stop, :disable]`. An action that can't be statically resolved (a variable, a node attribute) is treated as unknown and leaves the resource alone. No action at all is skipped too, since the default is `:nothing`.
- **Only the "does the init script exist" shape.** The guard block's sole expression must be `File.exist?`/`exists?`/`executable?`/`file?`/`readable?` (bare or `::`-scoped) on a path under `/etc/init.d/`, `/etc/rc.d/`, `/usr/local/etc/rc.d/`, `/etc/sv/`, or `*/systemd/system/`. A guard on a config file, a package, or a node attribute is left alone, as is a compound guard (`File.exist?(...) && node[...]`) or a shell-string guard (`only_if 'test -f ...'`). Interpolated paths like `"/etc/init.d/#{node['x']['service_name']}"` still match, since the literal directory prefix is present.

Autocorrect removes just the guard line and leaves the rest of the resource untouched.

## Verification

- `bundle exec rspec` — 982 examples, 0 failures (15 new)
- `bundle exec cookstyle` — no offenses in the new files
- `bundle exec rake validate_config` — cop registered; the 5 remaining `Chef/Ruby/*` errors are pre-existing on `main`
- End-to-end CLI run plus `-a` autocorrect against a sample recipe, output confirmed `Syntax OK`

Docs asset generated with `rake generate_cops_yml_documentation`. `VersionAdded` is set to `8.8.0` — happy to change it if this ships as a patch instead.