### PR TITLE
Treat the notification timing as optional in 2 cops

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1461,6 +1461,7 @@ Chef/Modernize/ExecuteAptUpdate:
   StyleGuide: 'chef_modernize_executeaptupdate'
   Enabled: true
   VersionAdded: '5.3.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
 
@@ -1511,6 +1512,7 @@ Chef/Modernize/LibarchiveFileResource:
   StyleGuide: 'chef_modernize_libarchivefileresource'
   Enabled: true
   VersionAdded: '5.5.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
 

--- a/lib/rubocop/cop/chef/modernize/execute_apt_update.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_apt_update.rb
@@ -53,8 +53,10 @@ module RuboCop
             (send nil? :execute (str { "apt-get update" "apt-get update -y" "apt-get -y update" }))
           PATTERN
 
+          # the notification timing is optional and defaults to :delayed, so the trailing
+          # argument is matched with ... rather than being required
           def_node_matcher :notification_property?, <<-PATTERN
-            (send nil? {:notifies :subscribes} (sym _) $(...) (sym _))
+            (send nil? {:notifies :subscribes} (sym _) $(...) ...)
           PATTERN
 
           def_node_matcher :execute_command?, <<-PATTERN

--- a/lib/rubocop/cop/chef/modernize/libarchive_file.rb
+++ b/lib/rubocop/cop/chef/modernize/libarchive_file.rb
@@ -44,8 +44,10 @@ module RuboCop
           MSG = 'Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive_file resource from the libarchive cookbook'
           RESTRICT_ON_SEND = [:libarchive_file, :notifies, :subscribes].freeze
 
+          # the notification timing is optional and defaults to :delayed, so the trailing
+          # argument is matched with ... rather than being required
           def_node_matcher :notification_property?, <<-PATTERN
-            (send nil? {:notifies :subscribes} (sym _) $(...) (sym _))
+            (send nil? {:notifies :subscribes} (sym _) $(...) ...)
           PATTERN
 
           def on_send(node)

--- a/spec/rubocop/cop/chef/modernize/execute_apt_update_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/execute_apt_update_spec.rb
@@ -79,4 +79,22 @@ describe RuboCop::Cop::Chef::Modernize::ExecuteAptUpdate, :config do
       end
     RUBY
   end
+
+  it "registers an offense when a resource notifies 'execute[apt-get update]' without a timing" do
+    expect_offense(<<~RUBY)
+      execute 'some execute resource' do
+        notifies :run, 'execute[apt-get update]'
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^ Use the apt_update resource instead of the execute resource to run an apt-get update package cache update
+      end
+    RUBY
+  end
+
+  it "registers an offense when a resource subscribes to 'execute[apt-get update]' without a timing" do
+    expect_offense(<<~RUBY)
+      execute 'some execute resource' do
+        subscribes :run, 'execute[apt-get update]'
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^ Use the apt_update resource instead of the execute resource to run an apt-get update package cache update
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/libarchive_file_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/libarchive_file_spec.rb
@@ -74,4 +74,36 @@ describe RuboCop::Cop::Chef::Modernize::LibarchiveFileResource, :config do
       RUBY
     end
   end
+
+  it 'registers an offense when a resource notifies libarchive_file without a timing' do
+    expect_offense(<<~RUBY)
+      remote_file archive_path do
+        action :create_if_missing
+        notifies :extract, 'libarchive_file[extract_yajsw]'
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive_file resource from the libarchive cookbook
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      remote_file archive_path do
+        action :create_if_missing
+        notifies :extract, 'archive_file[extract_yajsw]'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a resource subscribes to libarchive_file without a timing' do
+    expect_offense(<<~RUBY)
+      remote_file archive_path do
+        subscribes :extract, 'libarchive_file[extract_yajsw]'
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the archive_file resource built into Chef Infra Client 15+ instead of the libarchive_file resource from the libarchive cookbook
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      remote_file archive_path do
+        subscribes :extract, 'archive_file[extract_yajsw]'
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Two cops miss notifications that omit the timing argument:

```ruby
notifies :extract, 'libarchive_file[bar]', :immediately   # flagged
notifies :extract, 'libarchive_file[bar]'                 # missed
subscribes :extract, 'libarchive_file[bar]'               # missed

notifies :run, 'execute[apt-get update]', :immediately    # flagged
notifies :run, 'execute[apt-get update]'                  # missed
```

## Cause

Both use the same pattern:

```ruby
(send nil? {:notifies :subscribes} (sym _) $(...) (sym _))
```

The trailing `(sym _)` makes the timing **required**, so the matcher demands exactly three arguments. But the timing is optional in Chef and defaults to `:delayed` — `notifies :run, 'execute[foo]'` is perfectly ordinary, and neither cop could see it.

## Fix

```ruby
(send nil? {:notifies :subscribes} (sym _) $(...) ...)
```

`...` matches zero or more trailing nodes, so both the two- and three-argument forms are picked up.

Note this is the *opposite* of `Chef/Correctness/InvalidNotificationTiming` and `Chef/Style/ImmediateNotificationTiming`, which legitimately require the timing argument — they exist to check it. Those are untouched.

## Affected cops

| Cop | Missed form |
| --- | --- |
| `Chef/Modernize/ExecuteAptUpdate` | `notifies :run, 'execute[apt-get update]'` |
| `Chef/Modernize/LibarchiveFileResource` | `notifies :extract, 'libarchive_file[foo]'` |

## Verification

- `bundle exec rspec` — 971 examples, 0 failures (4 new; all four fail against the unpatched cops, covering both `notifies` and `subscribes`)
- `bundle exec cookstyle` on the changed Ruby files — no offenses
- `bundle exec rake validate_config` — unchanged from `main`
- Fixture re-run: before, only the three-argument notifications flagged; after, all five forms flagged. The libarchive autocorrect still produces the right `archive_file[...]` rewrite for the two-argument form.

`VersionChanged` set to `8.8.0` on both. Fourth of six classes from the matcher-coverage audit (#1091, #1092, #1093 are the others open).