### PR TITLE
Flag the deprecated ruby_block :create action in notifications

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1029,6 +1029,7 @@ Chef/Deprecations/RubyBlockCreateAction:
   StyleGuide: 'chef_deprecations_rubyblockcreateaction'
   Enabled: true
   VersionAdded: '5.16.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/attributes/*.rb'

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_rubyblockcreateaction.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_rubyblockcreateaction.yml
@@ -16,12 +16,22 @@ examples: |2-
     action :create
   end
 
+  # bad
+  template '/etc/foo.conf' do
+    notifies :create, 'ruby_block[my special ruby block]', :immediately
+  end
+
   # good
   ruby_block 'my special ruby block' do
     block do
       puts 'running'
     end
     action :run
+  end
+
+  # good
+  template '/etc/foo.conf' do
+    notifies :run, 'ruby_block[my special ruby block]', :immediately
   end
 version_added: 5.16.0
 enabled: true

--- a/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
@@ -31,6 +31,11 @@ module RuboCop
         #     action :create
         #   end
         #
+        #   # bad
+        #   template '/etc/foo.conf' do
+        #     notifies :create, 'ruby_block[my special ruby block]', :immediately
+        #   end
+        #
         #   # good
         #   ruby_block 'my special ruby block' do
         #     block do
@@ -39,11 +44,21 @@ module RuboCop
         #     action :run
         #   end
         #
+        #   # good
+        #   template '/etc/foo.conf' do
+        #     notifies :run, 'ruby_block[my special ruby block]', :immediately
+        #   end
+        #
         class RubyBlockCreateAction < Base
           include RuboCop::Chef::CookbookHelpers
           extend AutoCorrector
 
           MSG = 'Use the :run action in the ruby_block resource instead of the deprecated :create action'
+          RESTRICT_ON_SEND = [:notifies, :subscribes].freeze
+
+          def_node_matcher :notification?, <<-PATTERN
+            (send nil? {:notifies :subscribes} $(sym :create) ${str dstr} ...)
+          PATTERN
 
           def on_block(node)
             match_property_in_resource?(:ruby_block, 'action', node) do |ruby_action|
@@ -54,6 +69,30 @@ module RuboCop
                 end
               end
             end
+          end
+
+          def on_send(node)
+            notification?(node) do |action, notified_resource|
+              next unless ruby_block?(notified_resource)
+
+              add_offense(action, severity: :warning) do |corrector|
+                corrector.replace(action, ':run')
+              end
+            end
+          end
+
+          private
+
+          # Does the notified resource string address a ruby_block? An interpolated name
+          # ("ruby_block[#{foo}]") still starts with a literal segment we can key off of, but a
+          # string whose resource type is itself interpolated tells us nothing, so we skip it.
+          #
+          # @param [RuboCop::AST::Node] node the str or dstr the notification points at
+          #
+          # @return [Boolean]
+          def ruby_block?(node)
+            literal = node.str_type? ? node : node.children.first
+            literal&.str_type? && literal.value.start_with?('ruby_block[')
           end
         end
       end

