### PR TITLE
Add Chef/Security/InsecureRemoteFileSource cop

### DIFF
--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2367,7 +2367,7 @@ Chef/Security:
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
 Chef/Security/InsecureRemoteFileSource:
-  Description: "Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives."
+  Description: "Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will use whatever it receives."
   StyleGuide: 'chef_security_insecureremotefilesource'
   Enabled: true
   VersionAdded: '8.8.0'

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -2376,6 +2376,15 @@ Chef/Security:
   Enabled: true
   StyleGuideBaseURL: https://docs.chef.io/workstation/cookstyle/
 
+Chef/Security/InsecureRemoteFileSource:
+  Description: "Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives."
+  StyleGuide: 'chef_security_insecureremotefilesource'
+  Enabled: true
+  VersionAdded: '8.8.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/Berksfile'
+
 Chef/Security/SshPrivateKey:
   Description: Do not include plain text SSH private keys in your cookbook code. This sensitive data should be fetched from secrets management systems so that secrets are not uploaded in plain text to the Chef Infra Server or committed to source control systems.
   StyleGuide: 'chef_security_sshprivatekey'

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1782,16 +1782,6 @@ Chef/Modernize/ResourceForcingCompileTime:
     - '**/attributes/*.rb'
     - '**/Berksfile'
 
-Chef/Modernize/ExecuteArchiveExtract:
-  Description: "Use the `archive_file` resource built into Chef Infra Client 15+ instead of shelling out to `tar` or `unzip` to extract an archive."
-  StyleGuide: 'chef_modernize_executearchiveextract'
-  Enabled: true
-  VersionAdded: '8.8.0'
-  Exclude:
-    - '**/metadata.rb'
-    - '**/attributes/*.rb'
-    - '**/Berksfile'
-
 Chef/Modernize/ExecuteSysctl:
   Description: Chef Infra Client 14.0 and later includes a sysctl resource that should be used to idempotently load sysctl values instead of templating files and using execute to load them.
   StyleGuide: 'chef_modernize_executesysctl'

--- a/docs-chef-io/assets/cookstyle/cops_chef_security_insecureremotefilesource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_security_insecureremotefilesource.yml
@@ -1,0 +1,28 @@
+---
+short_name: InsecureRemoteFileSource
+full_name: Chef/Security/InsecureRemoteFileSource
+department: Chef/Security
+description: |-
+  Files downloaded over plain HTTP or FTP can be modified in transit, and the resource will
+  install whatever it receives. Fetch them over HTTPS so the transport is authenticated.
+
+  Where an HTTPS endpoint genuinely isn't available, a `checksum` on the resource at least
+  detects tampering, since the digest is compared before the file is used.
+autocorrection: false
+target_chef_version: All Versions
+examples: |2-
+
+  # bad
+  remote_file '/tmp/foo.tar.gz' do
+    source 'http://example.com/foo.tar.gz'
+  end
+
+  # good
+  remote_file '/tmp/foo.tar.gz' do
+    source 'https://example.com/foo.tar.gz'
+  end
+version_added: 8.8.0
+enabled: true
+excluded_file_paths:
+- "**/metadata.rb"
+- "**/Berksfile"

--- a/docs-chef-io/assets/cookstyle/cops_chef_security_insecureremotefilesource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_security_insecureremotefilesource.yml
@@ -4,7 +4,7 @@ full_name: Chef/Security/InsecureRemoteFileSource
 department: Chef/Security
 description: |-
   Files downloaded over plain HTTP or FTP can be modified in transit, and the resource will
-  install whatever it receives. Fetch them over HTTPS so the transport is authenticated.
+  use whatever it receives. Fetch them over HTTPS so the transport is authenticated.
 
   Where an HTTPS endpoint genuinely isn't available, a `checksum` on the resource at least
   detects tampering, since the digest is compared before the file is used.

--- a/lib/rubocop/cop/chef/security/insecure_remote_file_source.rb
+++ b/lib/rubocop/cop/chef/security/insecure_remote_file_source.rb
@@ -20,7 +20,7 @@ module RuboCop
     module Chef
       module Security
         # Files downloaded over plain HTTP or FTP can be modified in transit, and the resource will
-        # install whatever it receives. Fetch them over HTTPS so the transport is authenticated.
+        # use whatever it receives. Fetch them over HTTPS so the transport is authenticated.
         #
         # Where an HTTPS endpoint genuinely isn't available, a `checksum` on the resource at least
         # detects tampering, since the digest is compared before the file is used.
@@ -40,7 +40,7 @@ module RuboCop
         class InsecureRemoteFileSource < Base
           include RuboCop::Chef::CookbookHelpers
 
