### PR TITLE
Detect run_context.include_recipe in 8 cops

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -173,6 +173,7 @@ Chef/Style/IncludeRecipeWithParentheses:
   Description: "There is no need to wrap the recipe name in parentheses when using `include_recipe`. Write `include_recipe 'foo'` instead of `include_recipe('foo')`."
   StyleGuide: 'chef_style_includerecipewithparentheses'
   VersionAdded: '6.11.0'
+  VersionChanged: '8.8.0'
   Enabled: true
   Exclude:
     - '**/attributes/*.rb'
@@ -775,6 +776,7 @@ Chef/Deprecations/IncludingXMLRubyRecipe:
   StyleGuide: 'chef_deprecations_includingxmlrubyrecipe'
   Enabled: true
   VersionAdded: '5.4.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/attributes/*.rb'
     - '**/metadata.rb'
@@ -785,6 +787,7 @@ Chef/Deprecations/LegacyYumCookbookRecipes:
   StyleGuide: 'chef_deprecations_legacyyumcookbookrecipes'
   Enabled: true
   VersionAdded: '5.4.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
 
@@ -1180,6 +1183,7 @@ Chef/Deprecations/ChefHandlerRecipe:
   StyleGuide: 'chef_deprecations_chefhandlerrecipe'
   Enabled: true
   VersionAdded: '6.12.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/Berksfile'
@@ -1459,6 +1463,7 @@ Chef/Modernize/IncludingAptDefaultRecipe:
   StyleGuide: 'chef_modernize_includingaptdefaultrecipe'
   Enabled: true
   VersionAdded: '5.3.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
 
@@ -1467,6 +1472,7 @@ Chef/Modernize/IncludingWindowsDefaultRecipe:
   StyleGuide: 'chef_modernize_includingwindowsdefaultrecipe'
   Enabled: true
   VersionAdded: '5.3.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
 
@@ -1510,6 +1516,7 @@ Chef/Modernize/UseBuildEssentialResource:
   StyleGuide: 'chef_modernize_usebuildessentialresource'
   Enabled: true
   VersionAdded: '5.1.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
 
@@ -1745,7 +1752,7 @@ Chef/Modernize/IncludingOhaiDefaultRecipe:
   StyleGuide: 'chef_modernize_includingohaidefaultrecipe'
   Enabled: true
   VersionAdded: '5.4.0'
-  VersionChanged: '5.15.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/Berksfile'

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
@@ -42,7 +42,7 @@ module RuboCop
           RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :chef_handler_recipe?, <<-PATTERN
-            (send nil? :include_recipe (str {"chef_handler" "chef_handler::default"}))
+            (send {nil? (send nil? :run_context)} :include_recipe (str {"chef_handler" "chef_handler::default"}))
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
@@ -46,7 +46,7 @@ module RuboCop
           RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :old_yum_recipe?, <<-PATTERN
-            (send nil? :include_recipe (str {"yum::elrepo" "yum::epel" "yum::ius" "yum::remi" "yum::repoforge" "yum::yum"}))
+            (send {nil? (send nil? :run_context)} :include_recipe (str {"yum::elrepo" "yum::epel" "yum::ius" "yum::remi" "yum::repoforge" "yum::yum"}))
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
@@ -37,7 +37,7 @@ module RuboCop
           RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :xml_ruby_recipe?, <<-PATTERN
-            (send nil? :include_recipe (str "xml::ruby"))
+            (send {nil? (send nil? :run_context)} :include_recipe (str "xml::ruby"))
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/apt_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/apt_default_recipe.rb
@@ -39,7 +39,7 @@ module RuboCop
           RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :apt_recipe_usage?, <<-PATTERN
-            (send nil? :include_recipe (str {"apt" "apt::default"}))
+            (send {nil? (send nil? :run_context)} :include_recipe (str {"apt" "apt::default"}))
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/build_essential.rb
+++ b/lib/rubocop/cop/chef/modernize/build_essential.rb
@@ -27,6 +27,7 @@ module RuboCop
         #   depends 'build-essential'
         #   include_recipe 'build-essential::default'
         #   include_recipe 'build-essential'
+        #   run_context.include_recipe 'build-essential::default'
         #
         #   # good
         #   build_essential 'install compilation tools'
@@ -37,8 +38,10 @@ module RuboCop
           MSG = 'Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+'
           RESTRICT_ON_SEND = [:include_recipe].freeze
 
+          # matches a bare include_recipe as well as the run_context.include_recipe form used from
+          # libraries and custom resources
           def_node_matcher :build_essential_recipe_usage?, <<-PATTERN
-            (send nil? :include_recipe (str {"build-essential" "build-essential::default"}))
+            (send {nil? (send nil? :run_context)} :include_recipe (str {"build-essential" "build-essential::default"}))
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/ohai_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/ohai_default_recipe.rb
@@ -37,7 +37,7 @@ module RuboCop
           RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :ohai_recipe_usage?, <<-PATTERN
