### PR TITLE
Add Chef/Correctness/RubyGuardWithoutBlock cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -414,6 +414,16 @@ Chef/Correctness/ExecuteDeleteFile:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+Chef/Correctness/RubyGuardWithoutBlock:
+  Description: "A Ruby expression used as a resource guard (`not_if`/`only_if`) has to be wrapped in a block. String guards are run as shell commands and are fine as they are; it is only a bare Ruby expression that is a problem, since the guard receives the expression result rather than the expression."
+  StyleGuide: 'chef_correctness_rubyguardwithoutblock'
+  Enabled: true
+  VersionAdded: '8.8.0'
+  Exclude:
+    - '**/attributes/*.rb'
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 Chef/Correctness/PlatformVersionStringComparison:
   Description: "Ohai version attributes are strings, so comparing one with an ordering operator compares them character by character rather than as versions. `'7.9' >= '10'` is true. Use `.to_i` for a major version comparison, or `Gem::Version` to compare full versions."
   StyleGuide: 'chef_correctness_platformversionstringcomparison'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_rubyguardwithoutblock.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_rubyguardwithoutblock.yml
@@ -1,0 +1,38 @@
+---
+short_name: RubyGuardWithoutBlock
+full_name: Chef/Correctness/RubyGuardWithoutBlock
+department: Chef/Correctness
+description: |-
+  A `not_if`/`only_if` guard takes either a string, which is run as a shell command, or a block,
+  which is run as Ruby. Passing a Ruby expression directly gives the guard the expression's
+  *result* rather than the expression, because it is evaluated while the recipe is compiled.
+
+  A guard that receives `true` or `false` raises at converge time:
+
+    ArgumentError: Invalid only_if/not_if command, expected a string: true (TrueClass)
+
+  Worse, an expression that happens to return a string is accepted and then run as a shell
+  command, so the guard quietly tests something entirely different to what was intended.
+
+  Only expressions that clearly produce a boolean are flagged, so a shell command built in Ruby
+  and held in a variable is left alone.
+autocorrection: true
+target_chef_version: All Versions
+examples: |2-
+
+  # bad
+  not_if ::File.exist?('/etc/foo')
+  only_if node['foo']['version'] == '1.0'
+
+  # good
+  not_if { ::File.exist?('/etc/foo') }
+  only_if { node['foo']['version'] == '1.0' }
+
+  # good - a string guard runs as a shell command
+  not_if 'test -f /etc/foo'
+version_added: 8.8.0
+enabled: true
+excluded_file_paths:
+- "**/attributes/*.rb"
+- "**/metadata.rb"
+- "**/Berksfile"

