### PR TITLE
Add Chef/Sharing/EmptyPropertyDescription cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -637,6 +637,15 @@ Chef/Sharing/EmptyMetadataField:
   Include:
     - '**/metadata.rb'
 
+Chef/Sharing/EmptyPropertyDescription:
+  Description: Resource properties should not set an empty `description`. Automated documentation tools have nothing to render from it, so it does no more than a missing field would while looking like the property has been documented.
+  StyleGuide: 'chef_sharing_emptypropertydescription'
+  Enabled: true
+  VersionAdded: '8.8.0'
+  Include:
+    - '**/libraries/*.rb'
+    - '**/resources/*.rb'
+
 Chef/Sharing/IncludePropertyDescriptions:
   Description: Resource properties should include a `description` field so that automated documentation tools can generate helpful documentation for your custom resources. Requires Chef Infra Client 13.9 or later.
   StyleGuide: 'chef_sharing_includepropertydescriptions'

--- a/docs-chef-io/assets/cookstyle/cops_chef_sharing_emptypropertydescription.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_sharing_emptypropertydescription.yml
@@ -1,0 +1,26 @@
+---
+short_name: EmptyPropertyDescription
+full_name: Chef/Sharing/EmptyPropertyDescription
+department: Chef/Sharing
+description: |-
+  Resource properties should not set an empty `description`. Automated documentation tools have
+  nothing to render from it, so it does no more than a missing field would while looking like the
+  property has been documented.
+autocorrection: false
+target_chef_version: All Versions
+examples: |2-
+
+  # bad
+  property :site_name, String,
+           name_property: true,
+           description: ''
+
+  # good
+  property :site_name, String,
+           name_property: true,
+           description: 'The name of the site'
+version_added: 8.8.0
+enabled: true
+included_file_paths:
+- "**/libraries/*.rb"
+- "**/resources/*.rb"

--- a/lib/rubocop/cop/chef/sharing/empty_property_description.rb
+++ b/lib/rubocop/cop/chef/sharing/empty_property_description.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Sharing
+        # Resource properties should not set an empty `description`. Automated documentation tools have
+        # nothing to render from it, so it does no more than a missing field would while looking like the
+        # property has been documented.
+        #
+        # @example
+        #
+        #   # bad
+        #   property :site_name, String,
+        #            name_property: true,
+        #            description: ''
+        #
+        #   # good
+        #   property :site_name, String,
+        #            name_property: true,
+        #            description: 'The name of the site'
+        #
+        class EmptyPropertyDescription < Base
+          MSG = 'Resource properties should not set an empty `description`. Either describe the property or leave the field off entirely.'
+          RESTRICT_ON_SEND = [:property].freeze
+
+          # any method named property being called with a symbol argument and an options hash.
+          # capturing the hash rather than searching the whole send keeps us off `description`
+          # keys nested inside another option's value, such as `default: { description: '' }`
+          def_node_matcher :property_options, '(send nil? :property (sym _) ... $hash)'
+
+          def on_send(node)
+            property_options(node) do |options|
+              options.pairs.each do |pair|
+                next unless pair.key.sym_type? && pair.key.value == :description
+                # a description built by interpolation isn't a literal str node, so we can't tell
+                # whether it's empty and leave it alone
+                next unless pair.value.str_type? && pair.value.value.strip.empty?
+                add_offense(pair, severity: :refactor)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/sharing/empty_property_description_spec.rb
+++ b/spec/rubocop/cop/chef/sharing/empty_property_description_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Sharing::EmptyPropertyDescription, :config do
+  it 'registers an offense when a property has an empty description' do
+    expect_offense(<<~RUBY)
+      property :site_name, String,
+               name_property: true,
+               description: ''
+               ^^^^^^^^^^^^^^^ Resource properties should not set an empty `description`. Either describe the property or leave the field off entirely.
+    RUBY
+  end
+
+  it 'registers an offense when a property has an empty double quoted description' do
+    expect_offense(<<~RUBY)
+      property :site_name, String, description: ""
+                                   ^^^^^^^^^^^^^^^ Resource properties should not set an empty `description`. Either describe the property or leave the field off entirely.
+    RUBY
+  end
+
+  it 'registers an offense when a property has a whitespace only description' do
+    expect_offense(<<~RUBY)
+      property :site_name, String, description: '   '
+                                   ^^^^^^^^^^^^^^^^^^ Resource properties should not set an empty `description`. Either describe the property or leave the field off entirely.
+    RUBY
+  end
+
+  it "doesn't register an offense when a property has a description" do
+    expect_no_offenses(<<~RUBY)
+      property :site_name, String, description: 'The name of the site'
+    RUBY
+  end
+
+  it "doesn't register an offense when a property has no description" do
+    expect_no_offenses(<<~RUBY)
+      property :site_name, String, name_property: true
+    RUBY
+  end
+
+  it "doesn't register an offense when the description is built from a variable" do
+    expect_no_offenses(<<~'RUBY')
+      property :site_name, String, description: "The name of #{thing}"
+    RUBY
+  end
+
+  it "doesn't register an offense on an empty value for another property field" do
+    expect_no_offenses(<<~RUBY)
+      property :site_name, String, default: ''
+    RUBY
+  end
+
+  it "doesn't register an offense on an empty description outside a property" do
+    expect_no_offenses(<<~RUBY)
+      thing :site_name, description: ''
+    RUBY
+  end
+
+  it "doesn't register an offense on an empty description nested in another option's value" do
+    expect_no_offenses(<<~RUBY)
+      property :site_name, Hash, default: { description: '' }
+    RUBY
+  end
+
+  it "doesn't register an offense on an empty description nested several levels deep" do
+    expect_no_offenses(<<~RUBY)
+      property :site_name, Hash, default: { nested: { description: '' } }
+    RUBY
+  end
+
+  it 'registers an offense only for the property description when a nested one is also empty' do
+    expect_offense(<<~RUBY)
+      property :site_name, Hash, description: '', default: { description: '' }
+                                 ^^^^^^^^^^^^^^^ Resource properties should not set an empty `description`. Either describe the property or leave the field off entirely.
+    RUBY
+  end
+end


