### PR TITLE
Detect run_context.include_recipe 'build-essential'

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1487,6 +1487,7 @@ Chef/Modernize/UseBuildEssentialResource:
   StyleGuide: 'chef_modernize_usebuildessentialresource'
   Enabled: true
   VersionAdded: '5.1.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
 

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_usebuildessentialresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_usebuildessentialresource.yml
@@ -12,6 +12,7 @@ examples: |2-
   depends 'build-essential'
   include_recipe 'build-essential::default'
   include_recipe 'build-essential'
+  run_context.include_recipe 'build-essential::default'
 
   # good
   build_essential 'install compilation tools'

--- a/lib/rubocop/cop/chef/modernize/build_essential.rb
+++ b/lib/rubocop/cop/chef/modernize/build_essential.rb
@@ -27,6 +27,7 @@ module RuboCop
         #   depends 'build-essential'
         #   include_recipe 'build-essential::default'
         #   include_recipe 'build-essential'
+        #   run_context.include_recipe 'build-essential::default'
         #
         #   # good
         #   build_essential 'install compilation tools'
@@ -37,8 +38,10 @@ module RuboCop
           MSG = 'Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+'
           RESTRICT_ON_SEND = [:include_recipe].freeze
 
+          # matches a bare include_recipe as well as the run_context.include_recipe form used in
+          # libraries and custom resources
           def_node_matcher :build_essential_recipe_usage?, <<-PATTERN
-            (send nil? :include_recipe (str {"build-essential" "build-essential::default"}))
+            (send {nil? (send nil? :run_context)} :include_recipe (str {"build-essential" "build-essential::default"}))
           PATTERN
 
           def on_send(node)

--- a/spec/rubocop/cop/chef/modernize/build_essential_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/build_essential_spec.rb
@@ -40,9 +40,43 @@ describe RuboCop::Cop::Chef::Modernize::UseBuildEssentialResource, :config do
     RUBY
   end
 
+  it 'registers an offense when including the "build-essential" recipe via run_context' do
+    expect_offense(<<~RUBY)
+      run_context.include_recipe 'build-essential'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+
+    RUBY
+
+    expect_correction(<<~RUBY)
+      build_essential 'install compilation tools'
+    RUBY
+  end
+
+  it 'registers an offense when including the "build-essential::default" recipe via run_context' do
+    expect_offense(<<~RUBY)
+      run_context.include_recipe 'build-essential::default'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+
+    RUBY
+
+    expect_correction(<<~RUBY)
+      build_essential 'install compilation tools'
+    RUBY
+  end
+
   it "doesn't register an offense when using the build_essential resource" do
     expect_no_offenses(<<~RUBY)
       build_essential 'install some tools!'
+    RUBY
+  end
+
+  it "doesn't register an offense when including another cookbook's recipe" do
+    expect_no_offenses(<<~RUBY)
+      run_context.include_recipe 'some-other-cookbook::default'
+    RUBY
+  end
+
+  it "doesn't register an offense when include_recipe is called on an unrelated receiver" do
+    expect_no_offenses(<<~RUBY)
+      other_thing.include_recipe 'build-essential'
     RUBY
   end
 end


### PR DESCRIPTION
Closes #788

```ruby
# bad
include_recipe 'build-essential'
include_recipe 'build-essential::default'
run_context.include_recipe 'build-essential::default'   # <- newly detected

# good
build_essential 'install compilation tools'
```

## Cause

The node pattern pinned the receiver to `nil?`:

```ruby
(send nil? :include_recipe (str {"build-essential" "build-essential::default"}))
```

Libraries and custom resources reach the recipe DSL through `run_context.include_recipe`, which has a receiver, so that form never matched.

## Fix

```ruby
(send {nil? (send nil? :run_context)} :include_recipe (str {"build-essential" "build-essential::default"}))
```

The receiver is matched specifically rather than with a wildcard, so an unrelated `foo.include_recipe 'build-essential'` is still left alone — there's a test pinning that.

Autocorrect already replaced the whole send node, so it works unchanged on the new form and produces the same `build_essential 'install compilation tools'`. (The issue suggested `build_essential 'compiler tools'`; I kept the string the cop already emits rather than churn existing users' autocorrect output — easy to change if you'd prefer the new wording.)

## Note on the wider pattern

Every other `include_recipe` cop has the same blind spot — `Chef/Modernize/AptDefaultRecipe`, `WindowsDefaultRecipe`, `OhaiDefaultRecipe`, `Chef/Deprecations/ChefHandlerRecipe`, `LegacyYumCookbookRecipes`, `XMLRubyRecipe`, `YumDnfCompatRecipe`, and `Chef/Style/IncludeRecipeWithParentheses` all pin the receiver to `nil?`. This PR only covers build-essential, since that's what the issue asked for. Happy to do a sweep across the rest as a follow-up if that's wanted.

## Verification

- `bundle exec rspec` — 971 examples, 0 failures (4 new: both recipe names via `run_context`, plus two no-offense cases)
- `bundle exec cookstyle` — no offenses in the changed files

Docs asset regenerated with `rake generate_cops_yml_documentation`. `VersionChanged` set to `8.8.0` — adjust if this ships as a patch.