### PR TITLE
Fix Chef/Correctness/ChefApplicationFatal missing calls with an exit code

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -406,6 +406,7 @@ Chef/Correctness/ChefApplicationFatal:
   StyleGuide: 'chef_correctness_chefapplicationfatal'
   Enabled: true
   VersionAdded: '6.0.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/Berksfile'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_chefapplicationfatal.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_chefapplicationfatal.yml
@@ -2,14 +2,19 @@
 short_name: ChefApplicationFatal
 full_name: Chef/Correctness/ChefApplicationFatal
 department: Chef/Correctness
-description: Use `raise` to force Chef Infra Client to fail instead of using `Chef::Application.fatal`,
-  which masks the full stack trace of the failure and makes debugging difficult.
+description: |-
+  Use `raise` to force Chef Infra Client to fail instead of using `Chef::Application.fatal`, which masks the full stack trace of the failure and makes debugging difficult.
+
+  `Chef::Application.fatal!` optionally takes an exit code as a second argument. That form is
+  reported but not autocorrected, since `raise` has no way to express a specific exit code and
+  rewriting it would silently change how the run terminates.
 autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
   # bad
   Chef::Application.fatal!('Something horrible happened!')
+  Chef::Application.fatal!('Something horrible happened!', 1)
 
   # good
   raise "Something horrible happened!"

--- a/lib/rubocop/cop/chef/correctness/chef_application_fatal.rb
+++ b/lib/rubocop/cop/chef/correctness/chef_application_fatal.rb
@@ -21,10 +21,15 @@ module RuboCop
       module Correctness
         # Use `raise` to force Chef Infra Client to fail instead of using `Chef::Application.fatal`, which masks the full stack trace of the failure and makes debugging difficult.
         #
+        # `Chef::Application.fatal!` optionally takes an exit code as a second argument. That form is
+        # reported but not autocorrected, since `raise` has no way to express a specific exit code and
+        # rewriting it would silently change how the run terminates.
+        #
         # @example
         #
         #   # bad
         #   Chef::Application.fatal!('Something horrible happened!')
+        #   Chef::Application.fatal!('Something horrible happened!', 1)
         #
         #   # good
         #   raise "Something horrible happened!"
@@ -38,14 +43,21 @@ module RuboCop
           def_node_matcher :application_fatal?, <<-PATTERN
             (send
               (const
-                (const nil? :Chef) :Application) :fatal!
-              $( ... ))
+                (const {nil? cbase} :Chef) :Application) :fatal!
+              $...)
           PATTERN
 
           def on_send(node)
-            application_fatal?(node) do |val|
+            application_fatal?(node) do |args|
+              # Only the single message argument form maps cleanly onto raise. With an exit code (or
+              # with no message at all) we still report, but leave the rewrite to a human.
+              unless args.one?
+                add_offense(node, severity: :refactor)
+                next
+              end
+
               add_offense(node, severity: :refactor) do |corrector|
-                corrector.replace(node, "raise(#{val.source})")
+                corrector.replace(node, "raise(#{args.first.source})")
               end
             end
           end

--- a/spec/rubocop/cop/chef/correctness/chef_application_fatal_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/chef_application_fatal_spec.rb
@@ -29,4 +29,54 @@ describe RuboCop::Cop::Chef::Correctness::ChefApplicationFatal, :config do
       raise('foo')
     RUBY
   end
+
+  it 'registers an offense when ::Chef::Application.fatal! is called' do
+    expect_offense(<<~RUBY)
+      ::Chef::Application.fatal!('foo')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use raise to force Chef Infra Client to fail instead of using Chef::Application.fatal
+    RUBY
+
+    expect_correction(<<~RUBY)
+      raise('foo')
+    RUBY
+  end
+
+  it 'registers an offense when Chef::Application.fatal! is called with an exit code' do
+    expect_offense(<<~RUBY)
+      Chef::Application.fatal!('foo', 1)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use raise to force Chef Infra Client to fail instead of using Chef::Application.fatal
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense when ::Chef::Application.fatal! is called with an exit code' do
+    expect_offense(<<~'RUBY')
+      ::Chef::Application.fatal!("Unable to configure #{node['foo']['bar']}", 2)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use raise to force Chef Infra Client to fail instead of using Chef::Application.fatal
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense when Chef::Application.fatal! is called without any arguments' do
+    expect_offense(<<~RUBY)
+      Chef::Application.fatal!
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Use raise to force Chef Infra Client to fail instead of using Chef::Application.fatal
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it "doesn't register an offense when fatal! is called on another class" do
+    expect_no_offenses(<<~RUBY)
+      MyApp::Application.fatal!('foo', 1)
+    RUBY
+  end
+
+  it "doesn't register an offense when Chef::Log.fatal is called" do
+    expect_no_offenses(<<~RUBY)
+      Chef::Log.fatal('foo')
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #1068

`Chef::Application.fatal!("msg", 1)` went completely unreported while `Chef::Application.fatal!("msg")` was caught.

## Cause

The node pattern captured the arguments with `$( ... )`:

```ruby
def_node_matcher :application_fatal?, <<-PATTERN
  (send
    (const
      (const nil? :Chef) :Application) :fatal!
    $( ... ))
PATTERN
```

`( ... )` matches exactly one node, so a call with a message *and* an exit code has two argument nodes where the pattern demands one, and quietly fails to match. Capturing variadically with `$...` fixes it.

## Behavior after the fix

Running the reporter's exact repro:

```
dummy.rb:1:1: R: Chef/Correctness/ChefApplicationFatal: Use raise to force Chef Infra Client to fail instead of using Chef::Application.fatal
Chef::Application.fatal!("Not seen by cookstyle", 1)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
dummy.rb:3:1: R: [Correctable] Chef/Correctness/ChefApplicationFatal: Use raise to force Chef Infra Client to fail instead of using Chef::Application.fatal
Chef::Application.fatal!("Cookstyle found me")
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 2 offenses detected, 1 offense autocorrectable
```

Note the missing `[Correctable]` on the first one. **The exit code form is reported but deliberately not autocorrected.** `raise` has no way to express a specific exit code, so rewriting `Chef::Application.fatal!('msg', 1)` to `raise('msg')` under `-a` would silently change how the run terminates. Reporting without a corrector puts that judgment call in front of a human, which I think is the right answer to the issue's "identify both cases, or document why not" — it now identifies both, and the cop docs explain why only one is autocorrected.

A bare `Chef::Application.fatal!` with no arguments falls into the same reported-but-not-corrected bucket.

## Also fixed

The scope was pinned to `(const nil? :Chef)`, which does not match a cbase, so the fully qualified `::Chef::Application.fatal!` was missed as well — same class of bug, one-token fix (`{nil? cbase}`). Flagging it separately in case you'd rather it went in its own PR.

## Verification

- `bundle exec rspec` — 973 examples, 0 failures (6 new on this cop, covering both scopes, the exit code form, the no-argument form, and two no-offense cases)
- `bundle exec cookstyle` — no offenses in the changed files
- Reporter's repro confirmed by hand, including `-a`, which leaves the exit code call untouched

Docs asset regenerated with `rake generate_cops_yml_documentation`. `VersionChanged` set to `8.8.0` — adjust if this ships as a patch.