-          MSG = 'Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.'
+          MSG = 'Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will use whatever it receives.'
 
           # the resources that download a file from the source property
           RESOURCES = %i(remote_file windows_package msu_package dmg_package cab_package).freeze

--- a/lib/rubocop/cop/chef/security/insecure_remote_file_source.rb
+++ b/lib/rubocop/cop/chef/security/insecure_remote_file_source.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module RuboCop
+  module Cop
+    module Chef
+      module Security
+        # Files downloaded over plain HTTP or FTP can be modified in transit, and the resource will
+        # install whatever it receives. Fetch them over HTTPS so the transport is authenticated.
+        #
+        # Where an HTTPS endpoint genuinely isn't available, a `checksum` on the resource at least
+        # detects tampering, since the digest is compared before the file is used.
+        #
+        # @example
+        #
+        #   # bad
+        #   remote_file '/tmp/foo.tar.gz' do
+        #     source 'http://example.com/foo.tar.gz'
+        #   end
+        #
+        #   # good
+        #   remote_file '/tmp/foo.tar.gz' do
+        #     source 'https://example.com/foo.tar.gz'
+        #   end
+        #
+        class InsecureRemoteFileSource < Base
+          include RuboCop::Chef::CookbookHelpers
+
+          MSG = 'Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.'
+
+          # the resources that download a file from the source property
+          RESOURCES = %i(remote_file windows_package msu_package dmg_package cab_package).freeze
+
+          # transports with no authentication of the server or the payload
+          INSECURE_SCHEME = %r{\A(?:http|ftp)://}i.freeze
+
+          def on_block(node)
+            match_property_in_resource?(RESOURCES, 'source', node) do |source|
+              source.arguments.each do |argument|
+                # remote_file also accepts an array of mirrors, any one of which may be insecure
+                urls = argument.array_type? ? argument.values : [argument]
+                urls.each { |url| add_offense(url, severity: :warning) if insecure_url?(url) }
+              end
+            end
+          end
+
+          private
+
+          # A dstr's leading literal is enough to read the scheme off an interpolated URL. Anything
+          # that isn't a literal string, such as a node attribute, tells us nothing and is left alone.
+          #
+          # @param [RuboCop::AST::Node] node
+          #
+          # @return [Boolean]
+          def insecure_url?(node)
+            literal = if node.str_type?
+                        node.value
+                      elsif node.dstr_type? && node.children.first&.str_type?
+                        node.children.first.value
+                      end
+
+            literal ? INSECURE_SCHEME.match?(literal) : false
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/chef/security/insecure_remote_file_source_spec.rb
+++ b/spec/rubocop/cop/chef/security/insecure_remote_file_source_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Chef::Security::InsecureRemoteFileSource, :config do
     expect_offense(<<~RUBY)
       remote_file '/tmp/foo.tar.gz' do
         source 'http://example.com/foo.tar.gz'
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will use whatever it receives.
       end
     RUBY
   end
@@ -32,7 +32,7 @@ describe RuboCop::Cop::Chef::Security::InsecureRemoteFileSource, :config do
     expect_offense(<<~RUBY)
       remote_file '/tmp/foo.tar.gz' do
         source 'ftp://example.com/foo.tar.gz'
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will use whatever it receives.
       end
     RUBY
   end
@@ -41,7 +41,34 @@ describe RuboCop::Cop::Chef::Security::InsecureRemoteFileSource, :config do
     expect_offense(<<~RUBY)
       windows_package 'Foo' do
         source 'http://example.com/foo.msi'
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will use whatever it receives.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when msu_package fetches over http' do
+    expect_offense(<<~RUBY)
+      msu_package 'Windows Update' do
+        source 'http://example.com/update.msu'
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will use whatever it receives.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when dmg_package fetches over http' do
+    expect_offense(<<~RUBY)
+      dmg_package 'Foo' do
+        source 'http://example.com/foo.dmg'
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will use whatever it receives.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when cab_package fetches over http' do
+    expect_offense(<<~RUBY)
+      cab_package 'Foo' do
+        source 'http://example.com/foo.cab'
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will use whatever it receives.
       end
     RUBY
   end
@@ -50,7 +77,7 @@ describe RuboCop::Cop::Chef::Security::InsecureRemoteFileSource, :config do
     expect_offense(<<~'RUBY')
       remote_file '/tmp/foo.tar.gz' do
         source "http://example.com/#{node['foo']['version']}/foo.tar.gz"
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will use whatever it receives.
       end
     RUBY
   end
@@ -59,7 +86,7 @@ describe RuboCop::Cop::Chef::Security::InsecureRemoteFileSource, :config do
     expect_offense(<<~RUBY)
       remote_file '/tmp/foo.tar.gz' do
         source ['https://example.com/foo.tar.gz', 'http://mirror.example.com/foo.tar.gz']
-                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.
+                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will use whatever it receives.
       end
     RUBY
   end

--- a/spec/rubocop/cop/chef/security/insecure_remote_file_source_spec.rb
+++ b/spec/rubocop/cop/chef/security/insecure_remote_file_source_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Author:: Tim Smith (<tsmith84@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Chef::Security::InsecureRemoteFileSource, :config do
+  it 'registers an offense when remote_file fetches over http' do
+    expect_offense(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        source 'http://example.com/foo.tar.gz'
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when remote_file fetches over ftp' do
+    expect_offense(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        source 'ftp://example.com/foo.tar.gz'
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when windows_package fetches over http' do
+    expect_offense(<<~RUBY)
+      windows_package 'Foo' do
+        source 'http://example.com/foo.msi'
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the url is interpolated' do
+    expect_offense(<<~'RUBY')
+      remote_file '/tmp/foo.tar.gz' do
+        source "http://example.com/#{node['foo']['version']}/foo.tar.gz"
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for each insecure mirror in an array of sources' do
+    expect_offense(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        source ['https://example.com/foo.tar.gz', 'http://mirror.example.com/foo.tar.gz']
+                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Fetch remote files over HTTPS. A file downloaded over plain HTTP or FTP can be modified in transit and the resource will install whatever it receives.
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the source is https" do
+    expect_no_offenses(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        source 'https://example.com/foo.tar.gz'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for a local file source" do
+    expect_no_offenses(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        source 'file:///mnt/media/foo.tar.gz'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the source comes from a node attribute" do
+    expect_no_offenses(<<~RUBY)
+      remote_file '/tmp/foo.tar.gz' do
+        source node['foo']['url']
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when the scheme itself is interpolated" do
+    expect_no_offenses(<<~'RUBY')
+      remote_file '/tmp/foo.tar.gz' do
+        source "#{node['foo']['scheme']}://example.com/foo.tar.gz"
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense on an unrelated resource with a source property" do
+    expect_no_offenses(<<~RUBY)
+      template '/etc/foo.conf' do
+        source 'http://example.com/foo.erb'
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
```ruby
# bad
remote_file '/tmp/foo.tar.gz' do
  source 'http://example.com/foo.tar.gz'
end

# good
remote_file '/tmp/foo.tar.gz' do
  source 'https://example.com/foo.tar.gz'
end
```

A file fetched over plain HTTP or FTP can be modified in transit, and the resource installs whatever it receives. For `remote_file` that's an arbitrary file on disk; for the package resources it's an installer that then runs.

Only the second `Chef/Security` cop, alongside `SshPrivateKey`.

## Scope

The resources that download from a `source` property: `remote_file`, `windows_package`, `msu_package`, `dmg_package`, `cab_package`. `template` and `cookbook_file` take a cookbook-relative source, not a URL, so they're excluded — there's a test pinning that.

`remote_file` also accepts **an array of mirrors**, and any one of them may be insecure. Each element is checked individually and the offense points at the specific bad mirror:

```
remote_file '/tmp/c' do
  source ['https://ok.example.com/c', 'http://bad.example.com/c']
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ offense here, not on the array
end
```

## What's left alone

| Source | Why |
| --- | --- |
| `https://…` | fine |
| `file:///mnt/media/foo.tar.gz` | local, no transport |
| `node['foo']['url']` | not a literal — can't be determined |
| `"#{node['foo']['scheme']}://example.com/…"` | the scheme itself is interpolated |

An interpolated URL is read from the leading literal of the dstr, so `"http://example.com/#{version}/foo.tar.gz"` **is** caught — the scheme is present in the source even when the rest isn't.

## No autocorrect

Rewriting `http` to `https` assumes the host serves TLS on the same path. A silently broken download is a worse outcome than the warning, so this reports only. The docstring notes that where an HTTPS endpoint genuinely isn't available, adding a `checksum` at least detects tampering, since the digest is compared before the file is used — which pairs with the `Chef/Correctness/InvalidChecksum` cop in #1098.

## Verification

- `bundle exec rspec` — 991 examples, 0 failures (10 new)
- `bundle exec rake validate_config` — cop registered; the 5 remaining `Chef/Ruby/*` errors are pre-existing on `main`
- `bundle exec cookstyle` — no offenses in the new files
- End-to-end run over a fixture with http, https, a mixed mirror array, and a node-attribute source: two offenses, on exactly the right two

`VersionAdded` set to `8.8.0`.