### PR TITLE
Add Chef/Correctness/ConditionalUnifiedModeTrue cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -187,6 +187,15 @@ Chef/Correctness:
   Enabled: true
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
+Chef/Correctness/ConditionalUnifiedModeTrue:
+  Description: "Set `unified_mode true` unconditionally. Setting it conditionally leaves a resource running in unified mode on newer Chef Infra Client releases and in legacy mode on older ones, so it has to be written and tested against both execution models."
+  StyleGuide: 'chef_correctness_conditionalunifiedmodetrue'
+  Enabled: true
+  VersionAdded: '8.8.0'
+  Include:
+    - '**/libraries/*.rb'
+    - '**/resources/*.rb'
+
 Chef/Correctness/ServiceResource:
   Description: Use the `service` resource to start and stop services instead of shelling out with `execute` or `bash` resources. The `service` resource is idempotent and handles platform differences automatically.
   StyleGuide: 'chef_correctness_serviceresource'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_conditionalunifiedmodetrue.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_conditionalunifiedmodetrue.yml
@@ -1,0 +1,32 @@
+---
+short_name: ConditionalUnifiedModeTrue
+full_name: Chef/Correctness/ConditionalUnifiedModeTrue
+department: Chef/Correctness
+description: |-
+  Setting `unified_mode true` conditionally leaves a resource running in unified mode on newer
+  Chef Infra Client releases and in legacy mode on older ones. That's not a coherent thing to
+  want: the resource has to be written, tested, and debugged against both execution models.
+
+  Pick one. Set `unified_mode true` unconditionally and drop support for releases that predate
+  it, or set `unified_mode false if respond_to?(:unified_mode)` to deliberately opt out of
+  unified mode everywhere and keep writing the resource in the traditional style.
+
+  Only `unified_mode true` is flagged. `unified_mode false` under a guard is the supported way
+  to opt out and is left alone.
+autocorrection: true
+target_chef_version: 15.3+
+examples: |2-
+
+  # bad
+  unified_mode true if respond_to?(:unified_mode)
+
+  # good
+  unified_mode true
+
+  # good - deliberately opting out of unified mode
+  unified_mode false if respond_to?(:unified_mode)
+version_added: 8.8.0
+enabled: true
+included_file_paths:
+- "**/libraries/*.rb"
+- "**/resources/*.rb"

