### PR TITLE
Add Chef/Correctness/InvalidChecksum cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -424,6 +424,16 @@ Chef/Correctness/RubyGuardWithoutBlock:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+Chef/Correctness/InvalidChecksum:
+  Description: "The `checksum` property of the file downloading resources takes a SHA-256 digest. An MD5 or SHA-1 digest can never match, so the run fails with a checksum mismatch rather than installing anything."
+  StyleGuide: 'chef_correctness_invalidchecksum'
+  Enabled: true
+  VersionAdded: '9.0.0'
+  Exclude:
+    - '**/attributes/*.rb'
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 Chef/Correctness/PlatformVersionStringComparison:
   Description: "Ohai version attributes are strings, so comparing one with an ordering operator compares them character by character rather than as versions. `'7.9' >= '10'` is true. Use `.to_i` for a major version comparison, or `Gem::Version` to compare full versions."
   StyleGuide: 'chef_correctness_platformversionstringcomparison'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidchecksum.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidchecksum.yml
@@ -1,0 +1,32 @@
+---
+short_name: InvalidChecksum
+full_name: Chef/Correctness/InvalidChecksum
+department: Chef/Correctness
+description: |-
+  The `checksum` property of the file downloading resources is a SHA-256 digest. An MD5 or
+  SHA-1 digest can never match, so the resource fails the run with a checksum mismatch rather
+  than installing anything.
+
+  Only digests that are unambiguously the wrong algorithm are flagged: 32 character (MD5) and
+  40 character (SHA-1) hex strings. Anything else is left alone.
+autocorrection: false
+target_chef_version: All Versions
+examples: |2-
+
+  # bad
+  remote_file '/tmp/foo.tar.gz' do
+    source 'https://example.com/foo.tar.gz'
+    checksum 'd41d8cd98f00b204e9800998ecf8427e'
+  end
+
+  # good
+  remote_file '/tmp/foo.tar.gz' do
+    source 'https://example.com/foo.tar.gz'
+    checksum 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+  end
+version_added: 9.0.0
+enabled: true
+excluded_file_paths:
+- "**/attributes/*.rb"
+- "**/metadata.rb"
+- "**/Berksfile"

