### PR TITLE
Enable Security/YAMLLoad in both configs

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -164,6 +164,8 @@ Lint/RedundantCopDisableDirective:
 
 Security/Eval:
   Enabled: true
+Security/YAMLLoad:
+  Enabled: true
 
 #
 # Metrics

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2714,6 +2714,8 @@ Lint/EnsureReturn:
   Enabled: true
 Security/Eval:
   Enabled: true
+Security/YAMLLoad:
+  Enabled: true
 Lint/FloatOutOfRange:
   Enabled: true
 Lint/FormatParameterMismatch:

--- a/lib/rubocop/chef.rb
+++ b/lib/rubocop/chef.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Chef
     PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
     CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'cookstyle.yml').freeze
-    CONFIG         = YAML.load(CONFIG_DEFAULT.read).freeze
+    CONFIG         = YAML.safe_load(CONFIG_DEFAULT.read).freeze
 
     private_constant(*constants(false))
   end


### PR DESCRIPTION
Psych 4, which ships with Ruby 3.1, made `YAML.load` safe by default. Ordinary YAML that used to load now raises. Verified on Ruby 4.0.6:

```ruby
YAML.load("a: &x 1\nb: *x")     # Psych::AliasesNotEnabled
YAML.load("d: 2020-01-01")      # Psych::DisallowedClass: Tried to load unspecified class: Date
```

Anchors, aliases and dates are all commonplace in real config files, so a cookbook calling `YAML.load` fails the run outright on any current Chef Infra Client. Neither config enabled the cop, so nothing reported it.

Found while auditing which RuboCop cops catch Ruby-version breaking changes. Cookstyle already covers that family well — `Lint/UriRegexp`, `Lint/DeprecatedConstants`, `Lint/ErbNewArguments`, `Lint/BigDecimalNew`, `Lint/DeprecatedOpenSSLConstant`, `Lint/DeprecatedClassMethods`, `Lint/FlipFlop` are all on — and this was the significant remaining gap.

## Autocorrect is not applied by `-a`

Worth being explicit about, since the correction changes behavior. Upstream marks it `SafeAutoCorrect: false`, and cookstyle honors that:

```
$ cookstyle -a file.rb     # reports, leaves the code alone
config = YAML.load(raw_yaml_string)

$ cookstyle -A file.rb     # explicit unsafe autocorrect rewrites
config = YAML.safe_load(raw_yaml_string)
```

That distinction matters because the two are **not** equivalent even on Psych 4 — `YAML.load` permits `Symbol`, `safe_load` does not:

| Document | `YAML.load` | `YAML.safe_load` |
| --- | --- | --- |
| `a: 1` | works | works |
| `--- :foo` | `:foo` | raises `DisallowedClass` |
| alias | raises `AliasesNotEnabled` | raises `AliasesNotEnabled` |
| date | raises `DisallowedClass` | raises `DisallowedClass` |

So nobody's cookbook gets silently rewritten by a routine `cookstyle -a`; the offense is reported and the fix is a deliberate choice, which is the right shape for this one.

## One in-repo fix required

Enabling the cop caught a `YAML.load` in cookstyle's own source:

```
lib/rubocop/chef.rb:7:27: C: Security/YAMLLoad: Prefer using `YAML.safe_load` over `YAML.load`.
```

That took `bundle exec cookstyle` from exit 0 to **exit 1** and would have failed `rake style` in CI, so it's fixed here rather than left for later. Verified the parse is unchanged — `YAML.load` and `YAML.safe_load` produce the same 597-key hash from `config/cookstyle.yml`, compared with `==`.

Used `safe_load` rather than `safe_load_file` because the gemspec still declares `required_ruby_version >= 2.7`, and `safe_load_file` needs Psych 3.3 / Ruby 3.0.

## Verification

- `bundle exec rspec` — 967 examples, 0 failures
- `bundle exec cookstyle` — exit 0, back to the same 11 pre-existing `Chef/Style/CommentFormat` offenses as `main`
- `bundle exec rake validate_config` — unchanged from `main` (5 pre-existing `Chef/Ruby/*` errors)
- Both config files re-parsed as YAML
- Confirmed cookstyle still loads its own config and lints a sample cookbook correctly after the `safe_load` change
- `-a` and `-A` behavior checked by hand against a clean sample

Both configs get the entry, placed next to the existing `Security/Eval` in each.