### PR TITLE
Match scope-resolved constants in 14 cops

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -133,6 +133,7 @@ Chef/Style/TrueClassFalseClassResourceProperties:
   StyleGuide: 'chef_style_trueclassfalseclassresourceproperties'
   Enabled: true
   VersionAdded: '5.16.0'
+  VersionChanged: '8.8.0'
   Include:
     - '**/libraries/*.rb'
     - '**/resources/*.rb'
@@ -464,6 +465,7 @@ Chef/Correctness/OpenSSLPasswordHelpers:
   StyleGuide: 'chef_correctness_opensslpasswordhelpers'
   Enabled: true
   VersionAdded: '6.6.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/Berksfile'
@@ -765,6 +767,7 @@ Chef/Deprecations/UsesDeprecatedMixins:
   StyleGuide: 'chef_deprecations_usesdeprecatedmixins'
   Enabled: true
   VersionAdded: '5.4.0'
+  VersionChanged: '8.8.0'
   Include:
     - '**/libraries/*.rb'
     - '**/providers/*.rb'
@@ -793,6 +796,7 @@ Chef/Deprecations/UsesChefRESTHelpers:
   StyleGuide: 'chef_deprecations_useschefresthelpers'
   Enabled: true
   VersionAdded: '5.5.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
 
@@ -961,6 +965,7 @@ Chef/Deprecations/ResourceInheritsFromCompatResource:
   StyleGuide: 'chef_deprecations_resourceinheritsfromcompatresource'
   Enabled: true
   VersionAdded: '5.10.0'
+  VersionChanged: '8.8.0'
   Include:
     - '**/libraries/*.rb'
 
@@ -1098,6 +1103,7 @@ Chef/Deprecations/ChefWindowsPlatformHelper:
   StyleGuide: 'chef_deprecations_chefwindowsplatformhelper'
   Enabled: true
   VersionAdded: '6.0.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/Berksfile'
@@ -1216,6 +1222,7 @@ Chef/Deprecations/ChefShellout:
   StyleGuide: 'chef_deprecations_chefshellout'
   Enabled: true
   VersionAdded: '6.17.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/attributes/*.rb'
@@ -1802,6 +1809,7 @@ Chef/Modernize/DslIncludeInResource:
   StyleGuide: 'chef_modernize_dslincludeinresource'
   Enabled: true
   VersionAdded: '5.17.0'
+  VersionChanged: '8.8.0'
   Include:
     - '**/resources/*.rb'
     - '**/providers/*.rb'
@@ -1841,6 +1849,7 @@ Chef/Modernize/UseRequireRelative:
   StyleGuide: 'chef_modernize_userequirerelative'
   Enabled: true
   VersionAdded: '5.22.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/attributes/*.rb'
@@ -1890,6 +1899,7 @@ Chef/Modernize/DatabagHelpers:
   StyleGuide: 'chef_modernize_databaghelpers'
   Enabled: true
   VersionAdded: '6.0.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/Berksfile'
@@ -2149,7 +2159,7 @@ Chef/RedundantCode/UnnecessaryNameProperty:
   StyleGuide: 'chef_redundantcode_unnecessarynameproperty'
   Enabled: true
   VersionAdded: '5.8.0'
-  VersionChanged: '5.15.0'
+  VersionChanged: '8.8.0'
   Include:
     - '**/resources/*.rb'
     - '**/libraries/*.rb'
@@ -2234,6 +2244,7 @@ Chef/RedundantCode/StringPropertyWithNilDefault:
   StyleGuide: 'chef_redundantcode_stringpropertywithnildefault'
   Enabled: true
   VersionAdded: '5.21.0'
+  VersionChanged: '8.8.0'
   Include:
     - '**/resources/*.rb'
     - '**/libraries/*.rb'

--- a/lib/rubocop/cop/chef/correctness/openssl_password_helpers.rb
+++ b/lib/rubocop/cop/chef/correctness/openssl_password_helpers.rb
@@ -31,7 +31,7 @@ module RuboCop
           def_node_matcher :openssl_helper?, <<~PATTERN
             (const
               (const
-                (const nil? :Opscode) :OpenSSL) :Password)
+                (const {nil? cbase} :Opscode) :OpenSSL) :Password)
           PATTERN
 
           def on_const(node)

