### PR TITLE
Name the guard in the ConditionalUsingTest message

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1899,10 +1899,11 @@ Chef/Modernize/ShellOutHelper:
     - '**/libraries/*.rb'
 
 Chef/Modernize/ConditionalUsingTest:
-  Description: Use ::File.exist?('/foo/bar') instead of the slower 'test -f /foo/bar' which requires shelling out.
+  Description: "Use `::File.exist?('/foo/bar')` in an `only_if` or `not_if` guard instead of the slower `'test -f /foo/bar'`, which requires shelling out. The Ruby check has to be passed as a block."
   StyleGuide: 'chef_modernize_conditionalusingtest'
   Enabled: true
   VersionAdded: '6.11.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/Berksfile'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_conditionalusingtest.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_conditionalusingtest.yml
@@ -2,17 +2,24 @@
 short_name: ConditionalUsingTest
 full_name: Chef/Modernize/ConditionalUsingTest
 department: Chef/Modernize
-description: Use ::File.exist?('/foo/bar') instead of the slower 'test -f /foo/bar'
-  which requires shelling out
+description: 'Use `::File.exist?(''/foo/bar'')` in an `only_if` or `not_if` guard
+  instead of the slower `''test -f /foo/bar''`, which requires shelling out. The Ruby
+  check has to be passed as a block. Passing it directly, as `not_if ::File.exist?(''/foo/bar'')`,
+  raises `ArgumentError: Invalid only_if/not_if command, expected a string`.'
 autocorrection: true
 target_chef_version: All Versions
 examples: |2-
 
   # bad
   only_if 'test -f /bin/foo'
+  not_if 'test -f /bin/foo'
+
+  # bad - a Ruby guard has to be a block, this raises at converge time
+  only_if ::File.exist?('/bin/foo')
 
   # good
   only_if { ::File.exist?('/bin/foo') }
+  not_if { ::File.exist?('/bin/foo') }
 version_added: 6.11.0
 enabled: true
 excluded_file_paths:

--- a/lib/rubocop/cop/chef/modernize/conditional_using_test.rb
+++ b/lib/rubocop/cop/chef/modernize/conditional_using_test.rb
@@ -19,20 +19,27 @@ module RuboCop
   module Cop
     module Chef
       module Modernize
-        # Use ::File.exist?('/foo/bar') instead of the slower 'test -f /foo/bar' which requires shelling out
+        # Use `::File.exist?('/foo/bar')` in an `only_if` or `not_if` guard instead of the slower `'test -f /foo/bar'`, which requires shelling out. The Ruby check has to be passed as a block. Passing it directly, as `not_if ::File.exist?('/foo/bar')`, raises `ArgumentError: Invalid only_if/not_if command, expected a string`.
         #
         # @example
         #
         #   # bad
         #   only_if 'test -f /bin/foo'
+        #   not_if 'test -f /bin/foo'
+        #
+        #   # bad - a Ruby guard has to be a block, this raises at converge time
+        #   only_if ::File.exist?('/bin/foo')
         #
         #   # good
         #   only_if { ::File.exist?('/bin/foo') }
+        #   not_if { ::File.exist?('/bin/foo') }
         #
         class ConditionalUsingTest < Base
           extend AutoCorrector
 
-          MSG = "Use ::File.exist?('/foo/bar') instead of the slower 'test -f /foo/bar' which requires shelling out"
+          # %{guard} is the guard the offense was found on, so that a not_if offense isn't told to
+          # use an only_if, which would invert the condition
+          MSG = "Use %{guard} { ::File.exist?('/foo/bar') } instead of the slower %{guard} 'test -f /foo/bar' which requires shelling out"
           RESTRICT_ON_SEND = [:not_if, :only_if].freeze
 
           def_node_matcher :resource_conditional?, <<~PATTERN
@@ -42,7 +49,7 @@ module RuboCop
           def on_send(node)
             resource_conditional?(node) do |conditional|
               return unless conditional.value.match?(/^test -[ef] \S*$/)
-              add_offense(node, severity: :refactor) do |corrector|
+              add_offense(node, message: format(MSG, guard: node.method_name), severity: :refactor) do |corrector|
                 new_string = "{ ::File.exist?('#{conditional.value.match(/^test -[ef] (\S*)$/)[1]}') }"
                 corrector.replace(conditional, new_string)
               end