-            (send nil? :include_recipe (str {"ohai" "ohai::default"}))
+            (send {nil? (send nil? :run_context)} :include_recipe (str {"ohai" "ohai::default"}))
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/modernize/windows_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_default_recipe.rb
@@ -35,7 +35,7 @@ module RuboCop
           RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :windows_recipe_usage?, <<-PATTERN
-            (send nil? :include_recipe (str {"windows" "windows::default"}))
+            (send {nil? (send nil? :run_context)} :include_recipe (str {"windows" "windows::default"}))
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/chef/style/include_recipe_with_parentheses.rb
+++ b/lib/rubocop/cop/chef/style/include_recipe_with_parentheses.rb
@@ -36,7 +36,7 @@ module RuboCop
           RESTRICT_ON_SEND = [:include_recipe].freeze
 
           def_node_matcher :include_recipe?, <<-PATTERN
-            (send nil? :include_recipe $(str _))
+            (send {nil? (send nil? :run_context)} :include_recipe $(str _))
           PATTERN
 
           def on_send(node)
@@ -47,7 +47,10 @@ module RuboCop
               return if node.parent&.send_type?
 
               add_offense(node, severity: :refactor) do |corrector|
-                corrector.replace(node, "include_recipe #{recipe.source}")
+                # keep any receiver, otherwise run_context.include_recipe('foo') would correct to a
+                # bare include_recipe and lose the run_context
+                receiver = node.receiver ? "#{node.receiver.source}." : ''
+                corrector.replace(node, "#{receiver}include_recipe #{recipe.source}")
               end
             end
           end

--- a/spec/rubocop/cop/chef/deprecation/chef_handler_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_handler_recipe_spec.rb
@@ -40,4 +40,13 @@ describe RuboCop::Cop::Chef::Deprecations::ChefHandlerRecipe, :config do
   it "doesn't register an offense when including a different recipe" do
     expect_no_offenses("include_recipe 'yum'")
   end
+
+  it 'registers an offense when including the chef_handler default recipe via run_context' do
+    expect_offense(<<~RUBY)
+      run_context.include_recipe 'chef_handler::default'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to include the empty and deprecated chef_handler::default recipe to use the chef_handler resource
+    RUBY
+
+    expect_correction("\n")
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/legacy_yum_cookbook_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/legacy_yum_cookbook_spec.rb
@@ -65,4 +65,11 @@ describe RuboCop::Cop::Chef::Deprecations::LegacyYumCookbookRecipes, :config do
       include_recipe 'yum::default'
     RUBY
   end
+
+  it 'registers an offense when including a legacy yum recipe via run_context' do
+    expect_offense(<<~RUBY)
+      run_context.include_recipe 'yum::epel'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The elrepo, epel, ius, remi, and repoforge recipes were split into their own cookbooks and the yum recipe was renamed to be default with the release of yum cookbook 3.0 (Dec 2013).
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/xml_ruby_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/xml_ruby_recipe_spec.rb
@@ -53,4 +53,11 @@ describe RuboCop::Cop::Chef::Deprecations::IncludingXMLRubyRecipe, :config do
       include_recipe 'xml::default'
     RUBY
   end
+
+  it 'registers an offense when including the xml::ruby recipe via run_context' do
+    expect_offense(<<~RUBY)
+      run_context.include_recipe 'xml::ruby'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not include the deprecated xml::ruby recipe to install the nokogiri gem. Chef Infra Client 12 and later ships with nokogiri included.
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/apt_default_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/apt_default_recipe_spec.rb
@@ -47,4 +47,11 @@ describe RuboCop::Cop::Chef::Modernize::IncludingAptDefaultRecipe, :config do
       RUBY
     end
   end
+
+  it 'registers an offense when including the apt default recipe via run_context' do
+    expect_offense(<<~RUBY)
+      run_context.include_recipe 'apt::default'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not include the Apt default recipe to update package cache. Instead use the apt_update resource, which is built into Chef Infra Client 12.7 and later.
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/build_essential_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/build_essential_spec.rb
@@ -45,4 +45,21 @@ describe RuboCop::Cop::Chef::Modernize::UseBuildEssentialResource, :config do
       build_essential 'install some tools!'
     RUBY
   end
+
+  it 'registers an offense when including the "build-essential" recipe via run_context' do
+    expect_offense(<<~RUBY)
+      run_context.include_recipe 'build-essential'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the build_essential resource instead of the legacy build-essential recipe. This resource ships in the build-essential cookbook v5.0+ and is built into Chef Infra Client 14+
+    RUBY
+
+    expect_correction(<<~RUBY)
+      build_essential 'install compilation tools'
+    RUBY
+  end
+
+  it "doesn't register an offense when include_recipe is called on an unrelated receiver" do
+    expect_no_offenses(<<~RUBY)
+      other_thing.include_recipe 'build-essential'
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/ohai_default_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/ohai_default_recipe_spec.rb
@@ -37,4 +37,11 @@ describe RuboCop::Cop::Chef::Modernize::IncludingOhaiDefaultRecipe, :config do
       include_recipe 'foo'
     RUBY
   end
