### PR TITLE
Detect actions written as arrays in 3 cops

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -294,6 +294,7 @@ Chef/Correctness/ResourceWithNoneAction:
   StyleGuide: 'chef_correctness_resourcewithnoneaction'
   Enabled: true
   VersionAdded: '5.5.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/attributes/*.rb'
     - '**/metadata.rb'
@@ -801,6 +802,7 @@ Chef/Deprecations/ChocolateyPackageUninstallAction:
   StyleGuide: 'chef_deprecations_chocolateypackageuninstallaction'
   Enabled: true
   VersionAdded: '5.5.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
 

--- a/lib/rubocop/chef/cookbook_helpers.rb
+++ b/lib/rubocop/chef/cookbook_helpers.rb
@@ -67,6 +67,29 @@ module RuboCop
         end
       end
 
+      # Yield each action symbol declared by an `action` property, however it's written:
+      # `action :foo`, `action :foo, :bar`, `action [:foo, :bar]`, or `action %i(foo bar)`.
+      #
+      # The yielded prefix is what a corrector must put in front of a replacement action name.
+      # Inside a %i() literal the elements carry no colon, so replacing `%i(create)` with `:run`
+      # would produce the invalid `%i(:run)`.
+      #
+      # @param [RuboCop::AST::SendNode] action_property the `action` property node
+      #
+      # @yield [RuboCop::AST::SymbolNode, String] the action symbol and the replacement prefix
+      #
+      def each_action_symbol(action_property)
+        action_property.arguments.each do |arg|
+          if arg.sym_type?
+            yield(arg, ':')
+          elsif arg.array_type?
+            prefix = arg.percent_literal? ? '' : ':'
+            symbols = arg.values.select(&:sym_type?)
+            symbols.each { |symbol| yield(symbol, prefix) }
+          end
+        end
+      end
+
       def method_arg_ast_to_string(ast)
         # a property without a value. This is totally bogus, but they exist
         return if ast.children[2].nil?

--- a/lib/rubocop/cop/chef/correctness/resource_with_none_action.rb
+++ b/lib/rubocop/cop/chef/correctness/resource_with_none_action.rb
@@ -41,10 +41,10 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(nil, 'action', node) do |action_node|
-              action_node.arguments.each do |action|
-                next unless action.source == ':none'
+              each_action_symbol(action_node) do |action, prefix|
+                next unless action.value == :none
                 add_offense(action, severity: :refactor) do |corrector|
-                  corrector.replace(action, ':nothing')
+                  corrector.replace(action, "#{prefix}nothing")
                 end
               end
             end

--- a/lib/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action.rb
@@ -41,10 +41,10 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(:chocolatey_package, 'action', node) do |choco_action|
-              choco_action.arguments.each do |action|
-                next unless action.source == ':uninstall'
+              each_action_symbol(choco_action) do |action, prefix|
+                next unless action.value == :uninstall
                 add_offense(action, severity: :warning) do |corrector|
-                  corrector.replace(action, ':remove')
+                  corrector.replace(action, "#{prefix}remove")
                 end
               end
             end

--- a/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
+++ b/lib/rubocop/cop/chef/deprecation/ruby_block_create_action.rb
@@ -62,10 +62,10 @@ module RuboCop
 
           def on_block(node)
             match_property_in_resource?(:ruby_block, 'action', node) do |ruby_action|
-              ruby_action.arguments.each do |action|
-                next unless action.source == ':create'
+              each_action_symbol(ruby_action) do |action, prefix|
+                next unless action.value == :create
                 add_offense(action, severity: :warning) do |corrector|
-                  corrector.replace(action, ':run')
+                  corrector.replace(action, "#{prefix}run")
                 end
               end
             end

--- a/spec/rubocop/chef/cookbook_helpers_spec.rb
+++ b/spec/rubocop/chef/cookbook_helpers_spec.rb
@@ -223,4 +223,40 @@ RSpec.describe RuboCop::Chef::CookbookHelpers do
       end
     end
   end
+
+  describe '#each_action_symbol' do
+    def yielded_actions(source)
+      results = []
+      each_action_symbol(parse_source(source).ast) { |node, prefix| results << [node.value, prefix] }
+      results
+    end
+
+    it 'yields a single symbol action' do
+      expect(yielded_actions('action :create')).to eq [[:create, ':']]
+    end
+
+    it 'yields each symbol when several are passed as separate arguments' do
+      expect(yielded_actions('action :create, :run')).to eq [[:create, ':'], [:run, ':']]
+    end
+
+    it 'yields each symbol in a bracketed array with a colon prefix' do
+      expect(yielded_actions('action [:create, :run]')).to eq [[:create, ':'], [:run, ':']]
+    end
+
+    it 'yields each symbol in a %i array with no prefix' do
+      expect(yielded_actions('action %i(create run)')).to eq [[:create, ''], [:run, '']]
+    end
+
+    it 'yields nothing for a string array, which holds no symbols' do
+      expect(yielded_actions('action %w(create run)')).to eq []
+    end
+
+    it 'yields nothing when the action cannot be resolved statically' do
+      expect(yielded_actions("action node['foo']['action']")).to eq []
+    end
+
+    it 'yields nothing when no action is given' do
+      expect(yielded_actions('action')).to eq []
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/correctness/resource_with_none_action_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/resource_with_none_action_spec.rb
@@ -40,4 +40,19 @@ describe RuboCop::Cop::Chef::Correctness::ResourceWithNoneAction, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when a resource uses :none in a %i array' do
+    expect_offense(<<~RUBY)
+      service 'a' do
+        action %i(none)
+                  ^^^^ Resource uses the nonexistent :none action instead of the :nothing action
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      service 'a' do
+        action %i(nothing)
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chocolatey_package_uninstall_action_spec.rb
@@ -36,4 +36,19 @@ describe RuboCop::Cop::Chef::Deprecations::ChocolateyPackageUninstallAction, :co
       end
     RUBY
   end