--- a/lib/rubocop/cop/chef/deprecation/chef_rest.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rest.rb
@@ -39,7 +39,7 @@ module RuboCop
           PATTERN
 
           def_node_matcher :rest_const?, <<-PATTERN
-          (const (const nil? :Chef) :REST)
+          (const (const {nil? cbase} :Chef) :REST)
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/deprecation/chef_shellout.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_shellout.rb
@@ -43,7 +43,7 @@ module RuboCop
           def_node_matcher :include_shellout?, <<-PATTERN
           (send nil? :include
             (const
-              (const nil? :Chef) :ShellOut))
+              (const {nil? cbase} :Chef) :ShellOut))
           PATTERN
 
           def_node_matcher :require_shellout?, <<-PATTERN
@@ -53,7 +53,7 @@ module RuboCop
           def_node_matcher :shellout_new?, <<-PATTERN
           (send
             (const
-              (const nil? :Chef) :ShellOut) :new
+              (const {nil? cbase} :Chef) :ShellOut) :new
               ... )
           PATTERN
 

--- a/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_windows_platform_helper.rb
@@ -38,7 +38,7 @@ module RuboCop
           def_node_matcher :chef_platform_windows?, <<-PATTERN
             (send
               (const
-                (const nil? :Chef) :Platform) :windows?)
+                (const {nil? cbase} :Chef) :Platform) :windows?)
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
+++ b/lib/rubocop/cop/chef/deprecation/deprecated_mixins.rb
@@ -41,11 +41,11 @@ module RuboCop
           RESTRICT_ON_SEND = [:include, :require].freeze
 
           def_node_matcher :deprecated_mixin?, <<-PATTERN
-            (send nil? :include (const (const (const nil? :Chef) :Mixin) { :Language :LanguageIncludeAttribute :RecipeDefinitionDSLCore :LanguageIncludeRecipe }))
+            (send nil? :include (const (const (const {nil? cbase} :Chef) :Mixin) { :Language :LanguageIncludeAttribute :RecipeDefinitionDSLCore :LanguageIncludeRecipe }))
           PATTERN
 
           def_node_matcher :deprecated_dsl?, <<-PATTERN
-            (send nil? :include (const (const (const (const nil? :Chef) :DSL) :Recipe) :FullDSL))
+            (send nil? :include (const (const (const (const {nil? cbase} :Chef) :DSL) :Recipe) :FullDSL))
           PATTERN
 
           def_node_matcher :dsl_mixin_require?, <<-PATTERN

--- a/lib/rubocop/cop/chef/deprecation/hwrp_without_provides.rb
+++ b/lib/rubocop/cop/chef/deprecation/hwrp_without_provides.rb
@@ -94,7 +94,7 @@ module RuboCop
               $(class
                 (const nil? ... )
                 (const
-                  (const nil? :Chef) :Resource)
+                  (const {nil? cbase} :Chef) :Resource)
                   ...)))
           PATTERN
 

--- a/lib/rubocop/cop/chef/deprecation/hwrp_without_unified_mode_true.rb
+++ b/lib/rubocop/cop/chef/deprecation/hwrp_without_unified_mode_true.rb
@@ -67,7 +67,7 @@ module RuboCop
               $(class
                 (const nil? ... )
                 (const
-                  (const nil? :Chef) :Resource)
+                  (const {nil? cbase} :Chef) :Resource)
                   ...)))
           PATTERN
 

--- a/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
@@ -42,7 +42,7 @@ module RuboCop
           MSG = "HWRP style resource should inherit from the 'Chef::Resource' class and not the 'ChefCompat::Resource' class from the deprecated compat_resource cookbook."
 
           def_node_matcher :inherits_from_compat_resource?, <<-PATTERN
-          (class (const nil? _ ) (const (const nil? :ChefCompat) :Resource) ... )
+          (class (const nil? _ ) (const (const {nil? cbase} :ChefCompat) :Resource) ... )
           PATTERN
 
           def on_class(node)

