### PR TITLE
Flag empty guard blocks in Chef/Correctness/EmptyResourceGuard

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -411,10 +411,11 @@ Chef/Correctness/PlatformVersionStringComparison:
     - '**/Berksfile'
 
 Chef/Correctness/EmptyResourceGuard:
-  Description: "Resource guards (`not_if`/`only_if`) should not be empty strings. In Ruby, empty strings are 'truthy', so an empty guard string will always pass, which is almost certainly not what you intended."
+  Description: "Resource guards (`not_if`/`only_if`) should not be empty. In Ruby, an empty string is 'truthy', so an empty guard string always passes. An empty block returns `nil`, so it always fails. Neither is likely to be what you intended."
   StyleGuide: 'chef_correctness_emptyresourceguard'
   Enabled: true
   VersionAdded: '8.4.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/attributes/*.rb'
     - '**/metadata.rb'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_emptyresourceguard.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_emptyresourceguard.yml
@@ -3,12 +3,17 @@ short_name: EmptyResourceGuard
 full_name: Chef/Correctness/EmptyResourceGuard
 department: Chef/Correctness
 description: |-
-  Resource guards (not_if/only_if) should not be empty strings as empty strings will always evaluate to true.
-  This will cause confusion in your cookbooks as the guard will always pass.
+  Resource guards (not_if/only_if) should not be empty. An empty string always evaluates to true
+  and an empty block always evaluates to false, so in either case the guard stops doing the job
+  it was written for and the resource silently runs, or fails to run, on every converge.
 
   Empty strings in Ruby are "truthy", which means:
   - `only_if ''` will ALWAYS execute the resource (guard always passes)
   - `not_if ''` will NEVER execute the resource (guard always blocks)
+
+  An empty block behaves the other way around, since a block with no body returns `nil`:
+  - `only_if { }` will NEVER execute the resource
+  - `not_if { }` will ALWAYS execute the resource
 
   This behavior is usually unintended and can lead to resources running when they shouldn't
   or never running when they should.

--- a/lib/rubocop/cop/chef/correctness/empty_resource_guard.rb
+++ b/lib/rubocop/cop/chef/correctness/empty_resource_guard.rb
@@ -19,12 +19,17 @@ module RuboCop
   module Cop
     module Chef
       module Correctness
-        # Resource guards (not_if/only_if) should not be empty strings as empty strings will always evaluate to true.
-        # This will cause confusion in your cookbooks as the guard will always pass.
+        # Resource guards (not_if/only_if) should not be empty. An empty string always evaluates to true
+        # and an empty block always evaluates to false, so in either case the guard stops doing the job
+        # it was written for and the resource silently runs, or fails to run, on every converge.
         #
         # Empty strings in Ruby are "truthy", which means:
         # - `only_if ''` will ALWAYS execute the resource (guard always passes)
         # - `not_if ''` will NEVER execute the resource (guard always blocks)
+        #
+        # An empty block behaves the other way around, since a block with no body returns `nil`:
+        # - `only_if { }` will NEVER execute the resource
+        # - `not_if { }` will ALWAYS execute the resource
         #
         # This behavior is usually unintended and can lead to resources running when they shouldn't
         # or never running when they should.
@@ -72,6 +77,7 @@ module RuboCop
         #
         class EmptyResourceGuard < Base
           MSG = 'Resource guards (not_if/only_if) should not be empty strings as empty strings will always evaluate to true.'
+          EMPTY_BLOCK_MSG = 'Resource guards (not_if/only_if) should not be empty blocks as an empty block returns nil, which always evaluates to false.'
           RESTRICT_ON_SEND = [:not_if, :only_if].freeze
 
           def_node_matcher :empty_string_guard?, <<-PATTERN
@@ -80,6 +86,12 @@ module RuboCop
 
           def_node_matcher :empty_string_block_guard?, <<-PATTERN
             (block (send nil? {:not_if :only_if}) (args) (str #empty_string?))
+          PATTERN
+
+          # A block with no body at all. Such a block returns nil rather than the empty string matched
+          # above, so the guard fails rather than passes.
+          def_node_matcher :empty_block_guard?, <<-PATTERN
+            (block (send nil? {:not_if :only_if}) (args) nil?)
           PATTERN
 
           def empty_string?(str)
@@ -95,6 +107,10 @@ module RuboCop
           def on_block(node)
             empty_string_block_guard?(node) do
               add_offense(node, severity: :refactor)
+            end
+
+            empty_block_guard?(node) do
+              add_offense(node, message: EMPTY_BLOCK_MSG, severity: :refactor)
             end
           end
         end

--- a/spec/rubocop/cop/chef/correctness/empty_resource_guard_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/empty_resource_guard_spec.rb
@@ -98,4 +98,31 @@ describe RuboCop::Cop::Chef::Correctness::EmptyResourceGuard, :config do
       end
     RUBY
   end
+
+  it 'registers an offense when only_if is an empty block' do
+    expect_offense(<<~RUBY)
+      execute 'foo' do
+        only_if { }
+        ^^^^^^^^^^^ Resource guards (not_if/only_if) should not be empty blocks as an empty block returns nil, which always evaluates to false.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when not_if is an empty multi-line block' do
+    expect_offense(<<~RUBY)
+      execute 'foo' do
+        not_if do
+        ^^^^^^^^^ Resource guards (not_if/only_if) should not be empty blocks as an empty block returns nil, which always evaluates to false.
+        end
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the guard block has a body" do
+    expect_no_offenses(<<~RUBY)
+      execute 'foo' do
+        only_if { ::File.exist?('/etc/foo') }
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
`Chef/Correctness/EmptyResourceGuard` catches an empty string guard and an empty string *inside* a block, but not a genuinely empty block:

```ruby
only_if ''       # caught
only_if { '' }   # caught
only_if { }      # missed
```

## Why it belongs in this cop

The behaviour is the mirror image of the empty-string case the cop already documents in its own docstring:

| Guard | Result |
| --- | --- |
| `only_if ''` | empty string is truthy → resource **always** runs |
| `not_if ''` | → resource **never** runs |
| `only_if { }` | empty block returns `nil` → resource **never** runs |
| `not_if { }` | → resource **always** runs |

Same mistake, same cop, inverted consequence. Because the consequence is inverted, the empty block gets its own message rather than reusing the empty-string one, which would tell the user the opposite of what actually happens:

> Resource guards (not_if/only_if) should not be empty blocks as an empty block returns nil, which always evaluates to false.

Both the single-line `only_if { }` and the multi-line `not_if do ... end` forms are matched, since both parse to a block with a `nil` body.

No autocorrect — as with the existing empty-string case, there's no way to know what the guard was meant to test.

## Verification

- `bundle exec rspec` — 970 examples, 0 failures (3 new: single-line, multi-line, and a non-empty block that must stay clean)
- `bundle exec cookstyle` — no offenses in the changed files
- `bundle exec rake validate_config` — unchanged from `main`

Cop description and docs asset updated to cover both cases. `VersionChanged` set to `8.8.0`.