+
+  it 'registers an offense when chocolatey_package uses :uninstall in a %i array' do
+    expect_offense(<<~RUBY)
+      chocolatey_package 'a' do
+        action %i(uninstall)
+                  ^^^^^^^^^ Use the :remove action in the chocolatey_package resource instead of :uninstall which was removed in Chef Infra Client 14+
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      chocolatey_package 'a' do
+        action %i(remove)
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/ruby_block_create_action_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/ruby_block_create_action_spec.rb
@@ -136,4 +136,34 @@ describe RuboCop::Cop::Chef::Deprecations::RubyBlockCreateAction, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when ruby_block uses :create in a %i array' do
+    expect_offense(<<~RUBY)
+      ruby_block 'a' do
+        action %i(create)
+                  ^^^^^^ Use the :run action in the ruby_block resource instead of the deprecated :create action
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ruby_block 'a' do
+        action %i(run)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when ruby_block uses :create in a bracketed array' do
+    expect_offense(<<~RUBY)
+      ruby_block 'a' do
+        action [:create, :nothing]
+                ^^^^^^^ Use the :run action in the ruby_block resource instead of the deprecated :create action
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ruby_block 'a' do
+        action [:run, :nothing]
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Three cops miss deprecated actions whenever the action is written as an array:

```ruby
action :create        # flagged
action %i(create)     # missed
action [:create]      # missed
```

## Cause

Each compares the raw source of every argument against a literal string:

```ruby
ruby_action.arguments.each do |action|
  next unless action.source == ':create'
```

An array of actions is a *single* `array` node whose source is `%i(create)`, so it never equals `':create'` and the resource escapes entirely. Arrays are the normal way to write multiple actions, so any resource pairing a deprecated action with a second one goes unreported.

## Fix

A shared helper, since all three had copy-pasted the same loop:

```ruby
def each_action_symbol(action_property)
  action_property.arguments.each do |arg|
    if arg.sym_type?
      yield(arg, ':')
    elsif arg.array_type?
      prefix = arg.percent_literal? ? '' : ':'
      symbols = arg.values.select(&:sym_type?)
      symbols.each { |symbol| yield(symbol, prefix) }
    end
  end
end
```

It handles `action :foo`, `action :foo, :bar`, `action [:foo, :bar]`, and `action %i(foo bar)`.

## The prefix is the interesting part

Inside a `%i()` literal the elements carry **no colon** — the element node's source is `create`, not `:create`. A naive corrector would turn `%i(create)` into the invalid `%i(:run)`. So the helper also yields the prefix a corrector must use: empty inside `%i()`, `:` everywhere else.

Verified with `-a` against every form:

```ruby
ruby_block 'a' do action :run end
ruby_block 'b' do action %i(run) end        # not %i(:run)
ruby_block 'c' do action [:run] end
chocolatey_package 'e' do action %i(remove) end
service 'g' do action %i(nothing) end
```

`ruby -c` confirms the corrected output parses.

## Affected cops

| Cop | Missed form |
| --- | --- |
| `Chef/Correctness/ResourceWithNoneAction` | `action %i(none)` |
| `Chef/Deprecations/ChocolateyPackageUninstallAction` | `action %i(uninstall)` |
| `Chef/Deprecations/RubyBlockCreateAction` | `action %i(create)` |

## Verification

- `bundle exec rspec` — 971 examples, 0 failures (4 new; all four fail against the unpatched cops)
- `bundle exec cookstyle` on the changed Ruby files — no offenses
- `bundle exec rake validate_config` — unchanged from `main` (5 pre-existing `Chef/Ruby/*` errors)
- End-to-end `-a` run over a fixture holding all three action spellings for each cop, output checked with `ruby -c`

**Merge order note:** #1085 also touches `ruby_block_create_action.rb`, adding an `on_send` handler for notifications. This PR changes the `on_block` body. Different regions of the same file, but whichever lands second may want a look.

Third of six classes from the matcher-coverage audit — #1091 (scope-resolved constants) and #1092 (`run_context.include_recipe`) are the other two open so far.