### PR TITLE
Fix and widen Chef/Correctness/ServiceResource

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -188,10 +188,11 @@ Chef/Correctness:
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
 Chef/Correctness/ServiceResource:
-  Description: Use the `service` resource to start and stop services instead of shelling out with `execute` or `bash` resources. The `service` resource is idempotent and handles platform differences automatically.
+  Description: Use the `service` resource to manage services instead of shelling out to an init script, `service`, `systemctl`, or a similar tool. The `service` resource is idempotent and handles platform differences automatically.
   StyleGuide: 'chef_correctness_serviceresource'
   Enabled: true
   VersionAdded: '5.0.0'
+  VersionChanged: '8.8.0'
   Exclude:
     - '**/attributes/*.rb'
     - '**/metadata.rb'

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_serviceresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_serviceresource.yml
@@ -2,22 +2,25 @@
 short_name: ServiceResource
 full_name: Chef/Correctness/ServiceResource
 department: Chef/Correctness
-description: Use a service resource to start and stop services
+description: |-
+  Use the `service` resource to manage services instead of shelling out. The resource is
+  idempotent, picks the right init system for the platform, and reports correctly on what it
+  changed. A shelled out command runs on every converge whether or not anything needed to
+  change, so the run reports the resource as updated every time.
 autocorrection: false
 target_chef_version: All Versions
 examples: |2-
 
   # bad
-  command "/etc/init.d/mysql start"
-  command "/sbin/service/memcached start"
-
-  # good
-  service 'mysql' do
-    action :start
+  execute 'restart apache' do
+    command 'systemctl restart httpd'
   end
 
-  service 'memcached' do
-    action :start
+  execute '/etc/init.d/httpd start'
+
+  # good
+  service 'httpd' do
+    action :restart
   end
 version_added: 5.0.0
 enabled: true

--- a/lib/rubocop/cop/chef/correctness/service_resource.rb
+++ b/lib/rubocop/cop/chef/correctness/service_resource.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 #
-# Copyright:: 2016, Chris Henry
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,45 +19,86 @@ module RuboCop
   module Cop
     module Chef
       module Correctness
-        # Use a service resource to start and stop services
+        # Use the `service` resource to manage services instead of shelling out. The resource is
+        # idempotent, picks the right init system for the platform, and reports correctly on what it
+        # changed. A shelled out command runs on every converge whether or not anything needed to
+        # change, so the run reports the resource as updated every time.
         #
-        # @example when command starts a service
+        # @example
         #
         #   # bad
-        #   command "/etc/init.d/mysql start"
-        #   command "/sbin/service/memcached start"
-        #
-        #   # good
-        #   service 'mysql' do
-        #     action :start
+        #   execute 'restart apache' do
+        #     command 'systemctl restart httpd'
         #   end
         #
-        #   service 'memcached' do
-        #     action :start
+        #   execute '/etc/init.d/httpd start'
+        #
+        #   # good
+        #   service 'httpd' do
+        #     action :restart
         #   end
         #
         class ServiceResource < Base
-          MSG = 'Use a service resource to start and stop services'
-          RESTRICT_ON_SEND = [:command].freeze
+          MSG = 'Use the service resource to manage services instead of shelling out to an init script, service, systemctl, or a similar tool'
+          RESTRICT_ON_SEND = %i(command code execute).freeze
 
-          def_node_matcher :execute_command?, <<-PATTERN
-            (send nil? :command $str)
-          PATTERN
+          # the state changing verbs. `status` is left out: a status check is usually a guard rather
+          # than something the service resource replaces
+          SERVICE_ACTIONS = %w(
+            start stop restart reload force-reload try-restart reload-or-restart
+            enable disable mask unmask
+          ).freeze
+
+          # commands whose service action is captured and checked against SERVICE_ACTIONS
+          ACTION_COMMANDS = [
+            %r{\A/(?:etc/init\.d|etc/rc\.d|usr/local/etc/rc\.d)/\S+\s+(\S+)}, # /etc/init.d/httpd start
+            %r{\A(?:/usr/sbin/|/sbin/)?service\s+\S+\s+(\S+)},                # service httpd start
+            %r{\A(?:/usr/bin/|/bin/)?systemctl\s+(?:--\S+\s+)*(\S+)\s+\S+},   # systemctl start httpd
+            /\Ainvoke-rc\.d\s+\S+\s+(\S+)/,                                   # invoke-rc.d httpd start
+            /\Ainitctl\s+(\S+)\s+\S+/,                                        # initctl start httpd
+            /\Asvcadm\s+(\S+)\s+\S+/,                                         # svcadm enable httpd
+          ].freeze
+
+          # commands that manage a service whatever the rest of the line says
+          DIRECT_COMMANDS = [
+            /\A(?:start|stop|restart)\s+\S+\z/,                               # upstart: start httpd
+            /\Alaunchctl\s+(?:load|unload|start|stop|enable|disable|bootstrap|bootout)\s/,
+            /\Achkconfig\s+(?:--\S+\s+)*\S+\s+(?:on|off)\z/,                  # chkconfig httpd on
+            /\Aupdate-rc\.d\s/,                                               # update-rc.d httpd defaults
+            /\A(?:sc|net)\s+(?:start|stop|config)\s+\S+/i,                    # windows: net start httpd
+          ].freeze
+
+          # a command doing more than the one service action can't be swapped for the resource
+          SHELL_OPERATORS = ['&&', '||', ';', '|', '`', '$('].freeze
+
+          def_node_matcher :command_property?, '(send nil? {:command :code} $str)'
+          def_node_matcher :execute_with_command_name?, '(send nil? :execute $str)'
 
           def on_send(node)
