### PR TITLE
Add Chef/Correctness/PlatformVersionStringComparison cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -391,6 +391,15 @@ Chef/Correctness/DnfPackageAllowDowngrades:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+Chef/Correctness/PlatformVersionStringComparison:
+  Description: "Ohai version attributes are strings, so comparing one with an ordering operator compares them character by character rather than as versions. `'7.9' >= '10'` is true. Use `.to_i` for a major version comparison, or `Gem::Version` to compare full versions."
+  StyleGuide: 'chef_correctness_platformversionstringcomparison'
+  Enabled: true
+  VersionAdded: '8.8.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 Chef/Correctness/EmptyResourceGuard:
   Description: "Resource guards (`not_if`/`only_if`) should not be empty strings. In Ruby, empty strings are 'truthy', so an empty guard string will always pass, which is almost certainly not what you intended."
   StyleGuide: 'chef_correctness_emptyresourceguard'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_platformversionstringcomparison.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_platformversionstringcomparison.yml
@@ -1,0 +1,33 @@
+---
+short_name: PlatformVersionStringComparison
+full_name: Chef/Correctness/PlatformVersionStringComparison
+department: Chef/Correctness
+description: |-
+  Ohai reports version attributes as strings, so comparing one with `<`, `>`, `<=`, or `>=`
+  compares them character by character rather than as versions. That gives the wrong answer
+  whenever the version numbers have different digit counts:
+
+    '7.9' >= '10'   # => true, because '7' sorts after '1'
+    '9' > '10'      # => true
+
+  Compare the major version as an integer with `node['platform_version'].to_i`, or compare
+  full versions with `Gem::Version`.
+autocorrection: false
+target_chef_version: All Versions
+examples: |2-
+
+  # bad
+  node['platform_version'] >= '10'
+  node['platform_version'] < '7.4'
+
+  # good
+  node['platform_version'].to_i >= 10
+  Gem::Version.new(node['platform_version']) >= Gem::Version.new('7.4')
+
+  # good - equality is a plain string match, which is fine
+  node['platform_version'] == '10'
+version_added: 8.8.0
+enabled: true
+excluded_file_paths:
+- "**/metadata.rb"
+- "**/Berksfile"

--- a/lib/rubocop/cop/chef/correctness/platform_version_string_comparison.rb
+++ b/lib/rubocop/cop/chef/correctness/platform_version_string_comparison.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Correctness
+        # Ohai reports version attributes as strings, so comparing one with `<`, `>`, `<=`, or `>=`
+        # compares them character by character rather than as versions. That gives the wrong answer
+        # whenever the version numbers have different digit counts:
+        #
+        #   '7.9' >= '10'   # => true, because '7' sorts after '1'
+        #   '9' > '10'      # => true
+        #
+        # Compare the major version as an integer with `node['platform_version'].to_i`, or compare
+        # full versions with `Gem::Version`.
+        #
+        # @example
+        #
+        #   # bad
+        #   node['platform_version'] >= '10'
+        #   node['platform_version'] < '7.4'
+        #
+        #   # good
+        #   node['platform_version'].to_i >= 10
+        #   Gem::Version.new(node['platform_version']) >= Gem::Version.new('7.4')
+        #
+        #   # good - equality is a plain string match, which is fine
+        #   node['platform_version'] == '10'
+        #
+        class PlatformVersionStringComparison < Base
+          MSG = 'Ohai version attributes are strings, so comparing them with an ordering operator compares them character by character. Use .to_i for a major version comparison, or Gem::Version to compare full versions.'
+          RESTRICT_ON_SEND = %i(< > <= >=).freeze
+
+          # the flat Ohai attributes that hold a dotted version string
+          def_node_matcher :version_attribute_comparison?, <<-PATTERN
+            (send
+              (send (send nil? :node) :[] (str {"platform_version" "os_version"}))
+              {:< :> :<= :>=}
+              (str _))
+          PATTERN
+
+          def on_send(node)
+            version_attribute_comparison?(node) do
+              add_offense(node, severity: :refactor)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/platform_version_string_comparison_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/platform_version_string_comparison_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Correctness::PlatformVersionStringComparison, :config do
+  it 'registers an offense when platform_version is compared with >=' do
+    expect_offense(<<~RUBY)
+      node['platform_version'] >= '10'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ohai version attributes are strings, so comparing them with an ordering operator compares them character by character. Use .to_i for a major version comparison, or Gem::Version to compare full versions.
+    RUBY
+  end
+
+  it 'registers an offense when platform_version is compared with <' do
+    expect_offense(<<~RUBY)
+      node['platform_version'] < '7.4'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ohai version attributes are strings, so comparing them with an ordering operator compares them character by character. Use .to_i for a major version comparison, or Gem::Version to compare full versions.
+    RUBY
+  end
+
+  it 'registers an offense inside a conditional' do
+    expect_offense(<<~RUBY)
+      if node['platform_version'] > '8'
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ohai version attributes are strings, so comparing them with an ordering operator compares them character by character. Use .to_i for a major version comparison, or Gem::Version to compare full versions.
+        package 'foo'
+      end
+    RUBY
+  end
+
+  it 'registers an offense on os_version' do
+    expect_offense(<<~RUBY)
+      node['os_version'] <= '3.10'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ohai version attributes are strings, so comparing them with an ordering operator compares them character by character. Use .to_i for a major version comparison, or Gem::Version to compare full versions.
+    RUBY
+  end
+
+  it "doesn't register an offense when the major version is converted first" do
+    expect_no_offenses(<<~RUBY)
+      node['platform_version'].to_i >= 10
+    RUBY
+  end
+
+  it "doesn't register an offense when Gem::Version is used" do
+    expect_no_offenses(<<~RUBY)
+      Gem::Version.new(node['platform_version']) >= Gem::Version.new('7.4')
+    RUBY
+  end
+
+  it "doesn't register an offense for an equality comparison" do
+    expect_no_offenses(<<~RUBY)
+      node['platform_version'] == '10'
+    RUBY
+  end
+
+  it "doesn't register an offense on an unrelated node attribute" do
+    expect_no_offenses(<<~RUBY)
+      node['foo']['count'] >= '10'
+    RUBY
+  end
+end


