### PR TITLE
Add Chef/Modernize/ExecuteUpdateAlternatives cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1826,6 +1826,16 @@ Chef/Modernize/ResourceForcingCompileTime:
     - '**/attributes/*.rb'
     - '**/Berksfile'
 
+Chef/Modernize/ExecuteUpdateAlternatives:
+  Description: "Chef Infra Client 16.0 and later includes an `alternatives` resource that should be used to manage alternatives links instead of shelling out to `update-alternatives` or `alternatives`."
+  StyleGuide: 'chef_modernize_executeupdatealternatives'
+  Enabled: true
+  VersionAdded: '8.8.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 Chef/Modernize/ExecuteSysctl:
   Description: Chef Infra Client 14.0 and later includes a sysctl resource that should be used to idempotently load sysctl values instead of templating files and using execute to load them.
   StyleGuide: 'chef_modernize_executesysctl'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_executeupdatealternatives.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_executeupdatealternatives.yml
@@ -1,0 +1,33 @@
+---
+short_name: ExecuteUpdateAlternatives
+full_name: Chef/Modernize/ExecuteUpdateAlternatives
+department: Chef/Modernize
+description: |-
+  Chef Infra Client 16.0 and later includes an `alternatives` resource that should be used to
+  manage alternatives links instead of shelling out to `update-alternatives` or `alternatives`.
+  The resource is idempotent and handles both the Debian and RHEL flavours of the command, where
+  an `execute` re-runs on every converge and reports the resource as updated every time.
+autocorrection: false
+target_chef_version: 16.0+
+examples: |2-
+
+  # bad
+  execute 'install java alternative' do
+    command 'update-alternatives --install /usr/bin/java java /usr/lib/jvm/jre-11/bin/java 1'
+  end
+
+  execute 'alternatives --set java /usr/lib/jvm/jre-11/bin/java'
+
+  # good
+  alternatives 'java' do
+    link '/usr/bin/java'
+    path '/usr/lib/jvm/jre-11/bin/java'
+    priority 1
+    action :install
+  end
+version_added: 8.8.0
+enabled: true
+excluded_file_paths:
+- "**/metadata.rb"
+- "**/attributes/*.rb"
+- "**/Berksfile"

--- a/lib/rubocop/cop/chef/modernize/execute_update_alternatives.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_update_alternatives.rb
@@ -47,11 +47,12 @@ module RuboCop
 
           minimum_target_chef_version '16.0'
 
-          MSG = 'Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives'
+          MSG = 'Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives or alternatives'
           RESTRICT_ON_SEND = [:execute].freeze
 
           # Debian ships update-alternatives and RHEL ships alternatives, and the resource drives both.