### PR DESCRIPTION
Closes #905

```ruby
# bad
property :site_name, String,
         name_property: true,
         description: ''

# good
property :site_name, String,
         name_property: true,
         description: 'The name of the site'
```

Automated documentation tools have nothing to render from an empty description, so it does no more than a missing field would — while making the property look like it has been documented.

Filed under `Chef/Sharing` as requested in the issue, sitting next to `IncludePropertyDescriptions`, which asks for the field in the first place.

## Scope

- Whitespace-only descriptions (`description: '   '`) are treated as empty.
- A description built by interpolation (`description: "The name of #{thing}"`) isn't a literal `str` node, so emptiness can't be determined and it's left alone.
- Only the `description` key. `default: ''` is a legitimate value and isn't touched.
- Only inside `property`, so an unrelated `thing :foo, description: ''` doesn't match.

Scoped to `**/resources/*.rb` and `**/libraries/*.rb`, matching `IncludePropertyDescriptions`.

`Enabled: true`, unlike `IncludePropertyDescriptions`, which is opt-in. Requiring every property to be documented is aspirational; an empty description is just wrong, so it seems reasonable to have this one on by default. Happy to flip it if you'd rather they match.

## No autocorrect

Deliberate, matching the neighbouring `Chef/Sharing/EmptyMetadataField`. Deleting the field would only move the cookbook onto `IncludePropertyDescriptions`, and actually writing the description is the point.

## Possible follow-up

The same argument applies to the resource-level `description ''` covered by `IncludeResourceDescriptions`, and to `examples ''`. The issue asked specifically about property descriptions so I kept it there — say the word and I'll widen it.

## Verification

- `bundle exec rspec` — 975 examples, 0 failures (8 new)
- `bundle exec rake validate_config` — cop registered; the 5 remaining `Chef/Ruby/*` errors are pre-existing on `main`
- `bundle exec cookstyle` — no offenses in the new files

`VersionAdded` set to `8.8.0` — adjust to match whatever it ships in.