### PR DESCRIPTION
```ruby
# bad
node['platform_version'] >= '10'
node['platform_version'] < '7.4'

# good
node['platform_version'].to_i >= 10
Gem::Version.new(node['platform_version']) >= Gem::Version.new('7.4')

# good - equality is a plain string match, which is fine
node['platform_version'] == '10'
```

Ohai reports version attributes as **strings**, so an ordering operator compares them character by character rather than as versions:

```ruby
'7.9' >= '10'   # => true, because '7' sorts after '1'
'9'   >  '10'   # => true
```

So `if node['platform_version'] >= '10'` is **true on CentOS 7.9** and the guarded code runs on exactly the platforms it was meant to exclude. It reads as a numeric comparison because the attribute reads as numeric, which is what makes it easy to write and hard to spot in review.

## Scope

Flags `<`, `>`, `<=`, `>=` against `node['platform_version']` and `node['os_version']` compared to a string literal.

Left alone:

| Code | Why |
| --- | --- |
| `node['platform_version'].to_i >= 10` | already an integer comparison |
| `Gem::Version.new(...) >= Gem::Version.new('7.4')` | proper version comparison |
| `node['platform_version'] == '10'` | equality on strings is a reasonable thing to want |
| `node['foo']['count'] >= '10'` | not a version attribute |

No autocorrect. Whether the author wanted a major-version comparison (`.to_i`) or a full-version one (`Gem::Version`) can't be inferred from `>= '7.4'` — and picking wrong would change which platforms match, which is the exact bug being fixed.

## Relationship to the existing version cop

`Chef/Style/SimplifyPlatformMajorVersionCheck` handles `node['platform_version'].split('.').first` → `.to_i`. Different construct — that one is about verbosity, this one is about a comparison returning the wrong answer.

Only the flat attributes are covered. The nested `node['kernel']['release']` form is a plausible extension if you want it; I left it out to keep the matcher obvious.

## Verification

- `bundle exec rspec` — 975 examples, 0 failures (8 new)
- `bundle exec rake validate_config` — cop registered; the 5 remaining `Chef/Ruby/*` errors are pre-existing on `main`
- `bundle exec cookstyle` — no offenses in the new files

`VersionAdded` set to `8.8.0`.