-          # Only the subcommands the resource can express are matched: --config and --display are
+          # Matching is limited to the four subcommands the resource can express: --install, --set,
+          # --auto, and --remove. The rest are deliberately left alone -- --config and --display are
           # interactive or read only, and --remove-all has no resource equivalent.
           ALTERNATIVES_COMMAND = %r{
             \A\s*(?:/usr/sbin/|/usr/bin/|/sbin/|/bin/)?  # an optional absolute path to the binary

--- a/lib/rubocop/cop/chef/modernize/execute_update_alternatives.rb
+++ b/lib/rubocop/cop/chef/modernize/execute_update_alternatives.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Modernize
+        # Chef Infra Client 16.0 and later includes an `alternatives` resource that should be used to
+        # manage alternatives links instead of shelling out to `update-alternatives` or `alternatives`.
+        # The resource is idempotent and handles both the Debian and RHEL flavours of the command, where
+        # an `execute` re-runs on every converge and reports the resource as updated every time.
+        #
+        # @example
+        #
+        #   # bad
+        #   execute 'install java alternative' do
+        #     command 'update-alternatives --install /usr/bin/java java /usr/lib/jvm/jre-11/bin/java 1'
+        #   end
+        #
+        #   execute 'alternatives --set java /usr/lib/jvm/jre-11/bin/java'
+        #
+        #   # good
+        #   alternatives 'java' do
+        #     link '/usr/bin/java'
+        #     path '/usr/lib/jvm/jre-11/bin/java'
+        #     priority 1
+        #     action :install
+        #   end
+        #
+        class ExecuteUpdateAlternatives < Base
+          include RuboCop::Chef::CookbookHelpers
+          extend TargetChefVersion
+
+          minimum_target_chef_version '16.0'
+
+          MSG = 'Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives'
+          RESTRICT_ON_SEND = [:execute].freeze
+
+          # Debian ships update-alternatives and RHEL ships alternatives, and the resource drives both.
+          # Only the subcommands the resource can express are matched: --config and --display are
+          # interactive or read only, and --remove-all has no resource equivalent.
+          ALTERNATIVES_COMMAND = %r{
+            \A\s*(?:/usr/sbin/|/usr/bin/|/sbin/|/bin/)?  # an optional absolute path to the binary
+            (?:update-)?alternatives\s+
+            --(?:install|set|auto|remove(?!-all))\b
+          }x.freeze
+
+          # the shell resources whose script lives in a code property
+          SCRIPT_RESOURCES = %i(bash sh csh ksh zsh).freeze
+
+          def on_send(node)
+            command = node.arguments.first
+            return unless command&.str_type? && manages_alternatives?(command.value)
+
+            add_offense(node, severity: :refactor)
+          end
+
+          def on_block(node)
+            match_property_in_resource?(:execute, 'command', node) do |property|
+              report_property(node, property)
+            end
+
+            match_property_in_resource?(SCRIPT_RESOURCES, 'code', node) do |property|
+              report_property(node, property)
+            end
+          end
+
+          private
+
+          def report_property(node, property)
+            command = method_arg_ast_to_string(property)
+            add_offense(node, severity: :refactor) if command && manages_alternatives?(command)
+          end
+
+          # @param [String] command
+          #
+          # @return [Boolean]
+          def manages_alternatives?(command)
+            ALTERNATIVES_COMMAND.match?(command)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/execute_update_alternatives_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/execute_update_alternatives_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Modernize::ExecuteUpdateAlternatives, :config do
+  it 'registers an offense when execute uses a command property to install an alternative' do
+    expect_offense(<<~RUBY)
+      execute 'install java alternative' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives
+        command 'update-alternatives --install /usr/bin/java java /usr/lib/jvm/jre-11/bin/java 1'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the execute resource name is the alternatives command' do
+    expect_offense(<<~RUBY)
+      execute 'alternatives --set java /usr/lib/jvm/jre-11/bin/java'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives
+    RUBY
+  end
+
+  it 'registers an offense for the RHEL alternatives command' do
+    expect_offense(<<~RUBY)
+      execute 'set the java alternative' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives
+        command 'alternatives --auto java'
+      end
+    RUBY
+  end
+
+  it 'registers an offense for an absolute path to the binary' do
+    expect_offense(<<~RUBY)
+      execute 'remove the java alternative' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives
+        command '/usr/sbin/update-alternatives --remove java /usr/lib/jvm/jre-11/bin/java'
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a bash resource manages alternatives' do
+    expect_offense(<<~RUBY)
+      bash 'install java alternative' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives
+        code 'update-alternatives --install /usr/bin/java java /usr/lib/jvm/jre-11/bin/java 1'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for a read only alternatives query" do
+    expect_no_offenses(<<~RUBY)
+      execute 'check the java alternative' do
+        command 'update-alternatives --display java'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for the interactive config subcommand" do
+    expect_no_offenses(<<~RUBY)
+      execute 'configure the java alternative' do
+        command 'update-alternatives --config java'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for --remove-all, which the resource cannot express" do
+    expect_no_offenses(<<~RUBY)
+      execute 'remove all java alternatives' do
+        command 'update-alternatives --remove-all java'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for an unrelated command" do
+    expect_no_offenses(<<~RUBY)
+      execute 'build the thing' do
+        command 'make install'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for a script that merely contains the word alternatives" do
+    expect_no_offenses(<<~RUBY)
+      execute 'run the helper' do
+        command '/opt/scripts/list-alternatives.sh --install'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the alternatives resource is already used" do
+    expect_no_offenses(<<~RUBY)
+      alternatives 'java' do
+        link '/usr/bin/java'
+        path '/usr/lib/jvm/jre-11/bin/java'
+        priority 1
+        action :install
+      end
+    RUBY
+  end
+
+  context 'with TargetChefVersion set to 15' do
+    let(:config) { target_chef_version(15) }
+
+    it "doesn't register an offense" do
+      expect_no_offenses(<<~RUBY)
+        execute 'install java alternative' do
+          command 'update-alternatives --install /usr/bin/java java /usr/lib/jvm/jre-11/bin/java 1'
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/modernize/execute_update_alternatives_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/execute_update_alternatives_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Chef::Modernize::ExecuteUpdateAlternatives, :config do
   it 'registers an offense when execute uses a command property to install an alternative' do
     expect_offense(<<~RUBY)
       execute 'install java alternative' do
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives or alternatives
         command 'update-alternatives --install /usr/bin/java java /usr/lib/jvm/jre-11/bin/java 1'
       end
     RUBY
@@ -31,14 +31,14 @@ describe RuboCop::Cop::Chef::Modernize::ExecuteUpdateAlternatives, :config do
   it 'registers an offense when the execute resource name is the alternatives command' do
     expect_offense(<<~RUBY)
       execute 'alternatives --set java /usr/lib/jvm/jre-11/bin/java'
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives or alternatives
     RUBY
   end
 
   it 'registers an offense for the RHEL alternatives command' do
     expect_offense(<<~RUBY)
       execute 'set the java alternative' do
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives or alternatives
         command 'alternatives --auto java'
       end
     RUBY
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Chef::Modernize::ExecuteUpdateAlternatives, :config do
   it 'registers an offense for an absolute path to the binary' do
     expect_offense(<<~RUBY)
       execute 'remove the java alternative' do
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives or alternatives
         command '/usr/sbin/update-alternatives --remove java /usr/lib/jvm/jre-11/bin/java'
       end
     RUBY
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Chef::Modernize::ExecuteUpdateAlternatives, :config do
   it 'registers an offense when a bash resource manages alternatives' do
     expect_offense(<<~RUBY)
       bash 'install java alternative' do
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Chef Infra Client 16.0 and later includes an alternatives resource that should be used to manage alternatives links instead of shelling out to update-alternatives or alternatives
         code 'update-alternatives --install /usr/bin/java java /usr/lib/jvm/jre-11/bin/java 1'
       end
     RUBY


### PR DESCRIPTION
```ruby
# bad
execute 'install java alternative' do
  command 'update-alternatives --install /usr/bin/java java /usr/lib/jvm/jre-11/bin/java 1'
end

execute 'alternatives --set java /usr/lib/jvm/jre-11/bin/java'

# good
alternatives 'java' do
  link '/usr/bin/java'
  path '/usr/lib/jvm/jre-11/bin/java'
  priority 1
  action :install
end
```

Chef Infra Client 16.0 added the `alternatives` resource, so there's no longer a reason to shell out. The resource is idempotent and drives both the Debian `update-alternatives` and the RHEL `alternatives` command, where an `execute` re-runs on every converge and reports the resource as updated every time.

Joins the existing `Chef/Modernize/Execute*` family — `ExecuteAptUpdate`, `ExecuteSysctl`, `ExecuteTzUtil` — and follows their shape.

## Version gate

`minimum_target_chef_version '16.0'`. I confirmed the version from the resource itself rather than from memory — `lib/chef/resource/alternatives.rb` in `chef/chef` declares:

```ruby
description "Use the **alternatives** resource to configure command alternatives in Linux using the alternatives or update-alternatives packages."
introduced "16.0"
```

(The docs page doesn't carry a "New in" line, and the file's first commit lands March 2020, consistent with 16.0.) There's a spec asserting no offense at `TargetChefVersion 15`, and I checked it's load-bearing by lowering the minimum to `1.0` — that example is the only one that then fails.

## What's covered

- `execute` with a `command` property
- `bash` / `sh` / `csh` / `ksh` / `zsh` with a `code` property
- `execute 'update-alternatives --install ...'`, where the command is the resource name
- an absolute path to the binary, `/usr/sbin/update-alternatives ...`
- both the `update-alternatives` and `alternatives` spellings

## What's deliberately left alone

Only the subcommands the resource can actually express are matched, mapping to its `:install`, `:set`, `:auto`, and `:remove` actions:

| Command | Why not flagged |
| --- | --- |
| `--display java` / `--list` | read-only query |
| `--config java` | interactive |
| `--remove-all java` | no resource equivalent — note `--remove` matching had to exclude this explicitly |
| `/opt/scripts/list-alternatives.sh --install` | a script that merely contains the word |

No autocorrect. Mapping `--install /usr/bin/java java /path 1` onto `link`/`link_name`/`path`/`priority` is positional and breaks down as soon as any argument is interpolated, so the offense is reported and the conversion left to a human.

## Verification

- `bundle exec rspec` — 991 examples, 0 failures (12 new)
- `bundle exec rake validate_config` — cop registered; the 5 remaining `Chef/Ruby/*` errors are pre-existing on `main`
- `bundle exec cookstyle` — no offenses in the new files

`VersionAdded` set to `8.8.0`.