### PR TITLE
Match single-statement bodies in 3 cops

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1095,7 +1095,7 @@ Chef/Deprecations/HWRPWithoutProvides:
   StyleGuide: 'chef_deprecations_hwrpwithoutprovides'
   Enabled: true
   VersionAdded: '6.0.0'
-  VersionChanged: '6.8.0'
+  VersionChanged: '8.8.0'
   Include:
     - '**/libraries/*.rb'
 
@@ -1287,6 +1287,7 @@ Chef/Deprecations/HWRPWithoutUnifiedTrue:
   StyleGuide: 'chef_deprecations_hwrpwithoutunifiedtrue'
   Enabled: true
   VersionAdded: '7.12.0'
+  VersionChanged: '8.8.0'
   Include:
     - '**/libraries/*.rb'
 
@@ -2255,6 +2256,7 @@ Chef/RedundantCode/DoubleCompileTime:
   StyleGuide: 'chef_redundantcode_doublecompiletime'
   Enabled: true
   VersionAdded: '6.13.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/metadata.rb'
     - '**/attributes/*.rb'

--- a/lib/rubocop/cop/chef/deprecation/hwrp_without_provides.rb
+++ b/lib/rubocop/cop/chef/deprecation/hwrp_without_provides.rb
@@ -95,7 +95,7 @@ module RuboCop
                 (const nil? ... )
                 (const
                   (const nil? :Chef) :Resource)
-                  (begin ... ))))
+                  ...)))
           PATTERN
 
           def_node_search :provides, '(send nil? :provides (sym $_) ...)'

--- a/lib/rubocop/cop/chef/deprecation/hwrp_without_unified_mode_true.rb
+++ b/lib/rubocop/cop/chef/deprecation/hwrp_without_unified_mode_true.rb
@@ -68,7 +68,7 @@ module RuboCop
                 (const nil? ... )
                 (const
                   (const nil? :Chef) :Resource)
-                  (begin ... ))))
+                  ...)))
           PATTERN
 
           def_node_search :unified_mode?, '(send nil? :unified_mode ...)'

--- a/lib/rubocop/cop/chef/redundant/double_compile_time.rb
+++ b/lib/rubocop/cop/chef/redundant/double_compile_time.rb
@@ -41,23 +41,37 @@ module RuboCop
           MSG = "If a resource includes the `compile_time` property there's no need to also use `.run_action(:some_action)` on the resource block."
           RESTRICT_ON_SEND = [:run_action].freeze
 
-          def_node_matcher :compile_time_and_run_action?, <<-PATTERN
+          def_node_matcher :run_action_on_resource?, <<-PATTERN
           (send
             $(block
               (send nil? ... )
               (args)
-              (begin <
-                (send nil? :action (sym $_) )
-                (send nil? :compile_time (true) )
-                ...
-              >)
+              _
             ) :run_action (sym $_) )
           PATTERN
 
+          def_node_search :compile_time_true?, '(send nil? :compile_time (true))'
+          def_node_search :action_nodes, '(send nil? :action $(sym _))'
+
           def on_send(node)
-            compile_time_and_run_action?(node) do |resource, action, run_action|
+            run_action_on_resource?(node) do |resource, run_action|
+              next unless compile_time_true?(resource.body)
+
+              # without an explicit action there's nothing to rewrite: the resource runs its
+              # default action, and picking the replacement would mean knowing what that is.
+              # report it, but leave the fix to a human.
+              action = action_nodes(resource.body).first
+              unless action
+                add_offense(node.loc.selector, severity: :refactor)
+                next
+              end
+
               add_offense(node.loc.selector, severity: :refactor) do |corrector|
-                corrector.replace(node, resource.source.gsub(action.to_s, run_action.to_s))
+                # rewrite the action's value and drop the trailing .run_action(...). rewriting the
+                # whole block source instead would replace the action name wherever else it appears,
+                # renaming the resource itself in something like chef_gem 'nothing'
+                corrector.replace(action, ":#{run_action}")
+                corrector.remove(node.loc.dot.join(node.source_range.end))
               end
             end
           end

--- a/spec/rubocop/cop/chef/deprecation/hwrp_without_provides_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/hwrp_without_provides_spec.rb
@@ -177,4 +177,17 @@ describe RuboCop::Cop::Chef::Deprecations::HWRPWithoutProvides, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when a HWRP with a single-statement body does not define provides' do
+    expect_offense(<<~RUBY)
+      class Chef
+        class Resource
+          class UlimitRule < Chef::Resource
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ In Chef Infra Client 16 and later a legacy HWRP resource must use `provides` to define how the resource is called in recipes or other resources. To maintain compatibility with Chef Infra Client < 16 use both `resource_name` and `provides`.
+            resource_name :ulimit_rule
+          end
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/hwrp_without_unified_mode_true_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/hwrp_without_unified_mode_true_spec.rb
@@ -72,4 +72,17 @@ describe RuboCop::Cop::Chef::Deprecations::HWRPWithoutUnifiedTrue, :config do
       RUBY
     end
   end