--- a/spec/rubocop/cop/chef/modernize/conditional_using_test_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/conditional_using_test_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Chef::Modernize::ConditionalUsingTest, :config do
     expect_offense(<<~RUBY)
       execute 'apt-get update' do
         only_if 'test -f /sbin/apt'
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use ::File.exist?('/foo/bar') instead of the slower 'test -f /foo/bar' which requires shelling out
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use only_if { ::File.exist?('/foo/bar') } instead of the slower only_if 'test -f /foo/bar' which requires shelling out
       end
     RUBY
 
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Chef::Modernize::ConditionalUsingTest, :config do
     expect_offense(<<~RUBY)
       execute 'yum update' do
         not_if 'test -f /sbin/apt'
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use ::File.exist?('/foo/bar') instead of the slower 'test -f /foo/bar' which requires shelling out
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use not_if { ::File.exist?('/foo/bar') } instead of the slower not_if 'test -f /foo/bar' which requires shelling out
       end
     RUBY
 
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Chef::Modernize::ConditionalUsingTest, :config do
     expect_offense(<<~RUBY)
       execute 'yum update' do
         not_if 'test -e /sbin/apt'
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use ::File.exist?('/foo/bar') instead of the slower 'test -f /foo/bar' which requires shelling out
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use not_if { ::File.exist?('/foo/bar') } instead of the slower not_if 'test -f /foo/bar' which requires shelling out
       end
     RUBY
 


### PR DESCRIPTION
Closes #841

The offense message read:

> Use ::File.exist?('/foo/bar') instead of the slower 'test -f /foo/bar' which requires shelling out

Read literally, that says to write:

```ruby
not_if ::File.exist?('/foo/bar')
```

which raises `ArgumentError: Invalid only_if/not_if command, expected a string: true (TrueClass)` at converge time whenever the file actually exists. The `@example` block did show the block form, but the message — which is what people see in CLI output and in the docs description — did not.

## Change

The message names the guard so the braces have something to attach to. Since the cop fires on **both** `only_if` and `not_if`, the guard is interpolated from the offending node rather than hardcoded — writing `only_if` into the message would tell half of all offenses to invert their condition:

```
cond.rb:2:3: R: [Correctable] Chef/Modernize/ConditionalUsingTest: Use only_if { ::File.exist?('/foo/bar') } instead of the slower only_if 'test -f /foo/bar' which requires shelling out
  only_if 'test -f /sbin/apt'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
cond.rb:6:3: R: [Correctable] Chef/Modernize/ConditionalUsingTest: Use not_if { ::File.exist?('/foo/bar') } instead of the slower not_if 'test -f /foo/bar' which requires shelling out
  not_if 'test -e /sbin/apt'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The cop's docstring — the source of the docs description the issue quotes — spells out the failure explicitly and stays guard-neutral. The examples gained the mistaken form as a second bad case, and now show both guards:

```ruby
# bad
only_if 'test -f /bin/foo'
not_if 'test -f /bin/foo'

# bad - a Ruby guard has to be a block, this raises at converge time
only_if ::File.exist?('/bin/foo')

# good
only_if { ::File.exist?('/bin/foo') }
not_if { ::File.exist?('/bin/foo') }
```

`config/cookstyle.yml` and the docs asset were updated to match.

**No behavior change.** The cop already autocorrected to the block form and never touched the guard name; only the wording was misleading.

## Possible follow-up

Nothing currently catches the mistake itself. `Chef/Correctness/BlockGuardWithOnlyString` covers the inverse error (a shell string wrapped in `{}`), but a bare Ruby expression passed to `only_if`/`not_if` — the thing this issue's reporter actually wrote — goes unflagged and fails at converge time. That looks like a worthwhile `Chef/Correctness` cop. Happy to open one if you want it.

## Verification

- `bundle exec rspec` — 967 examples, 0 failures; the `not_if` expectations now assert a `not_if` message and the `only_if` one asserts `only_if`
- `bundle exec cookstyle` — no offenses in the changed files
- Rendered CLI output checked by hand with one of each guard in the same file

`VersionChanged` set to `8.8.0`.