### PR TITLE
Enable Lint/UriEscapeUnescape in the cookstyle config

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2760,6 +2760,8 @@ Lint/UnusedMethodArgument:
   Enabled: true
 Lint/UnreachableCode:
   Enabled: true
+Lint/UriEscapeUnescape:
+  Enabled: true
 Lint/UselessAccessModifier:
   Enabled: true
 Lint/UselessAssignment:


### PR DESCRIPTION
`URI.escape` and `URI.unescape` were obsoleted in Ruby 2.7 and **removed in Ruby 3.0**, so a cookbook still calling them raises `NoMethodError` on any modern Chef Infra Client. The cop points at the right replacement for the use case:

> \`URI.escape\` method is obsolete and should not be used. Instead, use \`CGI.escape\`, \`URI.encode_www_form\` or \`URI.encode_www_form_component\` depending on your specific use case.

## Only cookstyle.yml needed changing

`config/chefstyle.yml` **already enables it** (line 123), so this PR touches one file. I checked both before changing anything rather than making a no-op edit for symmetry:

```
$ grep -c "^Lint/UriEscapeUnescape:" config/chefstyle.yml
1
$ grep -c "^Lint/UriEscapeUnescape:" config/cookstyle.yml
0
```

Cookstyle sets `DisabledByDefault: true` in `AllCops`, so a cop absent from the config never runs. Confirmed by running the current config against `URI.escape('http://example.com/a b')` — no offense reported. With the entry added:

```
uri.rb:1:1: W: Lint/UriEscapeUnescape: `URI.escape` method is obsolete and should not be used...
uri.rb:2:1: W: Lint/UriEscapeUnescape: `URI.unescape` method is obsolete and should not be used...
```

## Placement

The entry sits between `Lint/UnreachableCode` and `Lint/UselessAccessModifier`, which is exactly where it sits in `chefstyle.yml`. Keeping the two files in the same order makes them easier to diff against each other when checking for drift like this.

## Verification

- `bundle exec rspec` — 967 examples, 0 failures
- `bundle exec rake validate_config` — unchanged from `main` (5 pre-existing `Chef/Ruby/*` errors)
- Both config files re-parsed as YAML
- `bundle exec cookstyle` on the repo itself — 11 offenses, identical to `main`; there are no `URI.escape`/`URI.unescape` calls in cookstyle's own source, so enabling this doesn't create new self-lint work
- Verified the cop fires under both the cookstyle and chefstyle configs

Diff is two lines.