### PR TITLE
Fix Chef/Modernize/CronDFileOrTemplate raising on non-string path literals

### DIFF
--- a/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
+++ b/lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb
@@ -106,11 +106,13 @@ module RuboCop
             end
 
             match_property_in_resource?(%i(template file cookbook_file), 'path', node) do |code_property|
-              # instead of using CookbookHelpers#method_arg_ast_to_string, walk the property's descendants
-              # and check if their value contains '/etc/cron.d'
+              # instead of using CookbookHelpers#method_arg_ast_to_string, walk the property's string
+              # descendants and check if their value contains '/etc/cron.d'
               # covers the case where the argument to the path property is provided via a method like File.join
-              code_property.each_descendant do |d|
-                add_offense(node, severity: :refactor) if d.respond_to?(:value) && d.value.match?(%r{/etc/cron\.d\b}i)
+              # only string nodes are walked: other literals respond to #value too, but return types
+              # like Integer that have no #match?, which raised inside the cop (issue #957)
+              code_property.each_descendant(:str) do |d|
+                add_offense(node, severity: :refactor) if d.value.match?(%r{/etc/cron\.d\b}i)
               end
             end
           end

--- a/spec/rubocop/cop/chef/modernize/cron_d_file_or_template_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/cron_d_file_or_template_spec.rb
@@ -137,4 +137,48 @@ describe RuboCop::Cop::Chef::Modernize::CronDFileOrTemplate, :config do
       end
     RUBY
   end
+
+  # https://github.com/chef/cookstyle/issues/957
+  it 'does not raise when the path property indexes into an array' do
+    expect_no_offenses(<<~'RUBY')
+      [ %w( test /etc/file1 ) ].each do |arr|
+        file "file_#{arr[1]}" do
+          path arr[1]
+        end
+      end
+    RUBY
+  end
+
+  # https://github.com/chef/cookstyle/issues/957
+  it 'does not raise when the path property indexes into a hash value' do
+    expect_no_offenses(<<~'RUBY')
+      {
+        files: [ 'test', '/etc/file3'],
+      }.each do |title, config|
+        file "file_#{title}" do
+          path config[1]
+        end
+      end
+    RUBY
+  end
+
+  # https://github.com/chef/cookstyle/issues/957
+  it 'does not raise when the path property contains a non-string literal' do
+    expect_no_offenses(<<~RUBY)
+      file 'some file' do
+        path foo(1, 2.5, :sym, true, nil)
+      end
+    RUBY
+  end
+
+  # https://github.com/chef/cookstyle/issues/957
+  it 'still registers an offense when a cron.d path is built with a numeric index' do
+    expect_offense(<<~RUBY)
+      file 'delete old cron job' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the cron_d resource that ships with Chef Infra Client 14.4+ instead of manually creating the file with template, file, or cookbook_file resources
+        path ::File.join('/etc/cron.d', jobs[0])
+        action :delete
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #957

`Chef/Modernize/CronDFileOrTemplate` raised an internal cop error on ordinary `file` resources that had nothing to do with cron.

## Cause

The `path` property handler walked *every* descendant of the property node and guarded with `respond_to?(:value)`:

```ruby
code_property.each_descendant do |d|
  add_offense(node, severity: :refactor) if d.respond_to?(:value) && d.value.match?(%r{/etc/cron\.d\b}i)
end
```

`respond_to?(:value)` is too weak a guard. Literal nodes other than strings respond to `#value` as well, and return objects with no `#match?`. An `(int 1)` node returns the Integer `1`, so `path arr[1]` blew up:

```
lib/rubocop/cop/chef/modernize/cron_d_file_or_template.rb:113: undefined method 'match?' for an instance of Integer (NoMethodError)

  add_offense(node, severity: :refactor) if d.respond_to?(:value) && d.value.match?(%r{/etc/cron\.d\b}i)
                                                                            ^^^^^^^
```

Same for floats. Symbols happened to survive only because `Symbol#match?` exists.

This was introduced by #941, which is what the reporter suspected.

## Fix

Walk only string descendants:

```ruby
code_property.each_descendant(:str) do |d|
  add_offense(node, severity: :refactor) if d.value.match?(%r{/etc/cron\.d\b}i)
end
```

No detection is lost. Every path form the cop documents carries the literal `/etc/cron.d` in a `str` node — `path "/etc/cron.d/#{job}"` is a dstr with a `str` child, and `path ::File.join('/etc/cron.d', job)` has `'/etc/cron.d'` as a `str` argument. Both are covered by existing tests, plus a new one confirming `::File.join('/etc/cron.d', jobs[0])` is still flagged now that a numeric index no longer aborts the walk.

The reporter's exact repro now runs clean:

```
Inspecting 1 file
.

1 file inspected, no offenses detected
```

## Verification

- `bundle exec rspec` — 971 examples, 0 failures
- 4 new regression tests, tagged with the issue link per the convention already in this spec file. All 4 fail with the `NoMethodError` before the fix.
- `bundle exec cookstyle` — no offenses in the changed files
- Reporter's repro confirmed by hand, before (3 cop errors) and after (clean)

No config change: this is a crash fix that doesn't alter what the cop detects, matching how the earlier `/etc/cron.deny` and `/etc/cron.daily` fixes to this cop were handled.