--- a/lib/rubocop/cop/chef/correctness/invalid_checksum.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_checksum.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Correctness
+        # The `checksum` property of the file downloading resources is a SHA-256 digest. An MD5 or
+        # SHA-1 digest can never match, so the resource fails the run with a checksum mismatch rather
+        # than installing anything.
+        #
+        # Only digests that are unambiguously the wrong algorithm are flagged: 32 character (MD5) and
+        # 40 character (SHA-1) hex strings. Anything else is left alone.
+        #
+        # @example
+        #
+        #   # bad
+        #   remote_file '/tmp/foo.tar.gz' do
+        #     source 'https://example.com/foo.tar.gz'
+        #     checksum 'd41d8cd98f00b204e9800998ecf8427e'
+        #   end
+        #
+        #   # good
+        #   remote_file '/tmp/foo.tar.gz' do
+        #     source 'https://example.com/foo.tar.gz'
+        #     checksum 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+        #   end
+        #
+        class InvalidChecksum < Base
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'The checksum property takes a SHA-256 digest. An MD5 or SHA-1 digest can never match, so the run fails with a checksum mismatch.'
+
+          # the file downloading resources that validate a SHA-256 checksum
+          RESOURCES = %i(remote_file windows_package msu_package dmg_package).freeze
+
+          # hex digest lengths of the algorithms people reach for by mistake, with the article that
+          # reads correctly in front of each name
+          WRONG_ALGORITHM_LENGTHS = { 32 => 'an MD5', 40 => 'a SHA-1' }.freeze
+
+          def on_block(node)
+            match_property_in_resource?(RESOURCES, 'checksum', node) do |checksum|
+              value = checksum.arguments.first
+              next unless value&.str_type?
+
+              algorithm = WRONG_ALGORITHM_LENGTHS[value.value.length]
+              next unless algorithm && hex?(value.value)
+
+              add_offense(checksum, message: "#{MSG} This looks like #{algorithm} digest.", severity: :refactor)
+            end
+          end
+
+          private
+
+          # @param [String] string
+          #
+          # @return [Boolean]
+          def hex?(string)
+            string.match?(/\A\h+\z/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/invalid_checksum_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/invalid_checksum_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Correctness::InvalidChecksum, :config do
+  it 'registers an offense when remote_file is given an MD5 digest' do
+    expect_offense(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        source 'https://example.com/foo.tar.gz'
+        checksum 'd41d8cd98f00b204e9800998ecf8427e'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The checksum property takes a SHA-256 digest. An MD5 or SHA-1 digest can never match, so the run fails with a checksum mismatch. This looks like an MD5 digest.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when remote_file is given a SHA-1 digest' do
+    expect_offense(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        checksum 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The checksum property takes a SHA-256 digest. An MD5 or SHA-1 digest can never match, so the run fails with a checksum mismatch. This looks like a SHA-1 digest.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when windows_package is given an MD5 digest' do
+    expect_offense(<<~RUBY)
+      windows_package 'Foo' do
+        source 'https://example.com/foo.msi'
+        checksum 'd41d8cd98f00b204e9800998ecf8427e'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The checksum property takes a SHA-256 digest. An MD5 or SHA-1 digest can never match, so the run fails with a checksum mismatch. This looks like an MD5 digest.
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for a SHA-256 digest" do
+    expect_no_offenses(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        source 'https://example.com/foo.tar.gz'
+        checksum 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the checksum is not a hex string" do
+    expect_no_offenses(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        checksum 'this-is-not-a-digest-but-is-32-ch'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the checksum comes from a node attribute" do
+    expect_no_offenses(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        checksum node['foo']['checksum']
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense on a resource without a checksum property" do
+    expect_no_offenses(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        source 'https://example.com/foo.tar.gz'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense on an unrelated resource with a checksum property" do
+    expect_no_offenses(<<~RUBY)
+      my_custom_resource 'foo' do
+        checksum 'd41d8cd98f00b204e9800998ecf8427e'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when msu_package is given an MD5 digest' do
+    expect_offense(<<~RUBY)
+      msu_package 'Windows Update' do
+        source 'https://example.com/foo.msu'
+        checksum 'd41d8cd98f00b204e9800998ecf8427e'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The checksum property takes a SHA-256 digest. An MD5 or SHA-1 digest can never match, so the run fails with a checksum mismatch. This looks like an MD5 digest.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when dmg_package is given a SHA-1 digest' do
+    expect_offense(<<~RUBY)
+      dmg_package 'Foo' do
+        source 'https://example.com/foo.dmg'
+        checksum 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The checksum property takes a SHA-256 digest. An MD5 or SHA-1 digest can never match, so the run fails with a checksum mismatch. This looks like a SHA-1 digest.
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
```ruby
# bad
remote_file '/tmp/foo.tar.gz' do
  source 'https://example.com/foo.tar.gz'
  checksum 'd41d8cd98f00b204e9800998ecf8427e'
end

# good
remote_file '/tmp/foo.tar.gz' do
  source 'https://example.com/foo.tar.gz'
  checksum 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
end
```

The `checksum` property on the file downloading resources is a **SHA-256** digest. An MD5 or SHA-1 digest can never match it, so the run fails with a checksum mismatch rather than installing anything. It's an easy mistake because plenty of upstream projects still publish MD5 sums next to their downloads.

## Kept deliberately narrow

Only digests that are *unambiguously* the wrong algorithm are flagged — hex strings of exactly 32 characters (MD5) or 40 (SHA-1). The message names which one it looks like:

> The checksum property takes a SHA-256 digest. An MD5 or SHA-1 digest can never match, so the run fails with a checksum mismatch. This looks like a MD5 digest.

Left alone:

| Checksum | Why |
| --- | --- |
| a 64-char SHA-256 | correct |
| `node['foo']['checksum']` | not a literal, can't be checked |
| a 32-char string that isn't hex | not a digest at all |
| any other length | not confidently identifiable |

Scoped to `remote_file`, `windows_package`, `msu_package`, and `dmg_package`, so a custom resource with a `checksum` property of its own isn't caught — there's a test pinning that.

No autocorrect: the right digest can't be derived from the wrong one.

## Verification

- `bundle exec rspec` — 975 examples, 0 failures (8 new)
- `bundle exec rake validate_config` — cop registered; the 5 remaining `Chef/Ruby/*` errors are pre-existing on `main`
- `bundle exec cookstyle` — no offenses in the new files

`VersionAdded` set to `8.8.0`.