### PR TITLE
Add Chef/Modernize/PowershellDownloadFile cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1522,6 +1522,16 @@ Chef/Modernize/PowershellScriptExpandArchive:
   Exclude:
     - '**/metadata.rb'
 
+Chef/Modernize/PowershellDownloadFile:
+  Description: "Use the `remote_file` resource to download files instead of shelling out to PowerShell. `remote_file` is idempotent and supports checksum verification, proxies, and conditional downloads."
+  StyleGuide: 'chef_modernize_powershelldownloadfile'
+  Enabled: true
+  VersionAdded: '8.8.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 Chef/Modernize/PowershellInstallPackage:
   Description: Use the package resource built into Chef Infra Client instead of using Install-Package in a powershell_script resource
   StyleGuide: 'chef_modernize_powershellinstallpackage'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershelldownloadfile.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershelldownloadfile.yml
@@ -1,0 +1,27 @@
+---
+short_name: PowershellDownloadFile
+full_name: Chef/Modernize/PowershellDownloadFile
+department: Chef/Modernize
+description: |-
+  Use the `remote_file` resource to download files instead of shelling out to PowerShell.
+  `remote_file` is idempotent, supports checksum verification, proxies, and conditional
+  downloads with etags and last-modified headers, none of which a script gets for free.
+autocorrection: false
+target_chef_version: All Versions
+examples: |2-
+
+  # bad
+  powershell_script 'download the installer' do
+    code 'Invoke-WebRequest -Uri https://example.com/foo.msi -OutFile C:\foo.msi'
+  end
+
+  # good
+  remote_file 'C:\foo.msi' do
+    source 'https://example.com/foo.msi'
+  end
+version_added: 8.8.0
+enabled: true
+excluded_file_paths:
+- "**/metadata.rb"
+- "**/attributes/*.rb"
+- "**/Berksfile"

--- a/lib/rubocop/cop/chef/modernize/powershell_download_file.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_download_file.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Modernize
+        # Use the `remote_file` resource to download files instead of shelling out to PowerShell.
+        # `remote_file` is idempotent, supports checksum verification, proxies, and conditional
+        # downloads with etags and last-modified headers, none of which a script gets for free.
+        #
+        # @example
+        #
+        #   # bad
+        #   powershell_script 'download the installer' do
+        #     code 'Invoke-WebRequest -Uri https://example.com/foo.msi -OutFile C:\foo.msi'
+        #   end
+        #
+        #   # good
+        #   remote_file 'C:\foo.msi' do
+        #     source 'https://example.com/foo.msi'
+        #   end
+        #
+        class PowershellDownloadFile < Base
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'Use the remote_file resource to download files instead of downloading them in a PowerShell script resource'
+
+          # the PowerShell ways of pulling a file down over HTTP
+          DOWNLOAD_COMMANDS = Regexp.union(
+            /invoke-webrequest\s/i,
+            /\bstart-bitstransfer\s/i,
+            /\bwget\s/i,        # PowerShell alias for Invoke-WebRequest
+            /\bcurl\s/i,        # PowerShell alias for Invoke-WebRequest
+            /system\.net\.webclient/i
+          ).freeze
+
+          def on_block(node)
+            match_property_in_resource?(%i(powershell_script pwsh_script), 'code', node) do |code_property|
+              property_data = method_arg_ast_to_string(code_property)
+              next unless property_data&.match?(DOWNLOAD_COMMANDS)
+
+              add_offense(node, severity: :refactor)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/powershell_download_file_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/powershell_download_file_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Modernize::PowershellDownloadFile, :config do
+  it 'registers an offense when a powershell_script uses Invoke-WebRequest' do
+    expect_offense(<<~RUBY)
+      powershell_script 'download the installer' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the remote_file resource to download files instead of downloading them in a PowerShell script resource
+        code 'Invoke-WebRequest -Uri https://example.com/foo.msi -OutFile C:/foo.msi'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a powershell_script uses Start-BitsTransfer' do
+    expect_offense(<<~RUBY)
+      powershell_script 'download the installer' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the remote_file resource to download files instead of downloading them in a PowerShell script resource
+        code 'Start-BitsTransfer -Source https://example.com/foo.msi -Destination C:/foo.msi'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a powershell_script uses System.Net.WebClient' do
+    expect_offense(<<~RUBY)
+      powershell_script 'download the installer' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the remote_file resource to download files instead of downloading them in a PowerShell script resource
+        code '(New-Object System.Net.WebClient).DownloadFile("https://example.com/foo.msi", "C:/foo.msi")'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a pwsh_script downloads a file' do
+    expect_offense(<<~RUBY)
+      pwsh_script 'download the installer' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the remote_file resource to download files instead of downloading them in a PowerShell script resource
+        code 'Invoke-WebRequest -Uri https://example.com/foo.msi -OutFile C:/foo.msi'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for an unrelated powershell_script" do
+    expect_no_offenses(<<~RUBY)
+      powershell_script 'set a thing' do
+        code 'Set-ItemProperty -Path HKLM:/Foo -Name Bar -Value 1'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when remote_file is already used" do
+    expect_no_offenses(<<~RUBY)
+      remote_file 'C:/foo.msi' do
+        source 'https://example.com/foo.msi'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for a script that queries rather than downloads" do
+    expect_no_offenses(<<~RUBY)
+      powershell_script 'check a thing' do
+        code 'Get-Service -Name foo'
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
```ruby
# bad
powershell_script 'download the installer' do
  code 'Invoke-WebRequest -Uri https://example.com/foo.msi -OutFile C:\foo.msi'
end

# good
remote_file 'C:\foo.msi' do
  source 'https://example.com/foo.msi'
end
```

`remote_file` is idempotent and brings checksum verification, proxy support, and conditional downloads via etag and last-modified headers. A PowerShell script gets none of that for free — it re-downloads on every run and reports the resource as updated every time.

This joins the family of cops already covering `powershell_script` doing a built-in resource's job: `PowershellExpandArchive`, `PowershellInstallPackage`, `PowershellInstallWindowsFeature`, and `ShellOutToChocolatey`. Downloading was the obvious remaining member.

## Detection

Matches the ways PowerShell pulls a file over HTTP:

| Command | Note |
| --- | --- |
| `Invoke-WebRequest` | the common one |
| `wget` / `curl` | PowerShell aliases for `Invoke-WebRequest`, not the Unix tools |
| `Start-BitsTransfer` | the BITS route |
| `System.Net.WebClient` | the `.DownloadFile` .NET route |

Applies to both `powershell_script` and `pwsh_script`.

No autocorrect. The mapping from a script to `remote_file` needs the source URL and destination path pulled out of arbitrary PowerShell argument syntax, which differs per command and often involves variables — too easy to get wrong silently.

## Verification

- `bundle exec rspec` — 974 examples, 0 failures (7 new)
- `bundle exec rake validate_config` — cop registered; the 5 remaining `Chef/Ruby/*` errors are pre-existing on `main`
- `bundle exec cookstyle` — no offenses in the new files
- Checked end-to-end against a real cookbook file

`VersionAdded` set to `8.8.0`.