--- a/lib/rubocop/cop/chef/modernize/databag_helpers.rb
+++ b/lib/rubocop/cop/chef/modernize/databag_helpers.rb
@@ -40,15 +40,18 @@ module RuboCop
           def_node_matcher :data_bag_class_load?, <<-PATTERN
           (send
             (const
-              (const nil? :Chef) {:DataBagItem :EncryptedDataBagItem}) :load
+              (const {nil? cbase} :Chef) {:DataBagItem :EncryptedDataBagItem}) :load
               ...)
           PATTERN
 
           def on_send(node)
             data_bag_class_load?(node) do
               add_offense(node, severity: :refactor) do |corrector|
-                corrector.replace(node,
-                   node.source.gsub(/Chef::(EncryptedDataBagItem|DataBagItem).load/, 'data_bag_item'))
+                # replace only the receiver and the .load selector, so that the arguments are left
+                # exactly as written. rewriting node.source would also hit any argument that
+                # happened to contain the class name, and would leave the leading :: of a scope
+                # resolved ::Chef::DataBagItem.load behind
+                corrector.replace(node.receiver.source_range.join(node.loc.selector), 'data_bag_item')
               end
             end
           end

--- a/lib/rubocop/cop/chef/modernize/dsl_include_in_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/dsl_include_in_resource.rb
@@ -38,7 +38,7 @@ module RuboCop
           (send nil? :include
             (const
               (const
-                (const nil? :Chef) :DSL) {:Recipe :IncludeRecipe}))
+                (const {nil? cbase} :Chef) :DSL) {:Recipe :IncludeRecipe}))
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/use_require_relative.rb
+++ b/lib/rubocop/cop/chef/modernize/use_require_relative.rb
@@ -38,7 +38,7 @@ module RuboCop
           def_node_matcher :require_with_expand_path?, <<-PATTERN
             (send nil? :require
               (send
-                (const nil? :File) :expand_path
+                (const {nil? cbase} :File) :expand_path
                 $( str ... )
                 $( str ... )))
           PATTERN