--- a/lib/rubocop/cop/chef/correctness/ruby_guard_without_block.rb
+++ b/lib/rubocop/cop/chef/correctness/ruby_guard_without_block.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Correctness
+        # A `not_if`/`only_if` guard takes either a string, which is run as a shell command, or a block,
+        # which is run as Ruby. Passing a Ruby expression directly gives the guard the expression's
+        # *result* rather than the expression, because it is evaluated while the recipe is compiled.
+        #
+        # A guard that receives `true` or `false` raises at converge time:
+        #
+        #   ArgumentError: Invalid only_if/not_if command, expected a string: true (TrueClass)
+        #
+        # Worse, an expression that happens to return a string is accepted and then run as a shell
+        # command, so the guard quietly tests something entirely different to what was intended.
+        #
+        # Only expressions that clearly produce a boolean are flagged, so a shell command built in Ruby
+        # and held in a variable is left alone.
+        #
+        # @example
+        #
+        #   # bad
+        #   not_if ::File.exist?('/etc/foo')
+        #   only_if node['foo']['version'] == '1.0'
+        #
+        #   # good
+        #   not_if { ::File.exist?('/etc/foo') }
+        #   only_if { node['foo']['version'] == '1.0' }
+        #
+        #   # good - a string guard runs as a shell command
+        #   not_if 'test -f /etc/foo'
+        #
+        class RubyGuardWithoutBlock < Base
+          extend AutoCorrector
+
+          MSG = 'A Ruby expression used as a resource guard has to be wrapped in a block. Passing it directly hands the guard the expression result, which raises at converge time or silently runs a shell command.'
+          RESTRICT_ON_SEND = [:not_if, :only_if].freeze
+
+          # comparison and negation operators always produce a boolean
+          BOOLEAN_OPERATORS = %i(== != < > <= >= =~ !~ ! equal? eql?).freeze
+
+          def_node_matcher :guard_with_argument, '(send nil? {:not_if :only_if} $_)'
+
+          def on_send(node)
+            guard_with_argument(node) do |argument|
+              next unless boolean_expression?(argument)
+
+              add_offense(node, severity: :refactor) do |corrector|
+                corrector.replace(node, "#{node.method_name} { #{argument.source} }")
+              end
+            end
+          end
+
+          private
+
+          # Can we tell that this expression produces a boolean rather than a shell command? Anything
+          # we can't be sure about, such as a bare method call or a local variable, is left alone: it
+          # may well hold a perfectly good command string.
+          #
+          # @param [RuboCop::AST::Node] node
+          #
+          # @return [Boolean]
+          def boolean_expression?(node)
+            return true if node.boolean_type? || node.defined_type?
+            return true if node.operator_keyword? # && and ||
+            return node.children.one? && boolean_expression?(node.children.first) if node.begin_type?
+            return false unless node.send_type?
+
+            node.method_name.to_s.end_with?('?') || BOOLEAN_OPERATORS.include?(node.method_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/ruby_guard_without_block_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/ruby_guard_without_block_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Correctness::RubyGuardWithoutBlock, :config do
+  it 'registers an offense when not_if is passed a File.exist? call' do
+    expect_offense(<<~RUBY)
+      execute 'foo' do
+        not_if ::File.exist?('/etc/foo')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A Ruby expression used as a resource guard has to be wrapped in a block. Passing it directly hands the guard the expression result, which raises at converge time or silently runs a shell command.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      execute 'foo' do
+        not_if { ::File.exist?('/etc/foo') }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when only_if is passed a comparison' do
+    expect_offense(<<~RUBY)
+      execute 'foo' do
+        only_if node['foo']['version'] == '1.0'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A Ruby expression used as a resource guard has to be wrapped in a block. Passing it directly hands the guard the expression result, which raises at converge time or silently runs a shell command.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      execute 'foo' do
+        only_if { node['foo']['version'] == '1.0' }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a guard is passed a negation' do
+    expect_offense(<<~RUBY)
+      execute 'foo' do
+        only_if !node['foo']['enabled']
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A Ruby expression used as a resource guard has to be wrapped in a block. Passing it directly hands the guard the expression result, which raises at converge time or silently runs a shell command.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      execute 'foo' do
+        only_if { !node['foo']['enabled'] }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a guard is passed a boolean literal' do
+    expect_offense(<<~RUBY)
+      execute 'foo' do
+        only_if true
+        ^^^^^^^^^^^^ A Ruby expression used as a resource guard has to be wrapped in a block. Passing it directly hands the guard the expression result, which raises at converge time or silently runs a shell command.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      execute 'foo' do
+        only_if { true }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a guard is passed a compound expression' do
+    expect_offense(<<~RUBY)
+      execute 'foo' do
+        only_if ::File.exist?('/etc/foo') && node['foo']['enabled']
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A Ruby expression used as a resource guard has to be wrapped in a block. Passing it directly hands the guard the expression result, which raises at converge time or silently runs a shell command.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      execute 'foo' do
+        only_if { ::File.exist?('/etc/foo') && node['foo']['enabled'] }
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard is a block" do
+    expect_no_offenses(<<~RUBY)
+      execute 'foo' do
+        not_if { ::File.exist?('/etc/foo') }
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard is a shell command string" do
+    expect_no_offenses(<<~RUBY)
+      execute 'foo' do
+        not_if 'test -f /etc/foo'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard is an interpolated string" do
+    expect_no_offenses(<<~'RUBY')
+      execute 'foo' do
+        not_if "test -f #{node['foo']['path']}"
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard is a variable holding a command" do
+    expect_no_offenses(<<~RUBY)
+      execute 'foo' do
+        not_if guard_command
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard is a local variable" do
+    expect_no_offenses(<<~RUBY)
+      cmd = 'test -f /etc/foo'
+      execute 'foo' do
+        not_if cmd
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
```ruby
# bad
not_if ::File.exist?('/etc/foo')
only_if node['foo']['enabled']

# good
not_if { ::File.exist?('/etc/foo') }
only_if { node['foo']['enabled'] }

# good - a string guard runs as a shell command
not_if 'test -f /etc/foo'
```

A `not_if`/`only_if` guard takes either a string, run as a shell command, or a block, run as Ruby. Passing a Ruby expression **directly** hands the guard the expression's *result*, because it's evaluated while the recipe compiles.

Two failure modes:

- The guard receives `true` or `false` and raises at converge: `ArgumentError: Invalid only_if/not_if command, expected a string: true (TrueClass)`
- Worse, an expression that happens to return a **string** is accepted and run as a shell command, so the guard silently tests something else entirely.

This is exactly the mistake reported in #841 — the reporter read the cop message as an instruction to write `not_if ::File.exist?('/foo/bar')` and hit the ArgumentError. #1089 rewords that message; nothing actually *detects* the mistake, which is what this adds.

## Avoiding false positives

The hard part is that a guard argument which isn't a literal string may still be perfectly valid — a command assembled in Ruby and held in a variable is idiomatic:

```ruby
cmd = 'test -f /etc/foo'
not_if cmd                     # fine, not flagged
not_if guard_command           # fine, not flagged
```

So only expressions that **clearly** produce a boolean are flagged: boolean literals, `defined?`, `&&`/`||`, comparison and negation operators, and predicate methods (`foo?`). Anything whose type can't be determined is left alone. Tests pin both directions.

| Guard | Flagged |
| --- | --- |
| `not_if ::File.exist?('/etc/foo')` | yes — predicate method |
| `only_if node['x'] == '1.0'` | yes — comparison |
| `only_if !node['x']` | yes — negation |
| `only_if true` | yes — boolean literal |
| `only_if ::File.exist?('/x') && node['y']` | yes — `&&` |
| `not_if { ::File.exist?('/etc/foo') }` | no — already a block |
| `not_if 'test -f /etc/foo'` | no — shell command |
| `not_if "test -f #{node['x']}"` | no — interpolated command |
| `not_if cmd` / `not_if guard_command` | no — can't tell, may be a command |

## Autocorrect

Wraps the expression in a block, which is what was meant in every flagged case:

```ruby
not_if ::File.exist?('/etc/foo')   →   not_if { ::File.exist?('/etc/foo') }
```

## Verification

- `bundle exec rspec` — 977 examples, 0 failures (10 new)
- `bundle exec rake validate_config` — cop registered; the 5 remaining `Chef/Ruby/*` errors are pre-existing on `main`
- `bundle exec cookstyle` — no offenses in the new files

`VersionAdded` set to `8.8.0`. One of a batch of cops proposed from an audit of Chef-specific failure modes not currently covered.