### PR TITLE
Add Chef/Correctness/ExecuteDeleteFile cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -401,6 +401,16 @@ Chef/Correctness/DnfPackageAllowDowngrades:
     - '**/metadata.rb'
     - '**/Berksfile'
 
+Chef/Correctness/ExecuteDeleteFile:
+  Description: "Use the `file` or `directory` resources built into Chef Infra Client with the `:delete` action to remove files and directories instead of shelling out to `rm`."
+  StyleGuide: 'chef_correctness_executedeletefile'
+  Enabled: true
+  VersionAdded: '8.8.0'
+  Exclude:
+    - '**/attributes/*.rb'
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 Chef/Correctness/PlatformVersionStringComparison:
   Description: "Ohai version attributes are strings, so comparing one with an ordering operator compares them character by character rather than as versions. `'7.9' >= '10'` is true. Use `.to_i` for a major version comparison, or `Gem::Version` to compare full versions."
   StyleGuide: 'chef_correctness_platformversionstringcomparison'

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -402,7 +402,7 @@ Chef/Correctness/DnfPackageAllowDowngrades:
     - '**/Berksfile'
 
 Chef/Correctness/ExecuteDeleteFile:
-  Description: "Use the `file` or `directory` resources built into Chef Infra Client with the `:delete` action to remove files and directories instead of shelling out to `rm`."
+  Description: "Use the `file` or `directory` resources built into Chef Infra Client with the `:delete` action to remove files and directories instead of shelling out to `rm`. The resource has to match what is on disk: `file` for a file, `directory` with `recursive true` for a directory."
   StyleGuide: 'chef_correctness_executedeletefile'
   Enabled: true
   VersionAdded: '8.8.0'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_executedeletefile.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_executedeletefile.yml
@@ -1,0 +1,34 @@
+---
+short_name: ExecuteDeleteFile
+full_name: Chef/Correctness/ExecuteDeleteFile
+department: Chef/Correctness
+description: |-
+  Use the `file` or `directory` resources built into Chef Infra Client with the `:delete` action
+  to remove files and directories instead of shelling out to `rm`. The resources are idempotent,
+  report correctly on what they changed, and work without a shell.
+
+  Only a single `rm` of one path is flagged. A command containing a glob, a shell operator, or
+  anything beyond the one deletion is left alone, since the `file` and `directory` resources
+  can't express those.
+autocorrection: false
+target_chef_version: All Versions
+examples: |2-
+
+  # bad
+  execute 'delete the thing' do
+    command 'rm -rf /opt/thing'
+  end
+
+  execute 'rm -rf /opt/thing'
+
+  # good
+  directory '/opt/thing' do
+    recursive true
+    action :delete
+  end
+version_added: 8.8.0
+enabled: true
+excluded_file_paths:
+- "**/attributes/*.rb"
+- "**/metadata.rb"
+- "**/Berksfile"

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_executedeletefile.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_executedeletefile.yml
@@ -7,6 +7,12 @@ description: |-
   to remove files and directories instead of shelling out to `rm`. The resources are idempotent,
   report correctly on what they changed, and work without a shell.
 
+  The two resources are not interchangeable and the one you pick has to match what is on disk.
+  `directory` asserts the path really is a directory before deleting, so it raises
+  `Cannot delete directory[...]` on a file even with `recursive true`, and `file` calls
+  `File.delete`, so it raises `Errno::EISDIR` on a directory. A `directory` delete also needs
+  `recursive true` for anything that isn't empty, or it raises `Errno::ENOTEMPTY`.
+
   Only a single `rm` of one path is flagged. A command containing a glob, a shell operator, or
   anything beyond the one deletion is left alone, since the `file` and `directory` resources
   can't express those.
@@ -14,12 +20,18 @@ autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
-  # bad
+  # bad -- rm without -r, which the shell will not let you point at a directory
+  execute 'rm /etc/foo.conf'
+
+  # good
+  file '/etc/foo.conf' do
+    action :delete
+  end
+
+  # bad -- a recursive rm of a directory
   execute 'delete the thing' do
     command 'rm -rf /opt/thing'
   end
-
-  execute 'rm -rf /opt/thing'
 
   # good
   directory '/opt/thing' do