--- a/lib/rubocop/cop/chef/redundant/string_property_with_nil_default.rb
+++ b/lib/rubocop/cop/chef/redundant/string_property_with_nil_default.rb
@@ -40,13 +40,13 @@ module RuboCop
 
           def_node_matcher :string_property_with_nil_default?, <<-PATTERN
             (send nil? :property (sym _)
-            {(const nil? :String) #string_and_nil_like?}
+            {(const {nil? cbase} :String) #string_and_nil_like?}
             (hash <$(pair (sym :default) (nil)) ...>))
           PATTERN
 
           # An array of types that includes String & either NilClass or nil
           def_node_matcher :string_and_nil_like?, <<-PATTERN
-            (array <(const nil? :String) {(const nil? :NilClass) (nil)}>)
+            (array <(const {nil? cbase} :String) {(const {nil? cbase} :NilClass) (nil)}>)
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/redundant/unnecessary_name_property.rb
+++ b/lib/rubocop/cop/chef/redundant/unnecessary_name_property.rb
@@ -39,7 +39,7 @@ module RuboCop
           def_node_matcher :name_property?, <<-PATTERN
           (send nil? {:attribute :property}
             (sym :name)
-            (const nil? :String)?
+            (const {nil? cbase} :String)?
             (hash $...)?
           )
           PATTERN

--- a/lib/rubocop/cop/chef/style/true_false_resource_properties.rb
+++ b/lib/rubocop/cop/chef/style/true_false_resource_properties.rb
@@ -36,7 +36,7 @@ module RuboCop
           RESTRICT_ON_SEND = [:property, :attribute].freeze
 
           def_node_matcher :trueclass_falseclass_property?, <<-PATTERN
-            (send nil? {:property :attribute} (sym _) $(array (const nil? :TrueClass) (const nil? :FalseClass)) ... )
+            (send nil? {:property :attribute} (sym _) $(array (const {nil? cbase} :TrueClass) (const {nil? cbase} :FalseClass)) ... )
           PATTERN
 
           def on_send(node)

--- a/spec/rubocop/cop/chef/correctness/openssl_password_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/openssl_password_helpers_spec.rb
@@ -25,4 +25,11 @@ describe RuboCop::Cop::Chef::Correctness::OpenSSLPasswordHelpers, :config do
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ The `secure_password` helper from the openssl cookbooks `Opscode::OpenSSL::Password` class should not be used to generate passwords.
     RUBY
   end
+
+  it 'registers an offense when using ::Opscode::OpenSSL::Password' do
+    expect_offense(<<~RUBY)
+      ::Opscode::OpenSSL::Password.random_password
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `secure_password` helper from the openssl cookbooks `Opscode::OpenSSL::Password` class should not be used to generate passwords.
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/chef_rest_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_rest_spec.rb
@@ -31,4 +31,11 @@ describe RuboCop::Cop::Chef::Deprecations::UsesChefRESTHelpers, :config do
       ^^^^^^^^^^ Don't use the helpers in Chef::REST which were removed in Chef Infra Client 13
     RUBY
   end
+
+  it 'registers an offense when using ::Chef::REST' do
+    expect_offense(<<~RUBY)
+      ::Chef::REST.new('http://example.com')
+      ^^^^^^^^^^^^ Don't use the helpers in Chef::REST which were removed in Chef Infra Client 13
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/chef_shellout_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_shellout_spec.rb
@@ -67,4 +67,11 @@ describe RuboCop::Cop::Chef::Deprecations::ChefShellout, :config do
       Mixlib::ShellOut.new('some_command').run_command
     RUBY
   end
+
+  it 'registers an offense when using ::Chef::ShellOut' do
+    expect_offense(<<~RUBY)
+      foo = ::Chef::ShellOut.new('foo')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use the deprecated `Chef::ShellOut` class which was removed in Chef Infra Client 13. Use the `Mixlib::ShellOut` class instead, which behaves identically.
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/chef_windows_platform_helper_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_windows_platform_helper_spec.rb
@@ -30,4 +30,15 @@ describe RuboCop::Cop::Chef::Deprecations::ChefWindowsPlatformHelper, :config do
   it "doesn't register an offense when calling other Chef::Platform helpers" do
     expect_no_offenses('Chef::Platform.foo?')
   end
+
+  it 'registers an offense when using ::Chef::Platform.windows?' do
+    expect_offense(<<~RUBY)
+      ::Chef::Platform.windows?
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `platform?('windows')` instead of the legacy `Chef::Platform.windows?` helper.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      platform?('windows')
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/deprecated_mixins_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/deprecated_mixins_spec.rb
@@ -95,4 +95,11 @@ describe RuboCop::Cop::Chef::Deprecations::UsesDeprecatedMixins, :config do
       depends 'foo'
     RUBY
   end
+
+  it 'registers an offense when including ::Chef::Mixin::LanguageIncludeAttribute' do
+    expect_offense(<<~RUBY)
+      include ::Chef::Mixin::LanguageIncludeAttribute
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use deprecated Mixins no longer included in Chef Infra Client 14 and later.
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/hwrp_without_provides_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/hwrp_without_provides_spec.rb
@@ -190,4 +190,20 @@ describe RuboCop::Cop::Chef::Deprecations::HWRPWithoutProvides, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when a HWRP inheriting from ::Chef::Resource does not define provides' do
+    expect_offense(<<~RUBY)
+      class Chef
+        class Resource
+          class UlimitRule < ::Chef::Resource
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ In Chef Infra Client 16 and later a legacy HWRP resource must use `provides` to define how the resource is called in recipes or other resources. To maintain compatibility with Chef Infra Client < 16 use both `resource_name` and `provides`.
+            property :type, [Symbol, String], required: true
+            property :item, [Symbol, String], required: true
+
+            # additional resource code
+          end
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/hwrp_without_unified_mode_true_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/hwrp_without_unified_mode_true_spec.rb
@@ -85,4 +85,20 @@ describe RuboCop::Cop::Chef::Deprecations::HWRPWithoutUnifiedTrue, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when a HWRP inheriting from ::Chef::Resource does not define unified_mode true' do
+    expect_offense(<<~RUBY)
+      class Chef
+        class Resource
+          class UlimitRule < ::Chef::Resource
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Set `unified_mode true` in Chef Infra Client 15.3+ HWRP style custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default.
+            provides :ulimit_rule
+            property :type, [Symbol, String], required: true
+
+            # additional resource code
+          end
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/databag_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/databag_helpers_spec.rb
@@ -40,4 +40,26 @@ describe RuboCop::Cop::Chef::Modernize::DatabagHelpers, :config do
       data_bag_item('foo', 'bar')
     RUBY
   end
+
+  it 'registers an offense when using ::Chef::DataBagItem.load' do
+    expect_offense(<<~RUBY)
+      ::Chef::DataBagItem.load('bag', 'item')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `data_bag_item` helper instead of `Chef::DataBagItem.load` or `Chef::EncryptedDataBagItem.load`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      data_bag_item('bag', 'item')
+    RUBY
+  end
+
+  it 'does not rewrite arguments that contain the class name' do
+    expect_offense(<<~RUBY)
+      Chef::DataBagItem.load('Chef::DataBagItem.load', 'item')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `data_bag_item` helper instead of `Chef::DataBagItem.load` or `Chef::EncryptedDataBagItem.load`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      data_bag_item('Chef::DataBagItem.load', 'item')
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/dsl_include_in_resource_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/dsl_include_in_resource_spec.rb
@@ -40,4 +40,11 @@ describe RuboCop::Cop::Chef::Modernize::DslIncludeInResource, :config do
   it "doesn't register an offense when including Chef::DSL::Foo" do
     expect_no_offenses('include Chef::DSL::Foo')
   end
+
+  it 'registers an offense when including ::Chef::DSL::Recipe' do
+    expect_offense(<<~RUBY)
+      include ::Chef::DSL::Recipe
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 12.4+ includes the Chef::DSL::Recipe in the resource and provider classes by default so there is no need to include this DSL in your resources or providers.
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/use_require_relative_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/use_require_relative_spec.rb
@@ -29,4 +29,15 @@ describe RuboCop::Cop::Chef::Modernize::UseRequireRelative, :config do
       require_relative '../libraries/helpers'
     RUBY
   end
+
+  it 'registers an offense when requiring a file with ::File.expand_path and __FILE__' do
+    expect_offense(<<~RUBY)
+      require ::File.expand_path('../../libraries/helpers', __FILE__)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Instead of using require with a File.expand_path and __FILE__ use the simpler require_relative method.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      require_relative '../libraries/helpers'
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/redundant/string_property_with_nil_default_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/string_property_with_nil_default_spec.rb
@@ -51,4 +51,11 @@ describe RuboCop::Cop::Chef::RedundantCode::StringPropertyWithNilDefault, :confi
       property :bob, String, default: 'foo'
     RUBY
   end
+
+  it 'registers an offense when a property uses ::String with a nil default' do
+    expect_offense(<<~RUBY)
+      property :config_file, ::String, default: nil
+                                       ^^^^^^^^^^^^ Properties have a nil value by default so there is no need to set the default value to nil.
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/redundant/unnecessary_name_property_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/unnecessary_name_property_spec.rb
@@ -69,4 +69,11 @@ describe RuboCop::Cop::Chef::RedundantCode::UnnecessaryNameProperty, :config do
       property :name, String, default: ''
     RUBY
   end
+
+  it 'registers an offense when a name property uses ::String' do
+    expect_offense(<<~RUBY)
+      property :name, ::String
+      ^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to define a property or attribute named :name in a resource as Chef Infra defines this on all resources by default.
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/style/true_false_resource_properties_spec.rb
+++ b/spec/rubocop/cop/chef/style/true_false_resource_properties_spec.rb
@@ -31,4 +31,15 @@ describe RuboCop::Cop::Chef::Style::TrueClassFalseClassResourceProperties, :conf
   it 'does not register an offense when a resource property has a type of true, false' do
     expect_no_offenses('property :foo, [true, false]')
   end
+
+  it 'registers an offense when a property uses ::TrueClass and ::FalseClass' do
+    expect_offense(<<~RUBY)
+      property :foo, [::TrueClass, ::FalseClass]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ When setting the allowed types for a resource to accept either true or false values it's much simpler to use true and false instead of TrueClass and FalseClass.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      property :foo, [true, false]
+    RUBY
+  end
 end


### PR DESCRIPTION
Fourteen cops silently ignore the `::`-prefixed form of the constant they target.

```ruby
Chef::REST.new('u')                    # flagged
::Chef::REST.new('u')                  # missed

class MyThing < Chef::Resource         # flagged
class MyThing < ::Chef::Resource       # missed

property :name, String                 # flagged
property :name, ::String               # missed
```

## Cause

The patterns pin the constant's scope to `nil?`:

```ruby
(const (const nil? :Chef) :REST)
```

A leading `::` parses as a `cbase` node in the scope position, so the fully qualified form matches nothing. Cookbook libraries reach for `::Chef::` constantly to avoid resolution ambiguity inside `class Chef` nesting, so this isn't an exotic spelling — it's the defensive one.

## Fix

`{nil? cbase}` in place of `nil?`, matching the idiom already used by `Chef/RedundantCode/UseCreateIfMissing`.

The HWRP cops needed care. Their patterns contain *two* `(const nil? :Chef)` nodes — the `class Chef` definition, where `nil?` is correct, and the `< Chef::Resource` superclass reference, which is the one that needed widening. Only the superclass changed:

```ruby
(class
  (const nil? :Chef) nil?              # class definition - unchanged
  (class
    (const nil? :Resource) nil?        # unchanged
    $(class
      (const nil? ... )
      (const
        (const {nil? cbase} :Chef) :Resource)   # superclass - widened
        (begin ... ))))
```

## Latent autocorrect bug this surfaced

`Chef/Modernize/DatabagHelpers` rewrites through a source gsub rather than replacing the node:

```ruby
node.source.gsub(/Chef::(EncryptedDataBagItem|DataBagItem).load/, 'data_bag_item')
```

Once the cop started matching `::Chef::DataBagItem.load`, that left the leading `::` behind and autocorrected to the invalid `::data_bag_item('bag', 'item')`. The regex now consumes an optional `::` (and escapes the literal dot). Caught by the new spec's `expect_correction`, not by inspection.

## Affected cops

| Cop | Missed form |
| --- | --- |
| `Chef/Correctness/OpenSSLPasswordHelpers` | `::Opscode::OpenSSL::Password` |
| `Chef/Deprecations/ChefShellout` | `::Chef::ShellOut` |
| `Chef/Deprecations/ChefWindowsPlatformHelper` | `::Chef::Platform.windows?` |
| `Chef/Deprecations/HWRPWithoutProvides` | `< ::Chef::Resource` |
| `Chef/Deprecations/HWRPWithoutUnifiedTrue` | `< ::Chef::Resource` |
| `Chef/Deprecations/ResourceInheritsFromCompatResource` | `< ::ChefCompat::Resource` |
| `Chef/Deprecations/UsesChefRESTHelpers` | `::Chef::REST` |
| `Chef/Deprecations/UsesDeprecatedMixins` | `include ::Chef::Mixin::Language` |
| `Chef/Modernize/DatabagHelpers` | `::Chef::DataBagItem.load` |
| `Chef/Modernize/DslIncludeInResource` | `include ::Chef::DSL::Recipe` |
| `Chef/Modernize/UseRequireRelative` | `require ::File.expand_path` |
| `Chef/RedundantCode/StringPropertyWithNilDefault` | `[::String, ::NilClass]` |
| `Chef/RedundantCode/UnnecessaryNameProperty` | `property :name, ::String` |
| `Chef/Style/TrueClassFalseClassResourceProperties` | `[::TrueClass, ::FalseClass]` |

`Chef/Correctness/ChefApplicationFatal` has the same bug and is already fixed in #1084, so it's left out of this PR to avoid a conflict.

The two HWRP entries are the reason this is worth doing: `HWRPWithoutProvides` flags a Chef Infra Client 16 breaking change, so a miss there is a cookbook that breaks at converge rather than in CI.

## How these were found and confirmed

Each was proven by running `cookstyle` over a fixture holding the bare and scope-resolved forms side by side, in the directory each cop's `Include` globs require — never from reading the pattern alone. Candidates that looked broken but weren't were dropped: `Chef/Correctness/ScopedFileExist` deliberately wants the `::File` form, and `UseCreateIfMissing` already accepts `cbase`.

## Verification

- `bundle exec rspec` — 980 examples, 0 failures (13 new; each fails against the unpatched cop)
- `bundle exec cookstyle` on the 27 changed files — no offenses
- `bundle exec rake validate_config` — unchanged from `main` (5 pre-existing `Chef/Ruby/*` errors)
- YAML re-parsed after the config edit; no duplicate `VersionChanged` keys

No docs assets changed — the generated YAML carries `version_added` but not `version_changed`, and no docstrings were touched. `VersionChanged` set to `8.8.0` on all 14 entries.

Found as part of a broader audit of matcher-coverage gaps; five more classes of the same kind of bug are queued behind this.