--- a/lib/rubocop/cop/chef/correctness/conditional_unified_mode_true.rb
+++ b/lib/rubocop/cop/chef/correctness/conditional_unified_mode_true.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Correctness
+        # Setting `unified_mode true` conditionally leaves a resource running in unified mode on newer
+        # Chef Infra Client releases and in legacy mode on older ones. That's not a coherent thing to
+        # want: the resource has to be written, tested, and debugged against both execution models.
+        #
+        # Pick one. Set `unified_mode true` unconditionally and drop support for releases that predate
+        # it, or set `unified_mode false if respond_to?(:unified_mode)` to deliberately opt out of
+        # unified mode everywhere and keep writing the resource in the traditional style.
+        #
+        # Only `unified_mode true` is flagged. `unified_mode false` under a guard is the supported way
+        # to opt out and is left alone.
+        #
+        # @example
+        #
+        #   # bad
+        #   unified_mode true if respond_to?(:unified_mode)
+        #
+        #   # good
+        #   unified_mode true
+        #
+        #   # good - deliberately opting out of unified mode
+        #   unified_mode false if respond_to?(:unified_mode)
+        #
+        class ConditionalUnifiedModeTrue < Base
+          extend AutoCorrector
+          extend TargetChefVersion
+
+          minimum_target_chef_version '15.3'
+
+          MSG = 'Set `unified_mode true` unconditionally. Making it conditional gives you unified mode on newer Chef Infra Client releases and legacy mode on older ones, so the resource has to be tested and reasoned about both ways.'
+          RESTRICT_ON_SEND = [:unified_mode].freeze
+
+          def_node_matcher :unified_mode_true?, '(send nil? :unified_mode (true))'
+
+          def on_send(node)
+            return unless unified_mode_true?(node)
+
+            conditional = node.each_ancestor(:if).first
+            return unless conditional
+
+            add_offense(node, severity: :refactor) do |corrector|
+              # only unwrap the conditional when it wraps nothing but this property, otherwise
+              # we'd delete whatever else the branch was guarding. an elsif is never safe to unwrap:
+              # its node covers only the elsif itself, so replacing it drops that branch's condition
+              # and folds the property into the preceding branch
+              next if conditional.elsif?
+              next unless sole_branch_body?(conditional, node)
+
+              corrector.replace(conditional, node.source)
+            end
+          end
+
+          private
+
+          # Is the property the entire body of the conditional? `if` puts the body in the first
+          # child after the condition and `unless` puts it in the second, so check both. A branch
+          # holding anything else is a `begin` node rather than the property itself, and an `if`
+          # with an `else` (or an `elsif` chain) leaves the other branch non-nil.
+          #
+          # @param [RuboCop::AST::IfNode] conditional
+          # @param [RuboCop::AST::SendNode] node the `unified_mode true` property
+          #
+          # @return [Boolean]
+          def sole_branch_body?(conditional, node)
+            conditional.children[1..2].compact == [node]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/conditional_unified_mode_true_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/conditional_unified_mode_true_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Correctness::ConditionalUnifiedModeTrue, :config do
+  it 'registers an offense when unified_mode true is guarded with respond_to?' do
+    expect_offense(<<~RUBY)
+      unified_mode true if respond_to?(:unified_mode)
+      ^^^^^^^^^^^^^^^^^ Set `unified_mode true` unconditionally. Making it conditional gives you unified mode on newer Chef Infra Client releases and legacy mode on older ones, so the resource has to be tested and reasoned about both ways.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      unified_mode true
+    RUBY
+  end
+
+  it 'registers an offense when unified_mode true is guarded with a multi-line if' do
+    expect_offense(<<~RUBY)
+      if respond_to?(:unified_mode)
+        unified_mode true
+        ^^^^^^^^^^^^^^^^^ Set `unified_mode true` unconditionally. Making it conditional gives you unified mode on newer Chef Infra Client releases and legacy mode on older ones, so the resource has to be tested and reasoned about both ways.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      unified_mode true
+    RUBY
+  end
+
+  it 'registers an offense when unified_mode true is guarded with unless' do
+    expect_offense(<<~RUBY)
+      unified_mode true unless Chef::VERSION.to_i < 16
+      ^^^^^^^^^^^^^^^^^ Set `unified_mode true` unconditionally. Making it conditional gives you unified mode on newer Chef Infra Client releases and legacy mode on older ones, so the resource has to be tested and reasoned about both ways.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      unified_mode true
+    RUBY
+  end
+
+  it 'registers an offense without autocorrecting when the branch does more than set unified_mode' do
+    expect_offense(<<~RUBY)
+      if respond_to?(:unified_mode)
+        unified_mode true
+        ^^^^^^^^^^^^^^^^^ Set `unified_mode true` unconditionally. Making it conditional gives you unified mode on newer Chef Infra Client releases and legacy mode on older ones, so the resource has to be tested and reasoned about both ways.
+        provides :my_resource
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense without autocorrecting when the if has an else branch' do
+    expect_offense(<<~RUBY)
+      if respond_to?(:unified_mode)
+        unified_mode true
+        ^^^^^^^^^^^^^^^^^ Set `unified_mode true` unconditionally. Making it conditional gives you unified mode on newer Chef Infra Client releases and legacy mode on older ones, so the resource has to be tested and reasoned about both ways.
+      else
+        provides :my_resource
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it "doesn't register an offense when unified_mode true is set unconditionally" do
+    expect_no_offenses(<<~RUBY)
+      unified_mode true
+    RUBY
+  end
+
+  it "doesn't register an offense when unified_mode false is guarded with respond_to?" do
+    expect_no_offenses(<<~RUBY)
+      unified_mode false if respond_to?(:unified_mode)
+    RUBY
+  end
+
+  it "doesn't register an offense when unified_mode false is set unconditionally" do
+    expect_no_offenses(<<~RUBY)
+      unified_mode false
+    RUBY
+  end
+
+  it "doesn't register an offense on an unrelated conditional property" do
+    expect_no_offenses(<<~RUBY)
+      resource_name :foo if respond_to?(:resource_name)
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 15.2' do
+    let(:config) { target_chef_version(15.2) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        unified_mode true if respond_to?(:unified_mode)
+      RUBY
+    end
+  end
+
+  it 'registers an offense without autocorrecting when the guard is an elsif' do
+    expect_offense(<<~RUBY)
+      if node['platform'] == 'windows'
+        provides :thing
+      elsif respond_to?(:unified_mode)
+        unified_mode true
+        ^^^^^^^^^^^^^^^^^ Set `unified_mode true` unconditionally. Making it conditional gives you unified mode on newer Chef Infra Client releases and legacy mode on older ones, so the resource has to be tested and reasoned about both ways.
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+end


### PR DESCRIPTION
Closes #936

Flags `unified_mode true` set behind a conditional:

```ruby
# bad
unified_mode true if respond_to?(:unified_mode)

# good
unified_mode true

# good - deliberately opting out of unified mode
unified_mode false if respond_to?(:unified_mode)
```

Per @lamont-granquist in the issue, the guarded `true` form leaves a resource running in unified mode on newer Chef Infra Client releases and in legacy mode on older ones, which means writing and testing the resource against both execution models. The two coherent choices are unconditional `unified_mode true`, or `unified_mode false if respond_to?(:unified_mode)` to opt out everywhere and keep writing traditional-style resources.

**Only `true` is flagged.** The `false` variant is called out in the issue as the supported opt-out and is explicitly left alone, with a test pinning that.

## Autocorrect

Unwraps the conditional to leave `unified_mode true` — but only when the conditional guards nothing but the property. These are reported with **no** correction rather than having code silently deleted:

```ruby
if respond_to?(:unified_mode)
  unified_mode true
  provides :my_resource   # would be destroyed by unwrapping
end

if respond_to?(:unified_mode)
  unified_mode true
else
  provides :my_resource   # ditto
end
```

Both the modifier and multi-line forms of `if` and `unless` are handled. `unless` puts its body in the third child of the `if` node while `if` uses the second, so the check covers both positions.

## Target version gating

`minimum_target_chef_version '15.3'`. The suggested fix would `NoMethodError` on clients predating the `unified_mode` property, so the cop stays quiet for anyone who has declared they target those.

Scoped to `**/resources/*.rb` and `**/libraries/*.rb`, matching the existing `ResourceWithoutUnifiedTrue` and `HWRPWithoutUnifiedTrue` cops.

## No overlap with the existing unified_mode cops

`Chef/Deprecations/ResourceWithoutUnifiedTrue` finds `unified_mode` with a `def_node_search`, which reaches inside the conditional, so it does not also fire on this code. Verified by running both cops over the same resource — one offense, from this cop only, and after `-a` the file is clean under both.

## Two things worth your call

1. **Department and name.** I put it in `Chef/Correctness` because the reporter frames it as incoherent behavior rather than obsolete style, and because the cop deliberately treats `true` and `false` differently — that asymmetry is semantic, not "this guard is no longer needed." The `Chef/Modernize/RespondTo*` family was the other candidate, but those cops say the guard itself is obsolete, which isn't true here. Easy to rename before merge if you disagree.
2. **Scope of the conditional match.** It flags `unified_mode true` under *any* conditional, not just `respond_to?(:unified_mode)`. `unified_mode true if Chef::VERSION.to_i >= 16` is the same incoherence, and I couldn't construct a case where conditionally enabling unified mode is legitimate. Narrowing to just `respond_to?` is a one-line change if you'd rather.

## Verification

- `bundle exec rspec` — 976 examples, 0 failures (9 new)
- `bundle exec rake validate_config` — cop registered; the 5 remaining `Chef/Ruby/*` errors are pre-existing on `main`
- `bundle exec cookstyle` — no offenses in the new files
- End-to-end run against a real `resources/` file, including `-a`

`VersionAdded` set to `8.8.0` — adjust to match whatever it ships in.