+
+  it 'registers an offense when a HWRP with a single-statement body does not define unified_mode true' do
+    expect_offense(<<~RUBY)
+      class Chef
+        class Resource
+          class UlimitRule < Chef::Resource
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Set `unified_mode true` in Chef Infra Client 15.3+ HWRP style custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default.
+            provides :ulimit_rule
+          end
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/redundant/double_compile_time_spec.rb
+++ b/spec/rubocop/cop/chef/redundant/double_compile_time_spec.rb
@@ -39,8 +39,48 @@ describe RuboCop::Cop::Chef::RedundantCode::DoubleCompileTime, :config do
   it 'does not register an offense if compile_time property is not present' do
     expect_no_offenses(<<~RUBY)
       chef_gem 'deep_merge' do
+        action :nothing
+      end.run_action(:install)
+    RUBY
+  end
+
+  it 'registers an offense when a resource sets compile_time without an action property' do
+    expect_offense(<<~RUBY)
+      chef_gem 'deep_merge' do
         compile_time true
       end.run_action(:install)
+          ^^^^^^^^^^ If a resource includes the `compile_time` property there's no need to also use `.run_action(:some_action)` on the resource block.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense when a multi-statement resource sets compile_time without an action' do
+    expect_offense(<<~RUBY)
+      chef_gem 'deep_merge' do
+        compile_time true
+        version '1.0'
+      end.run_action(:install)
+          ^^^^^^^^^^ If a resource includes the `compile_time` property there's no need to also use `.run_action(:some_action)` on the resource block.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'does not rewrite the resource name when it matches the action name' do
+    expect_offense(<<~RUBY)
+      chef_gem 'nothing' do
+        action :nothing
+        compile_time true
+      end.run_action(:install)
+          ^^^^^^^^^^ If a resource includes the `compile_time` property there's no need to also use `.run_action(:some_action)` on the resource block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      chef_gem 'nothing' do
+        action :install
+        compile_time true
+      end
     RUBY
   end
 end


### PR DESCRIPTION
Two related gaps around resource and class bodies. They were filed together in my audit as one class; investigating turned up two different root causes, so both are described separately below.

## 1. HWRP cops: `(begin ...)` requires two or more statements

```ruby
class Chef
  class Resource
    class UlimitRule < Chef::Resource
      resource_name :ulimit_rule       # single statement - missed
    end
  end
end
```

Both HWRP patterns ended with `(begin ... )`. Ruby wraps a single statement in **no** `begin` node at all, so a one-line HWRP matched nothing. Adding a second property made the same resource start being flagged.

Fixed by matching the body with `...`, which accepts any body:

```ruby
$(class
  (const nil? ... )
  (const
    (const nil? :Chef) :Resource)
    ...)))
```

This matters because `HWRPWithoutProvides` flags a Chef Infra Client 16 breaking change — a miss is a cookbook that breaks at converge.

## 2. DoubleCompileTime: the real constraint was a required `action`

I originally filed this as the same `begin` bug. It isn't, and the distinction is worth stating: its pattern required **both** an `action` and a `compile_time` property, and a body containing both always has two statements — so `begin` was never the binding constraint. The actual constraint is the required `action`:

```ruby
chef_gem 'deep_merge' do
  action :nothing
  compile_time true
end.run_action(:install)          # flagged

chef_gem 'deep_merge' do
  compile_time true
end.run_action(:install)          # missed - no action property

chef_gem 'deep_merge' do
  compile_time true
  version '1.0'
end.run_action(:install)          # also missed, and this one has a begin body
```

The action is now optional. With one present the existing rewrite still applies. Without one there is nothing to rewrite — picking the replacement would mean knowing the resource's default action — so the offense is **reported without a corrector** rather than guessing.

## A pre-existing spec that asserted the opposite of its own name

Making the action optional broke this test:

```ruby
it 'does not register an offense if compile_time property is not present' do
  expect_no_offenses(<<~RUBY)
    chef_gem 'deep_merge' do
      compile_time true          # <- the property the title says is absent
    end.run_action(:install)
  RUBY
end
```

The title describes a resource with no `compile_time`; the body sets it and merely omits the `action`. It passed only because of the gap this PR closes, so the assertion was an artifact of the bug rather than a designed behavior — that code really is the double-compile-time this cop exists to catch.

I changed the body to match the title (a resource with an `action` and no `compile_time`, still no offense) and added explicit tests for the missing-action case now being flagged. **Flagging this prominently since it means the cop now reports code it previously ignored** — if you consider the old assertion intentional, say so and I'll gate it instead.

## Verification

- `bundle exec rspec` — 971 examples, 0 failures (4 new; all four fail against the unpatched cops)
- `bundle exec cookstyle` on the changed Ruby files — no offenses
- `bundle exec rake validate_config` — unchanged from `main`
- End-to-end: single-statement HWRP now flagged by both cops; all three `DoubleCompileTime` shapes flagged, with only the action-bearing one marked `[Correctable]`; `-a` on that one still produces `action :install` and `ruby -c` passes

**Merge order note:** #1091 also touches both HWRP cops (scope-resolved superclasses) and stamps `VersionChanged` on them. Different lines, but the config file may need a trivial resolution depending on merge order.

Last of the classes from the matcher-coverage audit. Open siblings: #1091, #1092, #1093, #1094.