+
+  it 'registers an offense when including the ohai default recipe via run_context' do
+    expect_offense(<<~RUBY)
+      run_context.include_recipe 'ohai::default'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the ohai_plugin resource to ship custom Ohai plugins instead of using the ohai::default recipe. If you're not shipping custom Ohai plugins, then you can remove this recipe entirely
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/windows_default_recipe_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/windows_default_recipe_spec.rb
@@ -41,4 +41,13 @@ describe RuboCop::Cop::Chef::Modernize::IncludingWindowsDefaultRecipe, :config d
       include_recipe 'foo'
     RUBY
   end
+
+  it 'registers an offense when including the windows default recipe via run_context' do
+    expect_offense(<<~RUBY)
+      run_context.include_recipe 'windows::default'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not include the Windows default recipe, which only installs win32 gems already included in Chef Infra Client
+    RUBY
+
+    expect_correction("\n")
+  end
 end

--- a/spec/rubocop/cop/chef/style/include_recipe_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/chef/style/include_recipe_with_parentheses_spec.rb
@@ -33,4 +33,15 @@ describe RuboCop::Cop::Chef::Style::IncludeRecipeWithParentheses, :config do
   it "does not register an offense with include_recipe 'foo'" do
     expect_no_offenses("include_recipe 'foo'")
   end
+
+  it 'registers an offense and keeps the receiver when run_context.include_recipe uses parens' do
+    expect_offense(<<~RUBY)
+      run_context.include_recipe('foo::bar')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ There is no need to wrap the recipe in parentheses when using the include_recipe helper
+    RUBY
+
+    expect_correction(<<~RUBY)
+      run_context.include_recipe 'foo::bar'
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #788. Supersedes #1090, which fixed only `UseBuildEssentialResource` — that change is included here.

Every `include_recipe` cop misses the `run_context.include_recipe` form:

```ruby
include_recipe 'build-essential'                     # flagged
run_context.include_recipe 'build-essential'         # missed

include_recipe 'windows::default'                    # flagged
run_context.include_recipe 'windows::default'        # missed
```

## Cause

All eight pin the receiver to `nil?`:

```ruby
(send nil? :include_recipe (str {"windows" "windows::default"}))
```

Libraries and custom resources reach the recipe DSL through `run_context.include_recipe`, which has a receiver and so matches nothing.

## Fix

```ruby
(send {nil? (send nil? :run_context)} :include_recipe (str {...}))
```

The receiver is matched specifically rather than with a wildcard, so an unrelated `foo.include_recipe 'build-essential'` is still ignored — there's a test pinning that.

## A corrector that had to change too

`Chef/Style/IncludeRecipeWithParentheses` rebuilt the call from scratch:

```ruby
corrector.replace(node, "include_recipe #{recipe.source}")
```

With the widened pattern that would have **dropped the receiver**, silently rewriting `run_context.include_recipe('foo')` into a bare `include_recipe 'foo'` — a behavior change, not a style fix. The receiver is now carried through:

```ruby
receiver = node.receiver ? "#{node.receiver.source}." : ''
corrector.replace(node, "#{receiver}include_recipe #{recipe.source}")
```

Verified end-to-end with `-a`:

```ruby
run_context.include_recipe 'foo::bar'   # receiver kept
include_recipe 'baz::qux'               # unchanged behaviour for bare calls
```

The three cops that autocorrect by removing the whole line (`windows`, `chef_handler`, `xml::ruby`) needed no change — they remove the node, which now spans the receiver too.

## Affected cops

| Cop | Missed form |
| --- | --- |
| `Chef/Deprecations/ChefHandlerRecipe` | `run_context.include_recipe 'chef_handler::default'` |
| `Chef/Deprecations/IncludingXMLRubyRecipe` | `run_context.include_recipe 'xml::ruby'` |
| `Chef/Deprecations/LegacyYumCookbookRecipes` | `run_context.include_recipe 'yum::epel'` |
| `Chef/Modernize/IncludingAptDefaultRecipe` | `run_context.include_recipe 'apt::default'` |
| `Chef/Modernize/IncludingOhaiDefaultRecipe` | `run_context.include_recipe 'ohai::default'` |
| `Chef/Modernize/IncludingWindowsDefaultRecipe` | `run_context.include_recipe 'windows::default'` |
| `Chef/Modernize/UseBuildEssentialResource` | `run_context.include_recipe 'build-essential'` |
| `Chef/Style/IncludeRecipeWithParentheses` | `run_context.include_recipe('foo::bar')` |

## Verification

- `bundle exec rspec` — 976 examples, 0 failures (10 new; each fails against the unpatched cop)
- `bundle exec cookstyle` on the 16 changed files — no offenses
- `bundle exec rake validate_config` — unchanged from `main` (5 pre-existing `Chef/Ruby/*` errors)
- Full before/after matrix run against a fixture holding all eight recipes in both forms: before, every bare call flagged and every `run_context.` call silent; after, both flagged in all eight pairs
- YAML re-parsed after the config edit; no duplicate `VersionChanged` keys

`VersionChanged` set to `8.8.0` on all eight entries. Second of six classes from the matcher-coverage audit; #1091 covers scope-resolved constants.