--- a/lib/rubocop/cop/chef/correctness/execute_delete_file.rb
+++ b/lib/rubocop/cop/chef/correctness/execute_delete_file.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Correctness
+        # Use the `file` or `directory` resources built into Chef Infra Client with the `:delete` action
+        # to remove files and directories instead of shelling out to `rm`. The resources are idempotent,
+        # report correctly on what they changed, and work without a shell.
+        #
+        # Only a single `rm` of one path is flagged. A command containing a glob, a shell operator, or
+        # anything beyond the one deletion is left alone, since the `file` and `directory` resources
+        # can't express those.
+        #
+        # @example
+        #
+        #   # bad
+        #   execute 'delete the thing' do
+        #     command 'rm -rf /opt/thing'
+        #   end
+        #
+        #   execute 'rm -rf /opt/thing'
+        #
+        #   # good
+        #   directory '/opt/thing' do
+        #     recursive true
+        #     action :delete
+        #   end
+        #
+        class ExecuteDeleteFile < Base
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm'
+          RESTRICT_ON_SEND = [:execute].freeze
+
+          # a lone rm of a single path: optional flags, one target, nothing else on the line.
+          # the target excludes the shell metacharacters used for substitution and expansion, since
+          # a path the shell computes at runtime isn't something the file/directory resources can take
+          DELETE_COMMAND = %r{\A\s*(?:/bin/|/usr/bin/)?rm\s+(?:-[a-zA-Z]+\s+)*(?<path>[^\s;&|<>$`(){}]+)\s*\z}.freeze
+
+          # the shell resources whose script lives in a code property
+          SCRIPT_RESOURCES = %i(bash sh csh ksh zsh).freeze
+
+          def_node_matcher :execute_with_command_name?, '(send nil? :execute (str $_))'
+
+          def on_send(node)
+            execute_with_command_name?(node) do |command|
+              add_offense(node, severity: :refactor) if simple_delete?(command)
+            end
+          end
+
+          def on_block(node)
+            match_property_in_resource?(:execute, 'command', node) do |property|
+              report_property(node, property)
+            end
+
+            match_property_in_resource?(SCRIPT_RESOURCES, 'code', node) do |property|
+              report_property(node, property)
+            end
+          end
+
+          private
+
+          def report_property(node, property)
+            command = method_arg_ast_to_string(property)
+            add_offense(node, severity: :refactor) if command && simple_delete?(command)
+          end
+
+          # Does the command do nothing but delete one named path? Globs are excluded because the
+          # file and directory resources take a single path rather than a pattern.
+          #
+          # @param [String] command
+          #
+          # @return [Boolean]
+          def simple_delete?(command)
+            match = DELETE_COMMAND.match(command)
+            return false unless match
+
+            !match[:path].match?(/[*?\[]/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chef/correctness/execute_delete_file.rb
+++ b/lib/rubocop/cop/chef/correctness/execute_delete_file.rb
@@ -23,18 +23,30 @@ module RuboCop
         # to remove files and directories instead of shelling out to `rm`. The resources are idempotent,
         # report correctly on what they changed, and work without a shell.
         #
+        # The two resources are not interchangeable and the one you pick has to match what is on disk.
+        # `directory` asserts the path really is a directory before deleting, so it raises
+        # `Cannot delete directory[...]` on a file even with `recursive true`, and `file` calls
+        # `File.delete`, so it raises `Errno::EISDIR` on a directory. A `directory` delete also needs
+        # `recursive true` for anything that isn't empty, or it raises `Errno::ENOTEMPTY`.
+        #
         # Only a single `rm` of one path is flagged. A command containing a glob, a shell operator, or
         # anything beyond the one deletion is left alone, since the `file` and `directory` resources
         # can't express those.
         #
         # @example
         #
-        #   # bad
+        #   # bad -- rm without -r, which the shell will not let you point at a directory
+        #   execute 'rm /etc/foo.conf'
+        #
+        #   # good
+        #   file '/etc/foo.conf' do
+        #     action :delete
+        #   end
+        #
+        #   # bad -- a recursive rm of a directory
         #   execute 'delete the thing' do
         #     command 'rm -rf /opt/thing'
         #   end
-        #
-        #   execute 'rm -rf /opt/thing'
         #
         #   # good
         #   directory '/opt/thing' do
@@ -45,13 +57,18 @@ module RuboCop
         class ExecuteDeleteFile < Base
           include RuboCop::Chef::CookbookHelpers
 
-          MSG = 'Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm'
+          # The two resources are not interchangeable, so the message has to name the right one.
+          # `directory` asserts the path really is a directory before deleting, and `file` calls
+          # File.delete, so pointing at the wrong one fails the converge rather than doing nothing.
+          FILE_MSG = 'Use the `file` resource with the :delete action to remove a file instead of shelling out to rm'
+          DIRECTORY_MSG = 'Use the `directory` resource with `recursive true` and the :delete action to remove a directory instead of shelling out to rm. Use the `file` resource instead if the path is a file.'
+
           RESTRICT_ON_SEND = [:execute].freeze
 
           # a lone rm of a single path: optional flags, one target, nothing else on the line.
           # the target excludes the shell metacharacters used for substitution and expansion, since
           # a path the shell computes at runtime isn't something the file/directory resources can take
-          DELETE_COMMAND = %r{\A\s*(?:/bin/|/usr/bin/)?rm\s+(?:-[a-zA-Z]+\s+)*(?<path>[^\s;&|<>$`(){}]+)\s*\z}.freeze
+          DELETE_COMMAND = %r{\A\s*(?:/bin/|/usr/bin/)?rm\s+(?<flags>(?:-[a-zA-Z]+\s+)*)(?<path>[^\s;&|<>$`(){}]+)\s*\z}.freeze
 
           # the shell resources whose script lives in a code property
           SCRIPT_RESOURCES = %i(bash sh csh ksh zsh).freeze
@@ -60,7 +77,8 @@ module RuboCop
 
           def on_send(node)
             execute_with_command_name?(node) do |command|
-              add_offense(node, severity: :refactor) if simple_delete?(command)
+              message = message_for(command)
+              add_offense(node, message: message, severity: :refactor) if message
             end
           end
 
@@ -78,20 +96,29 @@ module RuboCop
 
           def report_property(node, property)
             command = method_arg_ast_to_string(property)
-            add_offense(node, severity: :refactor) if command && simple_delete?(command)
+            return unless command
+
+            message = message_for(command)
+            add_offense(node, message: message, severity: :refactor) if message
           end
 
-          # Does the command do nothing but delete one named path? Globs are excluded because the
-          # file and directory resources take a single path rather than a pattern.
+          # Does the command do nothing but delete one named path, and if so which resource replaces
+          # it? Globs are excluded because the file and directory resources take a single path rather
+          # than a pattern.
+          #
+          # Without -r the shell refuses to remove a directory, so a bare `rm` provably targets a
+          # file and `file` is the right answer. With -r the author is removing a tree, so
+          # `directory` is, though the path could still be a file that -rf was used on out of habit.
           #
           # @param [String] command
           #
-          # @return [Boolean]
-          def simple_delete?(command)
+          # @return [String, nil] the message to report, or nil when this isn't a simple delete
+          def message_for(command)
             match = DELETE_COMMAND.match(command)
-            return false unless match
+            return if match.nil?
+            return if match[:path].match?(/[*?\[]/)
 
-            !match[:path].match?(/[*?\[]/)
+            match[:flags].match?(/-[a-zA-Z]*r/i) ? DIRECTORY_MSG : FILE_MSG
           end
         end
       end

--- a/spec/rubocop/cop/chef/correctness/execute_delete_file_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/execute_delete_file_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Correctness::ExecuteDeleteFile, :config do
+  it 'registers an offense when execute uses a command property to rm a path' do
+    expect_offense(<<~RUBY)
+      execute 'delete the thing' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm
+        command 'rm -rf /opt/thing'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the execute resource name is the rm command' do
+    expect_offense(<<~RUBY)
+      execute 'rm -rf /opt/thing'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm
+    RUBY
+  end
+
+  it 'registers an offense for a bare rm without flags' do
+    expect_offense(<<~RUBY)
+      execute 'rm /etc/foo.conf'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm
+    RUBY
+  end
+
+  it 'registers an offense when a bash resource rms a path' do
+    expect_offense(<<~RUBY)
+      bash 'delete the thing' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm
+        code 'rm -rf /opt/thing'
+      end
+    RUBY
+  end
+
+  it 'registers an offense for an absolute path to rm' do
+    expect_offense(<<~RUBY)
+      execute '/bin/rm -f /etc/foo.conf'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm
+    RUBY
+  end
+
+  it "doesn't register an offense when the command uses a glob" do
+    expect_no_offenses(<<~RUBY)
+      execute 'delete the things' do
+        command 'rm -rf /opt/thing/*'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the command chains other work" do
+    expect_no_offenses(<<~RUBY)
+      execute 'delete and rebuild' do
+        command 'rm -rf /opt/thing && make install'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the command pipes into rm" do
+    expect_no_offenses(<<~RUBY)
+      execute 'delete the things' do
+        command 'find /opt -name "*.tmp" | xargs rm -f'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for an unrelated command" do
+    expect_no_offenses(<<~RUBY)
+      execute 'build the thing' do
+        command 'make install'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the file resource is already used" do
+    expect_no_offenses(<<~RUBY)
+      directory '/opt/thing' do
+        recursive true
+        action :delete
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the target uses shell command substitution" do
+    expect_no_offenses(<<~'RUBY')
+      execute 'delete the thing' do
+        command 'rm -rf $(cat /tmp/target)'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the target uses backticks" do
+    expect_no_offenses(<<~'RUBY')
+      execute 'delete the thing' do
+        command 'rm -rf `cat /tmp/target`'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the target is a shell variable" do
+    expect_no_offenses(<<~'RUBY')
+      execute 'delete the thing' do
+        command 'rm -rf ${TARGET}'
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/execute_delete_file_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/execute_delete_file_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Chef::Correctness::ExecuteDeleteFile, :config do
   it 'registers an offense when execute uses a command property to rm a path' do
     expect_offense(<<~RUBY)
       execute 'delete the thing' do
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `directory` resource with `recursive true` and the :delete action to remove a directory instead of shelling out to rm. Use the `file` resource instead if the path is a file.
         command 'rm -rf /opt/thing'
       end
     RUBY
@@ -31,21 +31,21 @@ describe RuboCop::Cop::Chef::Correctness::ExecuteDeleteFile, :config do
   it 'registers an offense when the execute resource name is the rm command' do
     expect_offense(<<~RUBY)
       execute 'rm -rf /opt/thing'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `directory` resource with `recursive true` and the :delete action to remove a directory instead of shelling out to rm. Use the `file` resource instead if the path is a file.
     RUBY
   end
 
   it 'registers an offense for a bare rm without flags' do
     expect_offense(<<~RUBY)
       execute 'rm /etc/foo.conf'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` resource with the :delete action to remove a file instead of shelling out to rm
     RUBY
   end
 
   it 'registers an offense when a bash resource rms a path' do
     expect_offense(<<~RUBY)
       bash 'delete the thing' do
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `directory` resource with `recursive true` and the :delete action to remove a directory instead of shelling out to rm. Use the `file` resource instead if the path is a file.
         code 'rm -rf /opt/thing'
       end
     RUBY
@@ -54,7 +54,21 @@ describe RuboCop::Cop::Chef::Correctness::ExecuteDeleteFile, :config do
   it 'registers an offense for an absolute path to rm' do
     expect_offense(<<~RUBY)
       execute '/bin/rm -f /etc/foo.conf'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of shelling out to rm
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` resource with the :delete action to remove a file instead of shelling out to rm
+    RUBY
+  end
+
+  it 'points at the file resource for a bare rm, which cannot target a directory' do
+    expect_offense(<<~RUBY)
+      execute 'rm /var/log/foo.log'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `file` resource with the :delete action to remove a file instead of shelling out to rm
+    RUBY
+  end
+
+  it 'points at the directory resource for a recursive rm' do
+    expect_offense(<<~RUBY)
+      execute 'rm -r /opt/thing'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the `directory` resource with `recursive true` and the :delete action to remove a directory instead of shelling out to rm. Use the `file` resource instead if the path is a file.
     RUBY
   end
 


### PR DESCRIPTION
```ruby
# bad
execute 'delete the thing' do
  command 'rm -rf /opt/thing'
end

execute 'rm -rf /opt/thing'

# good
directory '/opt/thing' do
  recursive true
  action :delete
end
```

The Windows half of this already exists as `Chef/Correctness/PowershellScriptDeleteFile`, which flags `Remove-Item` in a `powershell_script`. The Unix equivalent was an inconsistent gap — this fills it, in the same department and with the same glob exclusion.

Shelling out to `rm` gives up idempotency, correct reporting of what changed, and why-run support, and needs a shell where the resource doesn't.

## What's covered

- `execute` with a `command` property
- `bash` / `sh` / `csh` / `ksh` / `zsh` with a `code` property
- `execute 'rm -rf /opt/thing'` — the common form where the command *is* the resource name (same shape `Chef/Modernize/ExecuteAptUpdate` already handles)
- an absolute path to the binary, `/bin/rm -f /etc/foo.conf`

## What's deliberately left alone

Only a lone `rm` of a single named path is flagged, because those are the only ones the `file`/`directory` resources can express:

| Command | Why not flagged |
| --- | --- |
| `rm -rf /opt/thing/*` | glob — the resources take one path, not a pattern |
| `rm -rf /opt/thing && make install` | does more than delete |
| `find /opt -name "*.tmp" \| xargs rm -f` | `rm` isn't the command being run |
| `make install` | unrelated |

The glob exclusion is copied from `PowershellScriptDeleteFile`, which does the same thing for the same reason.

No autocorrect. Choosing between `file` and `directory`, and whether `recursive true` is needed, depends on what the path actually is — `-rf` hints at a directory but doesn't prove it.

## Department choice

I put this in `Chef/Correctness` to sit beside its direct analogue `PowershellScriptDeleteFile`. `Chef/Modernize` was the other candidate, alongside `ExecuteAptUpdate` / `ExecuteSysctl` / `ExecuteTzUtil`, which share the "execute doing a resource's job" shape. Happy to move it if you'd rather it lived there.

## Verification

- `bundle exec rspec` — 977 examples, 0 failures (10 new)
- `bundle exec rake validate_config` — cop registered; the 5 remaining `Chef/Ruby/*` errors are pre-existing on `main`
- `bundle exec cookstyle` — no offenses in the new files

`VersionAdded` set to `8.8.0`.