-            execute_command?(node) do |command|
-              if starts_service?(command)
-                add_offense(command, severity: :refactor)
-              end
+            command_property?(node) do |command|
+              add_offense(command, severity: :refactor) if manages_service?(command.value)
+            end
+
+            execute_with_command_name?(node) do |command|
+              add_offense(node, severity: :refactor) if manages_service?(command.value)
             end
           end
 
-          def starts_service?(cmd)
-            cmd_str = cmd.to_s
-            (cmd_str.include?('/etc/init.d') || ['service ', '/sbin/service ',
-                                                 'start ', 'stop ', 'invoke-rc.d '].any? do |service_cmd|
-               cmd_str.start_with?(service_cmd)
-             end) && %w(start stop restart reload).any? { |a| cmd_str.include?(a) }
+          private
+
+          # @param [String] command the literal command string
+          #
+          # @return [Boolean]
+          def manages_service?(command)
+            cmd = command.strip
+            return false if SHELL_OPERATORS.any? { |operator| cmd.include?(operator) }
+
+            ACTION_COMMANDS.each do |pattern|
+              match = pattern.match(cmd)
+              return true if match && SERVICE_ACTIONS.include?(match[1].downcase)
+            end
+
+            DIRECT_COMMANDS.any? { |pattern| cmd.match?(pattern) }
           end
         end
       end

--- a/spec/rubocop/cop/chef/correctness/service_resource_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/service_resource_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 #
 # Copyright:: 2016, Chris Henry
+# Author:: Tim Smith (<tsmith84@gmail.com>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +23,52 @@ describe RuboCop::Cop::Chef::Correctness::ServiceResource, :config do
     expect_offense(<<~RUBY)
       execute 'apache_start' do
         command '/etc/init.d/httpd start'
-                ^^^^^^^^^^^^^^^^^^^^^^^^^ Use a service resource to start and stop services
+                ^^^^^^^^^^^^^^^^^^^^^^^^^ Use the service resource to manage services instead of shelling out to an init script, service, systemctl, or a similar tool
+      end
+    RUBY
+  end
+
+  [
+    'service httpd start',
+    '/sbin/service httpd restart',
+    'systemctl restart httpd',
+    'systemctl enable httpd',
+    'systemctl --now enable httpd',
+    'invoke-rc.d httpd reload',
+    'initctl start httpd',
+    'svcadm enable httpd',
+    '/etc/rc.d/httpd start',
+    'chkconfig httpd on',
+    'update-rc.d httpd defaults',
+    'launchctl load /Library/LaunchDaemons/foo.plist',
+    'start httpd',
+    'stop httpd',
+    'net start httpd',
+    'sc stop httpd',
+  ].each do |command|
+    it "registers an offense for the command #{command}" do
+      carets = '^' * (command.length + 2) # the offense covers the quoted string
+      expect_offense(<<~RUBY)
+        execute 'manage the service' do
+          command '#{command}'
+                  #{carets} Use the service resource to manage services instead of shelling out to an init script, service, systemctl, or a similar tool
+        end
+      RUBY
+    end
+  end
+
+  it 'registers an offense when the execute resource name is the service command' do
+    expect_offense(<<~RUBY)
+      execute 'systemctl restart httpd'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the service resource to manage services instead of shelling out to an init script, service, systemctl, or a similar tool
+    RUBY
+  end
+
+  it 'registers an offense when a bash resource manages a service' do
+    expect_offense(<<~RUBY)
+      bash 'restart the service' do
+        code 'systemctl restart httpd'
+             ^^^^^^^^^^^^^^^^^^^^^^^^^ Use the service resource to manage services instead of shelling out to an init script, service, systemctl, or a similar tool
       end
     RUBY
   end