--- a/spec/rubocop/cop/chef/deprecation/ruby_block_create_action_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/ruby_block_create_action_spec.rb
@@ -50,4 +50,90 @@ describe RuboCop::Cop::Chef::Deprecations::RubyBlockCreateAction, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when a notification uses the :create action on a ruby_block' do
+    expect_offense(<<~RUBY)
+      template '/etc/foo.conf' do
+        source 'foo.conf.erb'
+        notifies :create, 'ruby_block[foo]', :immediately
+                 ^^^^^^^ Use the :run action in the ruby_block resource instead of the deprecated :create action
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      template '/etc/foo.conf' do
+        source 'foo.conf.erb'
+        notifies :run, 'ruby_block[foo]', :immediately
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a notification omits the timing' do
+    expect_offense(<<~RUBY)
+      template '/etc/foo.conf' do
+        notifies :create, 'ruby_block[foo]'
+                 ^^^^^^^ Use the :run action in the ruby_block resource instead of the deprecated :create action
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      template '/etc/foo.conf' do
+        notifies :run, 'ruby_block[foo]'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a subscription uses the :create action on a ruby_block' do
+    expect_offense(<<~RUBY)
+      template '/etc/foo.conf' do
+        subscribes :create, 'ruby_block[foo]', :immediately
+                   ^^^^^^^ Use the :run action in the ruby_block resource instead of the deprecated :create action
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      template '/etc/foo.conf' do
+        subscribes :run, 'ruby_block[foo]', :immediately
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the notified ruby_block name is interpolated' do
+    expect_offense(<<~'RUBY')
+      template '/etc/foo.conf' do
+        notifies :create, "ruby_block[#{node['foo']['name']}]", :delayed
+                 ^^^^^^^ Use the :run action in the ruby_block resource instead of the deprecated :create action
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      template '/etc/foo.conf' do
+        notifies :run, "ruby_block[#{node['foo']['name']}]", :delayed
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when a notification uses :create on another resource" do
+    expect_no_offenses(<<~RUBY)
+      template '/etc/foo.conf' do
+        notifies :create, 'template[/etc/bar.conf]', :immediately
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when a notification uses :run on a ruby_block" do
+    expect_no_offenses(<<~RUBY)
+      template '/etc/foo.conf' do
+        notifies :run, 'ruby_block[foo]', :immediately
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the notified resource type is interpolated" do
+    expect_no_offenses(<<~'RUBY')
+      template '/etc/foo.conf' do
+        notifies :create, "#{node['foo']['type']}[bar]", :immediately
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #1067

`notifies :create, "ruby_block[foo]", :immediately` was not reported, while `action :create` inside a `ruby_block` was.

## Cause

The cop only implemented `on_block`, and inside it used `match_property_in_resource?(:ruby_block, 'action', node)`. That can only ever see an `action` property *within* a `ruby_block` resource. A notification is a `send` inside some **other** resource's block, so it was structurally invisible to the cop.

## Fix

Added an `on_send` handler with `RESTRICT_ON_SEND = [:notifies, :subscribes]`. `RESTRICT_ON_SEND` gates only `on_send`, so the existing `on_block` path is untouched.

The reporter's repro now produces exactly the expected output:

```
notif.rb:3:12: W: [Correctable] Chef/Deprecations/RubyBlockCreateAction: Use the :run action in the ruby_block resource instead of the deprecated :create action
  notifies :create, "ruby_block[foo]", :immediately
           ^^^^^^^

1 file inspected, 1 offense detected, 1 offense autocorrectable
```

Autocorrect rewrites just the action symbol to `:run`, leaving the rest of the notification alone.

## Matching the notified resource

The notified resource is identified by the literal leading segment of the string, which handles both `str` and `dstr`:

- `'ruby_block[foo]'` — flagged
- `"ruby_block[#{node['foo']['name']}]"` — flagged; the interpolated part is the resource *name*, and the literal `ruby_block[` prefix is still there
- `"#{node['foo']['type']}[bar]"` — **not** flagged; the resource type is unknowable at lint time
- `'template[/etc/bar.conf]'` — not flagged

Both `notifies` and `subscribes` are covered, with and without a timing argument.

## Known remaining gaps

Two forms are still not caught, both deliberately left out of this PR:

- The legacy `notifies :create, resources(ruby_block: 'foo')` syntax. That form is already flagged by `Chef/Deprecations/LegacyNotifySyntax`, which tells users to convert it to the string form this cop now handles.
- `action %i(create)` / `action [:create]` inside a `ruby_block`. The pre-existing `on_block` path compares `action.source == ':create'`, so an array of actions slips past. Unusual for `ruby_block`, and it's a separate code path from this bug — happy to fold a fix in here if you'd prefer.

## Verification

- `bundle exec rspec` — 974 examples, 0 failures (7 new on this cop)
- `bundle exec cookstyle` — no offenses in the changed files
- Reporter's repro confirmed by hand, including `-a`

Docs asset regenerated with `rake generate_cops_yml_documentation`. `VersionChanged` set to `8.8.0` — adjust if this ships as a patch.