@@ -31,6 +77,46 @@ describe RuboCop::Cop::Chef::Correctness::ServiceResource, :config do
     expect_no_offenses(<<~RUBY)
       execute 'apache_start' do
         command 'echo "not starting a service"'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a systemctl status check' do
+    expect_no_offenses(<<~RUBY)
+      execute 'check the service' do
+        command 'systemctl status httpd'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for systemctl daemon-reload' do
+    expect_no_offenses(<<~RUBY)
+      execute 'reload systemd' do
+        command 'systemctl daemon-reload'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the command does more than manage the service' do
+    expect_no_offenses(<<~RUBY)
+      execute 'restart and log' do
+        command 'systemctl restart httpd && echo restarted'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a script whose name merely starts with start' do
+    expect_no_offenses(<<~RUBY)
+      execute 'run the installer' do
+        command 'start_my_app.sh'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for an unrelated binary under /usr/sbin' do
+    expect_no_offenses(<<~RUBY)
+      execute 'run the thing' do
+        command '/usr/sbin/servicelike-tool --flag'
       end
     RUBY
   end


### PR DESCRIPTION
This cop was catching roughly a fifth of what it was written to catch.

## The bug

```ruby
def starts_service?(cmd)
  cmd_str = cmd.to_s          # <- an AST node, not a string
  (cmd_str.include?('/etc/init.d') || ['service ', '/sbin/service ',
                                       'start ', 'stop ', 'invoke-rc.d '].any? do |service_cmd|
     cmd_str.start_with?(service_cmd)
   end) && ...
```

`cmd` is a node, so `cmd.to_s` returns the s-expression dump:

```
node.to_s   => "(str \"service nginx restart\")"
node.value  => "service nginx restart"

start_with?("service ") on to_s  => false
start_with?("service ") on value => true
```

Every `start_with?` branch was dead. Only `include?('/etc/init.d')` worked, because `include?` finds the substring anywhere in the dump. So `service nginx restart`, `/sbin/service ...`, and `invoke-rc.d ...` were all silently missed **despite being listed in the cop's own source**.

## What else was missing

`systemctl` wasn't in the list at all, which matters rather a lot now that systemd is the default nearly everywhere. Neither were the other init systems, nor the enable/disable tools.

The cop also only looked at a `command` property, so these went unreported:

```ruby
bash 'restart' do
  code 'systemctl restart httpd'      # code property, not command
end

execute 'systemctl restart httpd'     # command is the resource name
```

## After

Matching on `.value`, and covering how services are actually managed:

| Form | Example |
| --- | --- |
| init script | `/etc/init.d/httpd start`, `/etc/rc.d/httpd start` |
| service | `service httpd start`, `/sbin/service httpd restart` |
| systemd | `systemctl restart httpd`, `systemctl --now enable httpd` |
| upstart | `initctl start httpd`, `start httpd` |
| Debian | `invoke-rc.d httpd reload`, `update-rc.d httpd defaults` |
| RHEL | `chkconfig httpd on` |
| Solaris | `svcadm enable httpd` |
| macOS | `launchctl load /Library/LaunchDaemons/foo.plist` |
| Windows | `net start httpd`, `sc stop httpd` |

Plus the `code` property and the execute-name form.

Against the fixture that found this, all five lines are now flagged where only the first was before.

## Two deliberate exclusions

Widening detection this far needs guards against noise:

- **`status` is not a service action.** `systemctl status httpd` is normally a guard, not something the `service` resource replaces. `systemctl daemon-reload` is excluded for the same reason — there's no resource equivalent.
- **Commands containing a shell operator are left alone.** `systemctl restart httpd && echo restarted` does more than the resource can express.

Both have tests, as do two near-miss cases that must stay clean: `start_my_app.sh` (starts with `start` but isn't `start <service>`) and `/usr/sbin/servicelike-tool --flag`.

## Verification

- `bundle exec rspec` — 986 examples, 0 failures (20 new, including a table over 12 command forms)
- `bundle exec cookstyle` — no offenses in the changed files
- `bundle exec rake validate_config` — unchanged from `main`
- Original fixture re-run before and after

Cop description and docs asset updated. `VersionChanged` set to `8.8.0`. Chris Henry's copyright on both files is preserved.