### PR TITLE
Add good examples to cop docs that only showed bad code

### DIFF
--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformfamilyhelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformfamilyhelper.yml
@@ -13,7 +13,7 @@ examples: |2-
   platform_family?('redhat')
   platform_family?('sles')
 
-  # bad
+  # good
   platform_family?('rhel')
   platform_family?('suse')
 version_added: 5.15.0

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformfamilyincase.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformfamilyincase.yml
@@ -13,12 +13,16 @@ examples: |2-
   case node['platform_family']
   when 'redhat'
     puts "I'm on a RHEL-like system"
+  when 'debian'
+    puts "I'm on a Debian-like system"
   end
 
   # good
   case node['platform_family']
   when 'rhel'
     puts "I'm on a RHEL-like system"
+  when 'debian'
+    puts "I'm on a Debian-like system"
   end
 version_added: 6.6.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformfamilyincase.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformfamilyincase.yml
@@ -14,6 +14,12 @@ examples: |2-
   when 'redhat'
     puts "I'm on a RHEL-like system"
   end
+
+  # good
+  case node['platform_family']
+  when 'rhel'
+    puts "I'm on a RHEL-like system"
+  end
 version_added: 6.6.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformincase.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformincase.yml
@@ -12,12 +12,16 @@ examples: |2-
   case node['platform']
   when 'rhel'
     puts "I'm on a Red Hat system!"
+  when 'ubuntu'
+    puts "I'm on Ubuntu!"
   end
 
   # good
   case node['platform']
   when 'redhat'
     puts "I'm on a Red Hat system!"
+  when 'ubuntu'
+    puts "I'm on Ubuntu!"
   end
 version_added: 6.6.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformincase.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformincase.yml
@@ -13,6 +13,12 @@ examples: |2-
   when 'rhel'
     puts "I'm on a Red Hat system!"
   end
+
+  # good
+  case node['platform']
+  when 'redhat'
+    puts "I'm on a Red Hat system!"
+  end
 version_added: 6.6.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformvalueforplatformhelper.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_invalidplatformvalueforplatformhelper.yml
@@ -14,6 +14,7 @@ examples: |2-
     %w(rhel mac_os_x_server) => { 'default' => 'foo' },
     %w(sles) => { 'default' => 'bar' }
   )
+
   # good
   value_for_platform(
     %w(redhat mac_os_x) => { 'default' => 'foo' },

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_powershellfileexists.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_powershellfileexists.yml
@@ -9,7 +9,7 @@ target_chef_version: All Versions
 examples: |2-
 
   # bad
-  powershell_out('Test-Path "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"').stdout.strip == 'True'
+  powershell_out('Test-Path "C:\Program Files\LAPS\CSE\AdmPwd.dll"').stdout.strip == 'True'
 
   # good
   ::File.exist?('C:\Program Files\LAPS\CSE\AdmPwd.dll')

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_powershellscriptdeletefile.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_powershellscriptdeletefile.yml
@@ -16,7 +16,7 @@ examples: |2-
   # bad
   powershell_script 'Cleanup old files' do
     code 'Remove-Item C:\Windows\foo\bar.txt'
-    only_if { ::File.exist?('C:\\Windows\\foo\\bar.txt') }
+    only_if { ::File.exist?('C:\Windows\foo\bar.txt') }
   end
 version_added: 6.0.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_powershellscriptdeletefile.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_powershellscriptdeletefile.yml
@@ -2,13 +2,9 @@
 short_name: PowershellScriptDeleteFile
 full_name: Chef/Correctness/PowershellScriptDeleteFile
 department: Chef/Correctness
-description: |-
-  Use the `file` or `directory` resources built into Chef Infra Client with the :delete action to remove files/directories instead of using Remove-Item in a powershell_script resource
-
-   ### correct
-   file 'C:\Windows\foo\bar.txt' do
-     action :delete
-   end
+description: Use the `file` or `directory` resources built into Chef Infra Client
+  with the :delete action to remove files/directories instead of using Remove-Item
+  in a powershell_script resource
 autocorrection: false
 target_chef_version: All Versions
 examples: |2-
@@ -17,6 +13,11 @@ examples: |2-
   powershell_script 'Cleanup old files' do
     code 'Remove-Item C:\Windows\foo\bar.txt'
     only_if { ::File.exist?('C:\Windows\foo\bar.txt') }
+  end
+
+  # good
+  file 'C:\Windows\foo\bar.txt' do
+    action :delete
   end
 version_added: 6.0.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_correctness_serviceresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_correctness_serviceresource.yml
@@ -10,6 +10,15 @@ examples: |2-
   # bad
   command "/etc/init.d/mysql start"
   command "/sbin/service/memcached start"
+
+  # good
+  service 'mysql' do
+    action :start
+  end
+
+  service 'memcached' do
+    action :start
+  end
 version_added: 5.0.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefhandlerrecipe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefhandlerrecipe.yml
@@ -11,6 +11,13 @@ examples: |2-
   # bad
   include_recipe 'chef_handler'
   include_recipe 'chef_handler::default'
+
+  # good
+  # the chef_handler resource ships in Chef Infra Client, so no recipe include is needed
+  chef_handler 'MyHandler' do
+    source '/etc/chef/handlers/my_handler.rb'
+    action :enable
+  end
 version_added: 6.12.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefsugarhelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefsugarhelpers.yml
@@ -30,8 +30,8 @@ examples: |2-
   # good
   # the equivalent helpers now shipping in Chef Infra Client itself
   vagrant?
-  includes_recipe?('foo::bar')      # => node.recipe?('foo::bar')
-  File.exist?('/dev/null')          # => dev_null
+  node.recipe?('foo::bar')
+  ::File.exist?('/dev/null')
 version_added: 7.3.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefsugarhelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefsugarhelpers.yml
@@ -28,10 +28,10 @@ examples: |2-
   opensolaris?
 
   # good
-  # the equivalent helpers now shipping in Chef Infra Client itself
+  # the equivalents now shipping in Chef Infra Client and in Ruby itself
   vagrant?
   node.recipe?('foo::bar')
-  ::File.exist?('/dev/null')
+  shell_out!('/opt/app/bin/app --version', out: File::NULL)
 version_added: 7.3.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefsugarhelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_chefsugarhelpers.yml
@@ -26,6 +26,12 @@ examples: |2-
   opensolaris_platform?
   nexentacore?
   opensolaris?
+
+  # good
+  # the equivalent helpers now shipping in Chef Infra Client itself
+  vagrant?
+  includes_recipe?('foo::bar')      # => node.recipe?('foo::bar')
+  File.exist?('/dev/null')          # => dev_null
 version_added: 7.3.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cookbookdependsonpartialsearch.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_cookbookdependsonpartialsearch.yml
@@ -10,6 +10,10 @@ examples: |2-
 
   # bad
   depends 'partial_search'
+
+  # good
+  # the built-in search helper takes a filter_result option
+  search(:node, 'role:web', filter_result: { 'name' => ['name'], 'ip' => ['ipaddress'] })
 version_added: 5.1.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_foodcritictesting.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_foodcritictesting.yml
@@ -14,7 +14,6 @@ examples: |2-
 
   # good
   gem 'cookstyle'
-  require 'cookstyle'
 version_added: 7.1.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_foodcritictesting.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_foodcritictesting.yml
@@ -11,9 +11,6 @@ examples: |2-
   # bad
   gem 'foodcritic'
   require 'foodcritic'
-
-  # good
-  gem 'cookstyle'
 version_added: 7.1.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_foodcritictesting.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_foodcritictesting.yml
@@ -11,6 +11,10 @@ examples: |2-
   # bad
   gem 'foodcritic'
   require 'foodcritic'
+
+  # good
+  gem 'cookstyle'
+  require 'cookstyle'
 version_added: 7.1.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_hwrpwithoutprovides.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_hwrpwithoutprovides.yml
@@ -2,11 +2,9 @@
 short_name: HWRPWithoutProvides
 full_name: Chef/Deprecations/HWRPWithoutProvides
 department: Chef/Deprecations
-description: |-
-  Chef Infra Client 16 and later a legacy HWRP resource must use `provides` to define how the resource is called in recipes or other resources. To maintain compatibility with Chef Infra Client < 16 use both `resource_name` and `provides`.
-
-   # better
-   Convert your legacy HWRPs to custom resources
+description: Chef Infra Client 16 and later a legacy HWRP resource must use `provides`
+  to define how the resource is called in recipes or other resources. To maintain
+  compatibility with Chef Infra Client < 16 use both `resource_name` and `provides`.
 autocorrection: true
 target_chef_version: All Versions
 examples: |2-
@@ -65,6 +63,9 @@ examples: |2-
       end
     end
   end
+
+  # better
+  # Convert your legacy HWRPs to custom resources
 version_added: 6.0.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_includingxmlrubyrecipe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_includingxmlrubyrecipe.yml
@@ -10,6 +10,10 @@ examples: |2-
 
   # bad
   include_recipe 'xml::ruby'
+
+  # good
+  # nokogiri ships with Chef Infra Client, so just require it
+  require 'nokogiri'
 version_added: 5.4.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_legacyyumcookbookrecipes.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_legacyyumcookbookrecipes.yml
@@ -17,6 +17,14 @@ examples: |2-
   include_recipe 'yum::remi'
   include_recipe 'yum::repoforge'
   include_recipe 'yum::yum'
+
+  # good
+  include_recipe 'yum-elrepo'
+  include_recipe 'yum-epel'
+  include_recipe 'yum-ius'
+  include_recipe 'yum-remi'
+  include_recipe 'yum-repoforge'
+  include_recipe 'yum'
 version_added: 5.4.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_localedeprecatedlcallproperty.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_localedeprecatedlcallproperty.yml
@@ -13,6 +13,11 @@ examples: |2-
     lang 'en_gb.utf-8'
     lc_all 'en_gb.utf-8'
   end
+
+  # good
+  locale 'set locale' do
+    lang 'en_gb.utf-8'
+  end
 version_added: 5.5.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceinheritsfromcompatresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceinheritsfromcompatresource.yml
@@ -2,11 +2,9 @@
 short_name: ResourceInheritsFromCompatResource
 full_name: Chef/Deprecations/ResourceInheritsFromCompatResource
 department: Chef/Deprecations
-description: |-
-  Resources written in the class based HWRP style should inherit from the 'Chef::Resource' class and not the 'ChefCompat::Resource' class from the deprecated compat_resource cookbook.
-
-   # better
-   Write a custom resource using the custom resource DSL and avoid class based HWRPs entirely
+description: Resources written in the class based HWRP style should inherit from the
+  'Chef::Resource' class and not the 'ChefCompat::Resource' class from the deprecated
+  compat_resource cookbook.
 autocorrection: true
 target_chef_version: All Versions
 examples: |2-
@@ -20,6 +18,9 @@ examples: |2-
   class AptUpdate < Chef::Resource
     # some resource code
   end
+
+  # better
+  # Write a custom resource using the custom resource DSL and avoid class based HWRPs entirely
 version_added: 5.10.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesonlyresourcename.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesonlyresourcename.yml
@@ -12,11 +12,11 @@ target_chef_version: All Versions
 examples: |2-
 
   # bad
-  mycookbook/resources/myresource.rb:
+  # mycookbook/resources/myresource.rb
   resource_name :mycookbook_myresource
 
   # good
-  mycookbook/resources/myresource.rb:
+  # mycookbook/resources/myresource.rb
   provides :mycookbook_myresource
 
   # or, to also support Chef Infra Client < 16

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesonlyresourcename.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesonlyresourcename.yml
@@ -14,6 +14,14 @@ examples: |2-
   # bad
   mycookbook/resources/myresource.rb:
   resource_name :mycookbook_myresource
+
+  # good
+  mycookbook/resources/myresource.rb:
+  provides :mycookbook_myresource
+
+  # or, to also support Chef Infra Client < 16
+  resource_name :mycookbook_myresource
+  provides :mycookbook_myresource
 version_added: 6.7.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesproviderbasemethod.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_resourceusesproviderbasemethod.yml
@@ -12,6 +12,10 @@ examples: |2-
 
   # bad
   provider_base ::Chef::Provider::SomethingSomething
+
+  # good
+  # in the provider, register itself for the resource
+  provides :something_something
 version_added: 5.7.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useautomaticresourcename.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useautomaticresourcename.yml
@@ -17,6 +17,15 @@ examples: |2-
       # some additional code
     end
   end
+
+  # good
+  module MyCookbook
+    class MyCookbookService < Chef::Resource
+      provides :mycookbook_service
+
+      # some additional code
+    end
+  end
 version_added: 6.12.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useschefresthelpers.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_deprecations_useschefresthelpers.yml
@@ -10,6 +10,9 @@ examples: |2-
   # bad
   require 'chef/rest'
   Chef::REST::RESTRequest.new(:GET, FOO, nil).call
+
+  # good
+  Chef::ServerAPI.new(Chef::Config[:chef_server_url]).get('nodes')
 version_added: 5.5.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_chefgemnokogiri.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_chefgemnokogiri.yml
@@ -10,6 +10,10 @@ examples: |2-
 
   # bad
   chef_gem 'nokogiri'
+
+  # good
+  # nokogiri ships with Chef Infra Client, so just require it
+  require 'nokogiri'
 version_added: 5.14.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonchefvaultcookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonchefvaultcookbook.yml
@@ -10,6 +10,10 @@ examples: |2-
 
   # bad
   depends 'chef-vault'
+
+  # good
+  # the chef-vault helpers ship in Chef Infra Client 16+, so use them without a depends
+  chef_vault_item('secrets', 'my_secret')
 version_added: 7.20.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonchocolateycookbooks.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonchocolateycookbooks.yml
@@ -12,6 +12,13 @@ examples: |2-
   # bad
   depends 'chocolatey_source'
   depends 'chocolatey_config'
+
+  # good
+  # the resources ship in Chef Infra Client 14.3+, so use them without a depends
+  chocolatey_source 'internal' do
+    source 'https://mycorp.example/nuget'
+    action :add
+  end
 version_added: 7.20.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonkernelmodulecookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonkernelmodulecookbook.yml
@@ -10,6 +10,12 @@ examples: |2-
 
   # bad
   depends 'kernel_module'
+
+  # good
+  # the resource ships in Chef Infra Client 14.3+, so use it without a depends
+  kernel_module 'loop' do
+    action :install
+  end
 version_added: 7.19.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonlocalecookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonlocalecookbook.yml
@@ -10,6 +10,12 @@ examples: |2-
 
   # bad
   depends 'locale'
+
+  # good
+  # the resource ships in Chef Infra Client 14.5+, so use it without a depends
+  locale 'set locale' do
+    lang 'en_us.UTF-8'
+  end
 version_added: 7.19.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonopensslcookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonopensslcookbook.yml
@@ -11,6 +11,15 @@ examples: |2-
 
   # bad
   depends 'openssl'
+
+  # good
+  # the openssl_* resources ship in Chef Infra Client 14.4+, so use them without a depends
+  openssl_x509_certificate '/etc/httpd/ssl/mycert.pem' do
+    common_name 'www.example.com'
+    org 'Example Inc'
+    org_unit 'IT'
+    country 'US'
+  end
 version_added: 7.20.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsontimezonelwrpcookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsontimezonelwrpcookbook.yml
@@ -10,6 +10,10 @@ examples: |2-
 
   # bad
   depends 'timezone_lwrp'
+
+  # good
+  # the resource ships in Chef Infra Client 14.6+, so use it without a depends
+  timezone 'UTC'
 version_added: 7.19.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonwindowsfirewallcookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonwindowsfirewallcookbook.yml
@@ -11,6 +11,14 @@ examples: |2-
 
   # bad
   depends 'windows_firewall'
+
+  # good
+  # the resource ships in Chef Infra Client 14.7+, so use it without a depends
+  windows_firewall_rule 'permit ssh' do
+    local_port '22'
+    protocol 'TCP'
+    firewall_action :allow
+  end
 version_added: 7.19.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonzyppercookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonzyppercookbook.yml
@@ -14,7 +14,7 @@ examples: |2-
   # good
   # the resource ships in Chef Infra Client 13.3+, so use it without a depends
   zypper_repository 'apache' do
-    baseurl 'http://download.opensuse.org/repositories/Apache'
+    baseurl 'https://download.opensuse.org/repositories/Apache'
     action :add
   end
 version_added: 5.6.0

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonzyppercookbook.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_dependsonzyppercookbook.yml
@@ -10,6 +10,13 @@ examples: |2-
 
   # bad
   depends 'zypper'
+
+  # good
+  # the resource ships in Chef Infra Client 13.3+, so use it without a depends
+  zypper_repository 'apache' do
+    baseurl 'http://download.opensuse.org/repositories/Apache'
+    action :add
+  end
 version_added: 5.6.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingmixinshelloutinresources.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingmixinshelloutinresources.yml
@@ -13,6 +13,10 @@ examples: |2-
   include Chef::Mixin::ShellOut
   require 'chef/mixin/powershell_out'
   include Chef::Mixin::PowershellOut
+
+  # good
+  # shell_out is available in resources and providers with no include
+  shell_out!('systemctl reload nginx')
 version_added: 5.4.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingmixinshelloutinresources.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingmixinshelloutinresources.yml
@@ -16,7 +16,7 @@ examples: |2-
 
   # good
   # shell_out is available in resources and providers with no include
-  shell_out!('systemctl reload nginx')
+  shell_out!('/opt/app/bin/app --version')
 version_added: 5.4.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingohaidefaultrecipe.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_includingohaidefaultrecipe.yml
@@ -13,6 +13,11 @@ examples: |2-
   # bad
   include_recipe 'ohai::default'
   include_recipe 'ohai'
+
+  # good
+  ohai_plugin 'my_custom_plugin' do
+    source_file 'my_plugin.rb'
+  end
 version_added: 5.4.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_libarchivefileresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_libarchivefileresource.yml
@@ -11,12 +11,12 @@ examples: |2-
   # bad
   depends 'libarchive'
 
-  libarchive_file "C:\file.zip" do
+  libarchive_file 'C:\file.zip' do
     path 'C:\expand_here'
   end
 
   # good
-  archive_file "C:\file.zip" do
+  archive_file 'C:\file.zip' do
     path 'C:\expand_here'
   end
 version_added: 5.5.0

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellguardinterpreter.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellguardinterpreter.yml
@@ -11,22 +11,22 @@ examples: |2-
 
   # bad
   powershell_script 'Create Directory' do
-    code "New-Item -ItemType Directory -Force -Path C:\mydir"
+    code 'New-Item -ItemType Directory -Force -Path C:\mydir'
     guard_interpreter :powershell_script
   end
 
   batch 'Create Directory' do
-    code "mkdir C:\mydir"
+    code 'mkdir C:\mydir'
     guard_interpreter :powershell_script
   end
 
   # good
   powershell_script 'Create Directory' do
-    code "New-Item -ItemType Directory -Force -Path C:\mydir"
+    code 'New-Item -ItemType Directory -Force -Path C:\mydir'
   end
 
   batch 'Create Directory' do
-    code "mkdir C:\mydir"
+    code 'mkdir C:\mydir'
   end
 version_added: 5.9.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellscriptexpandarchive.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellscriptexpandarchive.yml
@@ -12,6 +12,13 @@ examples: |2-
   powershell_script 'Expand website' do
     code 'Expand-Archive "C:\\file.zip" -DestinationPath "C:\\inetpub\\wwwroot\\" -Force'
   end
+
+  # good
+  archive_file 'Expand website' do
+    path 'C:\\file.zip'
+    destination 'C:\\inetpub\\wwwroot'
+    overwrite true
+  end
 version_added: 5.5.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellscriptexpandarchive.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_powershellscriptexpandarchive.yml
@@ -10,13 +10,13 @@ examples: |2-
 
   # bad
   powershell_script 'Expand website' do
-    code 'Expand-Archive "C:\\file.zip" -DestinationPath "C:\\inetpub\\wwwroot\\" -Force'
+    code 'Expand-Archive "C:\file.zip" -DestinationPath "C:\inetpub\wwwroot" -Force'
   end
 
   # good
   archive_file 'Expand website' do
-    path 'C:\\file.zip'
-    destination 'C:\\inetpub\\wwwroot'
+    path 'C:\file.zip'
+    destination 'C:\inetpub\wwwroot'
     overwrite true
   end
 version_added: 5.5.0

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_sevenziparchiveresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_sevenziparchiveresource.yml
@@ -9,14 +9,14 @@ target_chef_version: 15.0+
 examples: |2-
 
   # bad
-  seven_zip_archive "C:\file.zip" do
+  seven_zip_archive 'C:\file.zip' do
     path 'C:\expand_here'
   end
 
   # good
   archive_file 'expand file.zip' do
-    path 'C:\\file.zip'
-    destination 'C:\\expand_here'
+    path 'C:\file.zip'
+    destination 'C:\expand_here'
   end
 version_added: 5.5.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_sevenziparchiveresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_sevenziparchiveresource.yml
@@ -12,6 +12,12 @@ examples: |2-
   seven_zip_archive "C:\file.zip" do
     path 'C:\expand_here'
   end
+
+  # good
+  archive_file 'expand file.zip' do
+    path 'C:\\file.zip'
+    destination 'C:\\expand_here'
+  end
 version_added: 5.5.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_shellouttochocolatey.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_shellouttochocolatey.yml
@@ -9,6 +9,17 @@ description: |-
      code "choco source add -n=artifactory -s='https://mycorp.jfrog.io/mycorp/api/nuget/chocolatey-remote' -u foo -p bar"
      not_if 'choco source list | findstr artifactory'
    end
+
+    # good
+    chocolatey_package 'foo' do
+      source 'artifactory'
+      options '--no-progress --ignore-package-exit-codes'
+    end
+
+    chocolatey_source 'artifactory' do
+      source 'https://mycorp.jfrog.io/mycorp/api/nuget/chocolatey-remote'
+      action :add
+    end
 autocorrection: false
 target_chef_version: All Versions
 examples: |2-

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_shellouttochocolatey.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_shellouttochocolatey.yml
@@ -2,24 +2,8 @@
 short_name: ShellOutToChocolatey
 full_name: Chef/Modernize/ShellOutToChocolatey
 department: Chef/Modernize
-description: |-
-  Use the Chocolatey resources built into Chef Infra Client instead of shelling out to the choco command
-
-   powershell_script 'add artifactory choco source' do
-     code "choco source add -n=artifactory -s='https://mycorp.jfrog.io/mycorp/api/nuget/chocolatey-remote' -u foo -p bar"
-     not_if 'choco source list | findstr artifactory'
-   end
-
-    # good
-    chocolatey_package 'foo' do
-      source 'artifactory'
-      options '--no-progress --ignore-package-exit-codes'
-    end
-
-    chocolatey_source 'artifactory' do
-      source 'https://mycorp.jfrog.io/mycorp/api/nuget/chocolatey-remote'
-      action :add
-    end
+description: Use the Chocolatey resources built into Chef Infra Client instead of
+  shelling out to the choco command
 autocorrection: false
 target_chef_version: All Versions
 examples: |2-
@@ -27,6 +11,22 @@ examples: |2-
   # bad
   execute 'install package foo' do
     command "choco install --source=artifactory \"foo\" -y --no-progress --ignore-package-exit-codes"
+  end
+
+  powershell_script 'add artifactory choco source' do
+    code "choco source add -n=artifactory -s='https://mycorp.jfrog.io/mycorp/api/nuget/chocolatey-remote' -u foo -p bar"
+    not_if 'choco source list | findstr artifactory'
+  end
+
+  # good
+  chocolatey_package 'foo' do
+    source 'artifactory'
+    options '--no-progress --ignore-package-exit-codes'
+  end
+
+  chocolatey_source 'artifactory' do
+    source 'https://mycorp.jfrog.io/mycorp/api/nuget/chocolatey-remote'
+    action :add
   end
 version_added: 5.5.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_unnecessarydependschef14.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_unnecessarydependschef14.yml
@@ -17,6 +17,14 @@ examples: |2-
   depends 'mac_os_x'
   depends 'swap'
   depends 'sysctl'
+
+  # good
+  # the resources ship in Chef Infra Client 14+, so use them without a depends
+  build_essential 'install compilation tools'
+
+  sysctl 'vm.swappiness' do
+    value 10
+  end
 version_added: 5.1.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_unnecessarydependschef15.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_unnecessarydependschef15.yml
@@ -14,6 +14,17 @@ examples: |2-
   depends 'windows_dns'
   depends 'windows_uac'
   depends 'windows_dfs'
+
+  # good
+  # the resources ship in Chef Infra Client 15+, so use them without a depends
+  archive_file 'expand website' do
+    path '/tmp/site.zip'
+    destination '/var/www/html'
+  end
+
+  windows_uac 'set uac' do
+    enable_uac true
+  end
 version_added: 7.19.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_useszypperrepo.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_useszypperrepo.yml
@@ -10,7 +10,7 @@ examples: |2-
 
   # bad
   zypper_repo 'apache' do
-    baseurl 'http://download.opensuse.org/repositories/Apache'
+    baseurl 'https://download.opensuse.org/repositories/Apache'
     path '/openSUSE_Leap_42.2'
     type 'rpm-md'
     priority '100'
@@ -18,7 +18,7 @@ examples: |2-
 
   # good
   zypper_repository 'apache' do
-    baseurl 'http://download.opensuse.org/repositories/Apache'
+    baseurl 'https://download.opensuse.org/repositories/Apache'
     path '/openSUSE_Leap_42.2'
     type 'rpm-md'
     priority '100'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowsscresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowsscresource.yml
@@ -13,14 +13,14 @@ examples: |2-
 
   # bad
   sc_windows 'chef-client' do
-    path "C:\\opscode\\chef\\bin"
+    path 'C:\opscode\chef\bin'
     action :create
   end
 
   # good
   windows_service 'chef-client' do
     action :create
-    binary_path_name "C:\\opscode\\chef\\bin"
+    binary_path_name 'C:\opscode\chef\bin'
   end
 version_added: 5.16.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowszipfileusage.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowszipfileusage.yml
@@ -12,6 +12,12 @@ examples: |2-
   windows_zipfile 'C:\\files\\' do
     source 'C:\\Temp\\file.zip'
   end
+
+  # good
+  archive_file 'expand file.zip' do
+    path 'C:\\Temp\\file.zip'
+    destination 'C:\\files'
+  end
 version_added: 5.4.0
 enabled: true
 excluded_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowszipfileusage.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_windowszipfileusage.yml
@@ -9,14 +9,14 @@ target_chef_version: 15.0+
 examples: |2-
 
   # bad
-  windows_zipfile 'C:\\files\\' do
-    source 'C:\\Temp\\file.zip'
+  windows_zipfile 'C:\files' do
+    source 'C:\Temp\file.zip'
   end
 
   # good
   archive_file 'expand file.zip' do
-    path 'C:\\Temp\\file.zip'
-    destination 'C:\\files'
+    path 'C:\Temp\file.zip'
+    destination 'C:\files'
   end
 version_added: 5.4.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_zipfileresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_zipfileresource.yml
@@ -12,5 +12,11 @@ examples: |2-
   zipfile "C:\file.zip" do
     path 'C:\expand_here'
   end
+
+  # good
+  archive_file 'expand file.zip' do
+    path 'C:\\file.zip'
+    destination 'C:\\expand_here'
+  end
 version_added: 5.12.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_zipfileresource.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_zipfileresource.yml
@@ -9,14 +9,14 @@ target_chef_version: 15.0+
 examples: |2-
 
   # bad
-  zipfile "C:\file.zip" do
+  zipfile 'C:\file.zip' do
     path 'C:\expand_here'
   end
 
   # good
   archive_file 'expand file.zip' do
-    path 'C:\\file.zip'
-    destination 'C:\\expand_here'
+    path 'C:\file.zip'
+    destination 'C:\expand_here'
   end
 version_added: 5.12.0
 enabled: true

--- a/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_customresourcewithallowedactions.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_redundantcode_customresourcewithallowedactions.yml
@@ -14,6 +14,16 @@ examples: |2-
 
   # also bad
   actions [:create, :remove]
+
+  # good
+  # Chef Infra Client derives the allowed actions from the actions you define
+  action :create do
+    # ...
+  end
+
+  action :remove do
+    # ...
+  end
 version_added: 5.2.0
 enabled: true
 included_file_paths:

--- a/docs-chef-io/assets/cookstyle/cops_chef_security_sshprivatekey.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_security_sshprivatekey.yml
@@ -15,6 +15,15 @@ examples: |2-
     content '-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----'
     mode '600'
   end
+
+  # good
+  # fetch the key from a secrets management system instead
+  file '/home/bob/.ssh/id_rsa' do
+    content chef_vault_item('ssh_keys', 'bob')['private_key']
+    mode '600'
+    owner 'bob'
+    sensitive true
+  end
 version_added: '7.28'
 enabled: true
 included_file_paths:

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_family_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_family_helper.rb
@@ -27,7 +27,7 @@ module RuboCop
         #   platform_family?('redhat')
         #   platform_family?('sles')
         #
-        #   # bad
+        #   # good
         #   platform_family?('rhel')
         #   platform_family?('suse')
         #

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case.rb
@@ -29,6 +29,12 @@ module RuboCop
         #     puts "I'm on a RHEL-like system"
         #   end
         #
+        #   # good
+        #   case node['platform_family']
+        #   when 'rhel'
+        #     puts "I'm on a RHEL-like system"
+        #   end
+        #
         class InvalidPlatformFamilyInCase < Base
           extend AutoCorrector
           include RangeHelp

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_family_values_in_case.rb
@@ -27,12 +27,16 @@ module RuboCop
         #   case node['platform_family']
         #   when 'redhat'
         #     puts "I'm on a RHEL-like system"
+        #   when 'debian'
+        #     puts "I'm on a Debian-like system"
         #   end
         #
         #   # good
         #   case node['platform_family']
         #   when 'rhel'
         #     puts "I'm on a RHEL-like system"
+        #   when 'debian'
+        #     puts "I'm on a Debian-like system"
         #   end
         #
         class InvalidPlatformFamilyInCase < Base

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_values_in_case.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_values_in_case.rb
@@ -27,12 +27,16 @@ module RuboCop
         #   case node['platform']
         #   when 'rhel'
         #     puts "I'm on a Red Hat system!"
+        #   when 'ubuntu'
+        #     puts "I'm on Ubuntu!"
         #   end
         #
         #   # good
         #   case node['platform']
         #   when 'redhat'
         #     puts "I'm on a Red Hat system!"
+        #   when 'ubuntu'
+        #     puts "I'm on Ubuntu!"
         #   end
         #
         class InvalidPlatformInCase < Base

--- a/lib/rubocop/cop/chef/correctness/invalid_platform_values_in_case.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_platform_values_in_case.rb
@@ -29,6 +29,12 @@ module RuboCop
         #     puts "I'm on a Red Hat system!"
         #   end
         #
+        #   # good
+        #   case node['platform']
+        #   when 'redhat'
+        #     puts "I'm on a Red Hat system!"
+        #   end
+        #
         class InvalidPlatformInCase < Base
           extend AutoCorrector
           include RangeHelp

--- a/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_helper.rb
+++ b/lib/rubocop/cop/chef/correctness/invalid_value_for_platform_helper.rb
@@ -28,6 +28,7 @@ module RuboCop
         #     %w(rhel mac_os_x_server) => { 'default' => 'foo' },
         #     %w(sles) => { 'default' => 'bar' }
         #   )
+        #
         #   # good
         #   value_for_platform(
         #     %w(redhat mac_os_x) => { 'default' => 'foo' },

--- a/lib/rubocop/cop/chef/correctness/powershell_delete_file.rb
+++ b/lib/rubocop/cop/chef/correctness/powershell_delete_file.rb
@@ -29,10 +29,10 @@ module RuboCop
         #     only_if { ::File.exist?('C:\Windows\foo\bar.txt') }
         #   end
         #
-        #  ### correct
-        #  file 'C:\Windows\foo\bar.txt' do
-        #    action :delete
-        #  end
+        #   # good
+        #   file 'C:\Windows\foo\bar.txt' do
+        #     action :delete
+        #   end
         #
         class PowershellScriptDeleteFile < Base
           include RuboCop::Chef::CookbookHelpers

--- a/lib/rubocop/cop/chef/correctness/powershell_delete_file.rb
+++ b/lib/rubocop/cop/chef/correctness/powershell_delete_file.rb
@@ -26,7 +26,7 @@ module RuboCop
         #   # bad
         #   powershell_script 'Cleanup old files' do
         #     code 'Remove-Item C:\Windows\foo\bar.txt'
-        #     only_if { ::File.exist?('C:\\Windows\\foo\\bar.txt') }
+        #     only_if { ::File.exist?('C:\Windows\foo\bar.txt') }
         #   end
         #
         #  ### correct

--- a/lib/rubocop/cop/chef/correctness/powershell_file_exists.rb
+++ b/lib/rubocop/cop/chef/correctness/powershell_file_exists.rb
@@ -24,7 +24,7 @@ module RuboCop
         # @example
         #
         #   # bad
-        #   powershell_out('Test-Path "C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"').stdout.strip == 'True'
+        #   powershell_out('Test-Path "C:\Program Files\LAPS\CSE\AdmPwd.dll"').stdout.strip == 'True'
         #
         #   # good
         #   ::File.exist?('C:\Program Files\LAPS\CSE\AdmPwd.dll')

--- a/lib/rubocop/cop/chef/correctness/service_resource.rb
+++ b/lib/rubocop/cop/chef/correctness/service_resource.rb
@@ -26,6 +26,15 @@ module RuboCop
         #   command "/etc/init.d/mysql start"
         #   command "/sbin/service/memcached start"
         #
+        #   # good
+        #   service 'mysql' do
+        #     action :start
+        #   end
+        #
+        #   service 'memcached' do
+        #     action :start
+        #   end
+        #
         class ServiceResource < Base
           MSG = 'Use a service resource to start and stop services'
           RESTRICT_ON_SEND = [:command].freeze

--- a/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_handler_recipe.rb
@@ -27,6 +27,13 @@ module RuboCop
         #   include_recipe 'chef_handler'
         #   include_recipe 'chef_handler::default'
         #
+        #   # good
+        #   # the chef_handler resource ships in Chef Infra Client, so no recipe include is needed
+        #   chef_handler 'MyHandler' do
+        #     source '/etc/chef/handlers/my_handler.rb'
+        #     action :enable
+        #   end
+        #
         class ChefHandlerRecipe < Base
           include RangeHelp
           extend AutoCorrector

--- a/lib/rubocop/cop/chef/deprecation/chef_rest.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_rest.rb
@@ -27,6 +27,9 @@ module RuboCop
         #   require 'chef/rest'
         #   Chef::REST::RESTRequest.new(:GET, FOO, nil).call
         #
+        #   # good
+        #   Chef::ServerAPI.new(Chef::Config[:chef_server_url]).get('nodes')
+        #
         class UsesChefRESTHelpers < Base
           MSG = "Don't use the helpers in Chef::REST which were removed in Chef Infra Client 13"
           RESTRICT_ON_SEND = [:require].freeze

--- a/lib/rubocop/cop/chef/deprecation/chef_sugar_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_sugar_helpers.rb
@@ -42,10 +42,10 @@ module RuboCop
         #   opensolaris?
         #
         #   # good
-        #   # the equivalent helpers now shipping in Chef Infra Client itself
+        #   # the equivalents now shipping in Chef Infra Client and in Ruby itself
         #   vagrant?
         #   node.recipe?('foo::bar')
-        #   ::File.exist?('/dev/null')
+        #   shell_out!('/opt/app/bin/app --version', out: File::NULL)
         #
         class ChefSugarHelpers < Base
           MSG = 'Do not use legacy chef-sugar helper methods, which will not be moved into Chef Infra Client itself. For a complete set of chef-sugar helpers now shipping in Chef Infra Client itself see https://github.com/chef/chef/tree/main/chef-utils#getting-started'

--- a/lib/rubocop/cop/chef/deprecation/chef_sugar_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_sugar_helpers.rb
@@ -41,6 +41,12 @@ module RuboCop
         #   nexentacore?
         #   opensolaris?
         #
+        #   # good
+        #   # the equivalent helpers now shipping in Chef Infra Client itself
+        #   vagrant?
+        #   includes_recipe?('foo::bar')      # => node.recipe?('foo::bar')
+        #   File.exist?('/dev/null')          # => dev_null
+        #
         class ChefSugarHelpers < Base
           MSG = 'Do not use legacy chef-sugar helper methods, which will not be moved into Chef Infra Client itself. For a complete set of chef-sugar helpers now shipping in Chef Infra Client itself see https://github.com/chef/chef/tree/main/chef-utils#getting-started'
           RESTRICT_ON_SEND = [:vagrant_key?, :vagrant_domain?, :vagrant_user?, :require_chef_gem, :best_ip_for, :nexus?, :ios_xr?, :ruby_20?, :ruby_19?, :includes_recipe?, :wrlinux?, :dev_null, :nexentacore_platform?, :opensolaris_platform?, :nexentacore?, :opensolaris?].freeze

--- a/lib/rubocop/cop/chef/deprecation/chef_sugar_helpers.rb
+++ b/lib/rubocop/cop/chef/deprecation/chef_sugar_helpers.rb
@@ -44,8 +44,8 @@ module RuboCop
         #   # good
         #   # the equivalent helpers now shipping in Chef Infra Client itself
         #   vagrant?
-        #   includes_recipe?('foo::bar')      # => node.recipe?('foo::bar')
-        #   File.exist?('/dev/null')          # => dev_null
+        #   node.recipe?('foo::bar')
+        #   ::File.exist?('/dev/null')
         #
         class ChefSugarHelpers < Base
           MSG = 'Do not use legacy chef-sugar helper methods, which will not be moved into Chef Infra Client itself. For a complete set of chef-sugar helpers now shipping in Chef Infra Client itself see https://github.com/chef/chef/tree/main/chef-utils#getting-started'

--- a/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
+++ b/lib/rubocop/cop/chef/deprecation/depends_partial_search.rb
@@ -26,6 +26,10 @@ module RuboCop
         #   # bad
         #   depends 'partial_search'
         #
+        #   # good
+        #   # the built-in search helper takes a filter_result option
+        #   search(:node, 'role:web', filter_result: { 'name' => ['name'], 'ip' => ['ipaddress'] })
+        #
         class CookbookDependsOnPartialSearch < Base
           extend TargetChefVersion
 

--- a/lib/rubocop/cop/chef/deprecation/foodcritic_testing.rb
+++ b/lib/rubocop/cop/chef/deprecation/foodcritic_testing.rb
@@ -27,6 +27,10 @@ module RuboCop
         #   gem 'foodcritic'
         #   require 'foodcritic'
         #
+        #   # good
+        #   gem 'cookstyle'
+        #   require 'cookstyle'
+        #
         class FoodcriticTesting < Base
           MSG = 'The Foodcritic cookbook linter has been deprecated and should no longer be used for validating cookbooks.'
           RESTRICT_ON_SEND = [:require, :gem].freeze

--- a/lib/rubocop/cop/chef/deprecation/foodcritic_testing.rb
+++ b/lib/rubocop/cop/chef/deprecation/foodcritic_testing.rb
@@ -27,9 +27,6 @@ module RuboCop
         #   gem 'foodcritic'
         #   require 'foodcritic'
         #
-        #   # good
-        #   gem 'cookstyle'
-        #
         class FoodcriticTesting < Base
           MSG = 'The Foodcritic cookbook linter has been deprecated and should no longer be used for validating cookbooks.'
           RESTRICT_ON_SEND = [:require, :gem].freeze

--- a/lib/rubocop/cop/chef/deprecation/foodcritic_testing.rb
+++ b/lib/rubocop/cop/chef/deprecation/foodcritic_testing.rb
@@ -29,7 +29,6 @@ module RuboCop
         #
         #   # good
         #   gem 'cookstyle'
-        #   require 'cookstyle'
         #
         class FoodcriticTesting < Base
           MSG = 'The Foodcritic cookbook linter has been deprecated and should no longer be used for validating cookbooks.'

--- a/lib/rubocop/cop/chef/deprecation/hwrp_without_provides.rb
+++ b/lib/rubocop/cop/chef/deprecation/hwrp_without_provides.rb
@@ -78,8 +78,8 @@ module RuboCop
         #     end
         #   end
         #
-        #  # better
-        #  Convert your legacy HWRPs to custom resources
+        #   # better
+        #   # Convert your legacy HWRPs to custom resources
         #
         class HWRPWithoutProvides < Base
           extend AutoCorrector

--- a/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
+++ b/lib/rubocop/cop/chef/deprecation/inherits_compat_resource.rb
@@ -33,8 +33,8 @@ module RuboCop
         #     # some resource code
         #   end
         #
-        #  # better
-        #  Write a custom resource using the custom resource DSL and avoid class based HWRPs entirely
+        #   # better
+        #   # Write a custom resource using the custom resource DSL and avoid class based HWRPs entirely
         #
         class ResourceInheritsFromCompatResource < Base
           extend AutoCorrector

--- a/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
+++ b/lib/rubocop/cop/chef/deprecation/legacy_yum_cookbook_recipes.rb
@@ -33,6 +33,14 @@ module RuboCop
         #   include_recipe 'yum::repoforge'
         #   include_recipe 'yum::yum'
         #
+        #   # good
+        #   include_recipe 'yum-elrepo'
+        #   include_recipe 'yum-epel'
+        #   include_recipe 'yum-ius'
+        #   include_recipe 'yum-remi'
+        #   include_recipe 'yum-repoforge'
+        #   include_recipe 'yum'
+        #
         class LegacyYumCookbookRecipes < Base
           MSG = 'The elrepo, epel, ius, remi, and repoforge recipes were split into their own cookbooks and the yum recipe was renamed to be default with the release of yum cookbook 3.0 (Dec 2013).'
           RESTRICT_ON_SEND = [:include_recipe].freeze

--- a/lib/rubocop/cop/chef/deprecation/locale_lc_all_property.rb
+++ b/lib/rubocop/cop/chef/deprecation/locale_lc_all_property.rb
@@ -29,6 +29,11 @@ module RuboCop
         #     lc_all 'en_gb.utf-8'
         #   end
         #
+        #   # good
+        #   locale 'set locale' do
+        #     lang 'en_gb.utf-8'
+        #   end
+        #
         class LocaleDeprecatedLcAllProperty < Base
           include RuboCop::Chef::CookbookHelpers
 

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
@@ -27,6 +27,14 @@ module RuboCop
         #   mycookbook/resources/myresource.rb:
         #   resource_name :mycookbook_myresource
         #
+        #   # good
+        #   mycookbook/resources/myresource.rb:
+        #   provides :mycookbook_myresource
+        #
+        #   # or, to also support Chef Infra Client < 16
+        #   resource_name :mycookbook_myresource
+        #   provides :mycookbook_myresource
+        #
         class ResourceUsesOnlyResourceName < Base
           include RuboCop::Chef::CookbookHelpers
           include RangeHelp

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_only_resource_name.rb
@@ -24,11 +24,11 @@ module RuboCop
         # @example
         #
         #   # bad
-        #   mycookbook/resources/myresource.rb:
+        #   # mycookbook/resources/myresource.rb
         #   resource_name :mycookbook_myresource
         #
         #   # good
-        #   mycookbook/resources/myresource.rb:
+        #   # mycookbook/resources/myresource.rb
         #   provides :mycookbook_myresource
         #
         #   # or, to also support Chef Infra Client < 16

--- a/lib/rubocop/cop/chef/deprecation/resource_uses_provider_base_method.rb
+++ b/lib/rubocop/cop/chef/deprecation/resource_uses_provider_base_method.rb
@@ -26,6 +26,10 @@ module RuboCop
         #   # bad
         #   provider_base ::Chef::Provider::SomethingSomething
         #
+        #   # good
+        #   # in the provider, register itself for the resource
+        #   provides :something_something
+        #
         class ResourceUsesProviderBaseMethod < Base
           MSG = "Don't use the deprecated provider_base method in a resource to specify the provider module to use. Instead, the provider should call provides to register itself, or the resource should call provider to specify the provider to use. This will cause failures in Chef Infra Client 13 and later."
           RESTRICT_ON_SEND = [:provider_base].freeze

--- a/lib/rubocop/cop/chef/deprecation/use_automatic_resource_name.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_automatic_resource_name.rb
@@ -33,6 +33,15 @@ module RuboCop
         #     end
         #   end
         #
+        #   # good
+        #   module MyCookbook
+        #     class MyCookbookService < Chef::Resource
+        #       provides :mycookbook_service
+        #
+        #       # some additional code
+        #     end
+        #   end
+        #
         class UseAutomaticResourceName < Base
           extend RuboCop::Cop::AutoCorrector
           include RangeHelp

--- a/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
+++ b/lib/rubocop/cop/chef/deprecation/xml_ruby_recipe.rb
@@ -26,6 +26,10 @@ module RuboCop
         #   # bad
         #   include_recipe 'xml::ruby'
         #
+        #   # good
+        #   # nokogiri ships with Chef Infra Client, so just require it
+        #   require 'nokogiri'
+        #
         class IncludingXMLRubyRecipe < Base
           extend AutoCorrector
 

--- a/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_14_resources.rb
@@ -32,6 +32,14 @@ module RuboCop
         #   depends 'swap'
         #   depends 'sysctl'
         #
+        #   # good
+        #   # the resources ship in Chef Infra Client 14+, so use them without a depends
+        #   build_essential 'install compilation tools'
+        #
+        #   sysctl 'vm.swappiness' do
+        #     value 10
+        #   end
+        #
         class UnnecessaryDependsChef14 < Base
           extend AutoCorrector
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/chef_15_resources.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_15_resources.rb
@@ -29,6 +29,17 @@ module RuboCop
         #   depends 'windows_uac'
         #   depends 'windows_dfs'
         #
+        #   # good
+        #   # the resources ship in Chef Infra Client 15+, so use them without a depends
+        #   archive_file 'expand website' do
+        #     path '/tmp/site.zip'
+        #     destination '/var/www/html'
+        #   end
+        #
+        #   windows_uac 'set uac' do
+        #     enable_uac true
+        #   end
+        #
         class UnnecessaryDependsChef15 < Base
           extend AutoCorrector
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/chef_gem_nokogiri.rb
+++ b/lib/rubocop/cop/chef/modernize/chef_gem_nokogiri.rb
@@ -26,6 +26,10 @@ module RuboCop
         #   # bad
         #   chef_gem 'nokogiri'
         #
+        #   # good
+        #   # nokogiri ships with Chef Infra Client, so just require it
+        #   require 'nokogiri'
+        #
         class ChefGemNokogiri < Base
           extend AutoCorrector
           include RangeHelp

--- a/lib/rubocop/cop/chef/modernize/depends_chef_vault_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_chef_vault_cookbook.rb
@@ -26,6 +26,10 @@ module RuboCop
         #   # bad
         #   depends 'chef-vault'
         #
+        #   # good
+        #   # the chef-vault helpers ship in Chef Infra Client 16+, so use them without a depends
+        #   chef_vault_item('secrets', 'my_secret')
+        #
         class DependsOnChefVaultCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/depends_chocolatey_cookbooks.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_chocolatey_cookbooks.rb
@@ -27,6 +27,13 @@ module RuboCop
         #   depends 'chocolatey_source'
         #   depends 'chocolatey_config'
         #
+        #   # good
+        #   # the resources ship in Chef Infra Client 14.3+, so use them without a depends
+        #   chocolatey_source 'internal' do
+        #     source 'https://mycorp.example/nuget'
+        #     action :add
+        #   end
+        #
         class DependsOnChocolateyCookbooks < Base
           extend AutoCorrector
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/depends_kernel_module_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_kernel_module_cookbook.rb
@@ -26,6 +26,12 @@ module RuboCop
         #   # bad
         #   depends 'kernel_module'
         #
+        #   # good
+        #   # the resource ships in Chef Infra Client 14.3+, so use it without a depends
+        #   kernel_module 'loop' do
+        #     action :install
+        #   end
+        #
         class DependsOnKernelModuleCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/depends_locale_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_locale_cookbook.rb
@@ -26,6 +26,12 @@ module RuboCop
         #   # bad
         #   depends 'locale'
         #
+        #   # good
+        #   # the resource ships in Chef Infra Client 14.5+, so use it without a depends
+        #   locale 'set locale' do
+        #     lang 'en_us.UTF-8'
+        #   end
+        #
         class DependsOnLocaleCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/depends_openssl_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_openssl_cookbook.rb
@@ -26,6 +26,15 @@ module RuboCop
         #   # bad
         #   depends 'openssl'
         #
+        #   # good
+        #   # the openssl_* resources ship in Chef Infra Client 14.4+, so use them without a depends
+        #   openssl_x509_certificate '/etc/httpd/ssl/mycert.pem' do
+        #     common_name 'www.example.com'
+        #     org 'Example Inc'
+        #     org_unit 'IT'
+        #     country 'US'
+        #   end
+        #
         class DependsOnOpensslCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/depends_timezone_lwrp_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_timezone_lwrp_cookbook.rb
@@ -26,6 +26,10 @@ module RuboCop
         #   # bad
         #   depends 'timezone_lwrp'
         #
+        #   # good
+        #   # the resource ships in Chef Infra Client 14.6+, so use it without a depends
+        #   timezone 'UTC'
+        #
         class DependsOnTimezoneLwrpCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/depends_windows_firewall_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_windows_firewall_cookbook.rb
@@ -26,6 +26,14 @@ module RuboCop
         #   # bad
         #   depends 'windows_firewall'
         #
+        #   # good
+        #   # the resource ships in Chef Infra Client 14.7+, so use it without a depends
+        #   windows_firewall_rule 'permit ssh' do
+        #     local_port '22'
+        #     protocol 'TCP'
+        #     firewall_action :allow
+        #   end
+        #
         class DependsOnWindowsFirewallCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
@@ -29,7 +29,7 @@ module RuboCop
         #   # good
         #   # the resource ships in Chef Infra Client 13.3+, so use it without a depends
         #   zypper_repository 'apache' do
-        #     baseurl 'http://download.opensuse.org/repositories/Apache'
+        #     baseurl 'https://download.opensuse.org/repositories/Apache'
         #     action :add
         #   end
         #

--- a/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
+++ b/lib/rubocop/cop/chef/modernize/depends_zypper_cookbook.rb
@@ -26,6 +26,13 @@ module RuboCop
         #   # bad
         #   depends 'zypper'
         #
+        #   # good
+        #   # the resource ships in Chef Infra Client 13.3+, so use it without a depends
+        #   zypper_repository 'apache' do
+        #     baseurl 'http://download.opensuse.org/repositories/Apache'
+        #     action :add
+        #   end
+        #
         class DependsOnZypperCookbook < Base
           extend AutoCorrector
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
+++ b/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
@@ -31,7 +31,7 @@ module RuboCop
         #
         #   # good
         #   # shell_out is available in resources and providers with no include
-        #   shell_out!('systemctl reload nginx')
+        #   shell_out!('/opt/app/bin/app --version')
         #
         class IncludingMixinShelloutInResources < Base
           extend AutoCorrector

--- a/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
+++ b/lib/rubocop/cop/chef/modernize/includes_mixin_shellout.rb
@@ -29,6 +29,10 @@ module RuboCop
         #   require 'chef/mixin/powershell_out'
         #   include Chef::Mixin::PowershellOut
         #
+        #   # good
+        #   # shell_out is available in resources and providers with no include
+        #   shell_out!('systemctl reload nginx')
+        #
         class IncludingMixinShelloutInResources < Base
           extend AutoCorrector
           include RangeHelp

--- a/lib/rubocop/cop/chef/modernize/libarchive_file.rb
+++ b/lib/rubocop/cop/chef/modernize/libarchive_file.rb
@@ -26,12 +26,12 @@ module RuboCop
         #   # bad
         #   depends 'libarchive'
         #
-        #   libarchive_file "C:\file.zip" do
+        #   libarchive_file 'C:\file.zip' do
         #     path 'C:\expand_here'
         #   end
         #
         #   # good
-        #   archive_file "C:\file.zip" do
+        #   archive_file 'C:\file.zip' do
         #     path 'C:\expand_here'
         #   end
         #

--- a/lib/rubocop/cop/chef/modernize/ohai_default_recipe.rb
+++ b/lib/rubocop/cop/chef/modernize/ohai_default_recipe.rb
@@ -27,6 +27,11 @@ module RuboCop
         #   include_recipe 'ohai::default'
         #   include_recipe 'ohai'
         #
+        #   # good
+        #   ohai_plugin 'my_custom_plugin' do
+        #     source_file 'my_plugin.rb'
+        #   end
+        #
         class IncludingOhaiDefaultRecipe < Base
           MSG = "Use the ohai_plugin resource to ship custom Ohai plugins instead of using the ohai::default recipe. If you're not shipping custom Ohai plugins, then you can remove this recipe entirely"
           RESTRICT_ON_SEND = [:include_recipe].freeze

--- a/lib/rubocop/cop/chef/modernize/powershell_expand_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_expand_archive.rb
@@ -28,6 +28,13 @@ module RuboCop
         #     code 'Expand-Archive "C:\\file.zip" -DestinationPath "C:\\inetpub\\wwwroot\\" -Force'
         #   end
         #
+        #   # good
+        #   archive_file 'Expand website' do
+        #     path 'C:\\file.zip'
+        #     destination 'C:\\inetpub\\wwwroot'
+        #     overwrite true
+        #   end
+        #
         class PowershellScriptExpandArchive < Base
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/powershell_expand_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_expand_archive.rb
@@ -25,13 +25,13 @@ module RuboCop
         #
         #   # bad
         #   powershell_script 'Expand website' do
-        #     code 'Expand-Archive "C:\\file.zip" -DestinationPath "C:\\inetpub\\wwwroot\\" -Force'
+        #     code 'Expand-Archive "C:\file.zip" -DestinationPath "C:\inetpub\wwwroot" -Force'
         #   end
         #
         #   # good
         #   archive_file 'Expand website' do
-        #     path 'C:\\file.zip'
-        #     destination 'C:\\inetpub\\wwwroot'
+        #     path 'C:\file.zip'
+        #     destination 'C:\inetpub\wwwroot'
         #     overwrite true
         #   end
         #

--- a/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
+++ b/lib/rubocop/cop/chef/modernize/powershell_guard_interpreter.rb
@@ -25,22 +25,22 @@ module RuboCop
         #
         #   # bad
         #   powershell_script 'Create Directory' do
-        #     code "New-Item -ItemType Directory -Force -Path C:\mydir"
+        #     code 'New-Item -ItemType Directory -Force -Path C:\mydir'
         #     guard_interpreter :powershell_script
         #   end
         #
         #   batch 'Create Directory' do
-        #     code "mkdir C:\mydir"
+        #     code 'mkdir C:\mydir'
         #     guard_interpreter :powershell_script
         #   end
         #
         #   # good
         #   powershell_script 'Create Directory' do
-        #     code "New-Item -ItemType Directory -Force -Path C:\mydir"
+        #     code 'New-Item -ItemType Directory -Force -Path C:\mydir'
         #   end
         #
         #   batch 'Create Directory' do
-        #     code "mkdir C:\mydir"
+        #     code 'mkdir C:\mydir'
         #   end
         #
         class PowerShellGuardInterpreter < Base

--- a/lib/rubocop/cop/chef/modernize/sc_windows_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/sc_windows_resource.rb
@@ -25,14 +25,14 @@ module RuboCop
         #
         #   # bad
         #   sc_windows 'chef-client' do
-        #     path "C:\\opscode\\chef\\bin"
+        #     path 'C:\opscode\chef\bin'
         #     action :create
         #   end
         #
         #   # good
         #   windows_service 'chef-client' do
         #     action :create
-        #     binary_path_name "C:\\opscode\\chef\\bin"
+        #     binary_path_name 'C:\opscode\chef\bin'
         #   end
         #
         class WindowsScResource < Base

--- a/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
@@ -24,14 +24,14 @@ module RuboCop
         # @example
         #
         #   # bad
-        #   seven_zip_archive "C:\file.zip" do
+        #   seven_zip_archive 'C:\file.zip' do
         #     path 'C:\expand_here'
         #   end
         #
         #   # good
         #   archive_file 'expand file.zip' do
-        #     path 'C:\\file.zip'
-        #     destination 'C:\\expand_here'
+        #     path 'C:\file.zip'
+        #     destination 'C:\expand_here'
         #   end
         #
         class SevenZipArchiveResource < Base

--- a/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
+++ b/lib/rubocop/cop/chef/modernize/seven_zip_archive.rb
@@ -28,6 +28,12 @@ module RuboCop
         #     path 'C:\expand_here'
         #   end
         #
+        #   # good
+        #   archive_file 'expand file.zip' do
+        #     path 'C:\\file.zip'
+        #     destination 'C:\\expand_here'
+        #   end
+        #
         class SevenZipArchiveResource < Base
           extend TargetChefVersion
 

--- a/lib/rubocop/cop/chef/modernize/shellouts_to_chocolatey.rb
+++ b/lib/rubocop/cop/chef/modernize/shellouts_to_chocolatey.rb
@@ -33,6 +33,17 @@ module RuboCop
         #    not_if 'choco source list | findstr artifactory'
         #  end
         #
+        #   # good
+        #   chocolatey_package 'foo' do
+        #     source 'artifactory'
+        #     options '--no-progress --ignore-package-exit-codes'
+        #   end
+        #
+        #   chocolatey_source 'artifactory' do
+        #     source 'https://mycorp.jfrog.io/mycorp/api/nuget/chocolatey-remote'
+        #     action :add
+        #   end
+        #
         class ShellOutToChocolatey < Base
           include RuboCop::Chef::CookbookHelpers
 

--- a/lib/rubocop/cop/chef/modernize/shellouts_to_chocolatey.rb
+++ b/lib/rubocop/cop/chef/modernize/shellouts_to_chocolatey.rb
@@ -28,10 +28,10 @@ module RuboCop
         #     command "choco install --source=artifactory \"foo\" -y --no-progress --ignore-package-exit-codes"
         #   end
         #
-        #  powershell_script 'add artifactory choco source' do
-        #    code "choco source add -n=artifactory -s='https://mycorp.jfrog.io/mycorp/api/nuget/chocolatey-remote' -u foo -p bar"
-        #    not_if 'choco source list | findstr artifactory'
-        #  end
+        #   powershell_script 'add artifactory choco source' do
+        #     code "choco source add -n=artifactory -s='https://mycorp.jfrog.io/mycorp/api/nuget/chocolatey-remote' -u foo -p bar"
+        #     not_if 'choco source list | findstr artifactory'
+        #   end
         #
         #   # good
         #   chocolatey_package 'foo' do

--- a/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
@@ -24,14 +24,14 @@ module RuboCop
         # @example
         #
         #   # bad
-        #   windows_zipfile 'C:\\files\\' do
-        #     source 'C:\\Temp\\file.zip'
+        #   windows_zipfile 'C:\files' do
+        #     source 'C:\Temp\file.zip'
         #   end
         #
         #   # good
         #   archive_file 'expand file.zip' do
-        #     path 'C:\\Temp\\file.zip'
-        #     destination 'C:\\files'
+        #     path 'C:\Temp\file.zip'
+        #     destination 'C:\files'
         #   end
         #
         class WindowsZipfileUsage < Base

--- a/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
+++ b/lib/rubocop/cop/chef/modernize/windows_zipfile.rb
@@ -28,6 +28,12 @@ module RuboCop
         #     source 'C:\\Temp\\file.zip'
         #   end
         #
+        #   # good
+        #   archive_file 'expand file.zip' do
+        #     path 'C:\\Temp\\file.zip'
+        #     destination 'C:\\files'
+        #   end
+        #
         class WindowsZipfileUsage < Base
           extend TargetChefVersion
 

--- a/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
@@ -28,6 +28,12 @@ module RuboCop
         #     path 'C:\expand_here'
         #   end
         #
+        #   # good
+        #   archive_file 'expand file.zip' do
+        #     path 'C:\\file.zip'
+        #     destination 'C:\\expand_here'
+        #   end
+        #
         class ZipfileResource < Base
           include RuboCop::Chef::CookbookHelpers
           extend TargetChefVersion

--- a/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
+++ b/lib/rubocop/cop/chef/modernize/zipfile_resource.rb
@@ -24,14 +24,14 @@ module RuboCop
         # @example
         #
         #   # bad
-        #   zipfile "C:\file.zip" do
+        #   zipfile 'C:\file.zip' do
         #     path 'C:\expand_here'
         #   end
         #
         #   # good
         #   archive_file 'expand file.zip' do
-        #     path 'C:\\file.zip'
-        #     destination 'C:\\expand_here'
+        #     path 'C:\file.zip'
+        #     destination 'C:\expand_here'
         #   end
         #
         class ZipfileResource < Base

--- a/lib/rubocop/cop/chef/modernize/zypper_repo.rb
+++ b/lib/rubocop/cop/chef/modernize/zypper_repo.rb
@@ -25,7 +25,7 @@ module RuboCop
         #
         #   # bad
         #   zypper_repo 'apache' do
-        #     baseurl 'http://download.opensuse.org/repositories/Apache'
+        #     baseurl 'https://download.opensuse.org/repositories/Apache'
         #     path '/openSUSE_Leap_42.2'
         #     type 'rpm-md'
         #     priority '100'
@@ -33,7 +33,7 @@ module RuboCop
         #
         #   # good
         #   zypper_repository 'apache' do
-        #     baseurl 'http://download.opensuse.org/repositories/Apache'
+        #     baseurl 'https://download.opensuse.org/repositories/Apache'
         #     path '/openSUSE_Leap_42.2'
         #     type 'rpm-md'
         #     priority '100'

--- a/lib/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions.rb
+++ b/lib/rubocop/cop/chef/redundant/custom_resource_with_allowed_actions.rb
@@ -29,6 +29,16 @@ module RuboCop
         #   # also bad
         #   actions [:create, :remove]
         #
+        #   # good
+        #   # Chef Infra Client derives the allowed actions from the actions you define
+        #   action :create do
+        #     # ...
+        #   end
+        #
+        #   action :remove do
+        #     # ...
+        #   end
+        #
         class CustomResourceWithAllowedActions < Base
           include RangeHelp
           extend AutoCorrector

--- a/lib/rubocop/cop/chef/security/ssh_private_key.rb
+++ b/lib/rubocop/cop/chef/security/ssh_private_key.rb
@@ -29,6 +29,15 @@ module RuboCop
         #     mode '600'
         #   end
         #
+        #   # good
+        #   # fetch the key from a secrets management system instead
+        #   file '/home/bob/.ssh/id_rsa' do
+        #     content chef_vault_item('ssh_keys', 'bob')['private_key']
+        #     mode '600'
+        #     owner 'bob'
+        #     sensitive true
+        #   end
+        #
         class SshPrivateKey < Base
           MSG = 'Do not include plain text SSH private keys in your cookbook code. This sensitive data should be fetched from secrets management systems so that secrets are not uploaded in plain text to the Chef Infra Server or committed to source control systems.'
 


### PR DESCRIPTION
## What

Most cop doc comments pair a `# bad` example with the `# good` code that replaces it. **75 cops showed only what *not* to write.** These comments are the source for the cop pages on docs.chef.io, so a user hitting one of these was told their code was wrong without being shown the fix.

This adds a `# good` example to **34** of them and fixes one genuine documentation bug.

```diff
  # bad
  depends 'zypper'
+
+ # good
+ # the resource ships in Chef Infra Client 13.3+, so use it without a depends
+ zypper_repository 'apache' do
+   baseurl 'http://download.opensuse.org/repositories/Apache'
+   action :add
+ end
```

## Documentation bug in InvalidPlatformFamilyHelper

This cop labelled **both** of its examples `# bad`:

```ruby
# bad
platform_family?('redhat')
platform_family?('sles')

# bad          <-- these are actually the corrections
platform_family?('rhel')
platform_family?('suse')
```

The cop's own `INVALID_PLATFORM_FAMILIES` map has `'redhat' => 'rhel'` and `'sles' => 'suse'`, so the second block is the *good* example — it was telling readers the correct values were wrong. Now labelled `# good`. I checked the sibling platform cops (`InvalidPlatformHelper`, `InvalidPlatformMetadata`, and both `value_for_platform*` cops) and they're all labelled correctly.

Also added a missing blank line between the bad and good blocks in `InvalidPlatformValueForPlatformHelper` so it renders consistently with the rest.

## What's covered

| Group | Good example shown |
|---|---|
| `depends` on a cookbook obsoleted by core Chef (zypper, locale, openssl, timezone_lwrp, windows_firewall, kernel_module, chocolatey, chef-vault, Chef 14/15 resource sets) | the built-in resource used directly, without the `depends` |
| Archive cops (`seven_zip_archive`, `windows_zipfile`, `zipfile`, `PowershellScriptExpandArchive`) | the equivalent `archive_file` block |
| Deprecated APIs (`Chef::REST`, `provider_base`, `use_automatic_resource_name`, `resource_name` without `provides`, chef-sugar helpers, `partial_search`) | the current API |
| Misc (`ServiceResource`, `locale` `lc_all`, foodcritic → cookstyle, `xml::ruby` → `require 'nokogiri'`, `ohai::default` → `ohai_plugin`, chocolatey shellouts, ssh private keys) | the modern equivalent |

## What's deliberately left alone

41 cops still have a bad-only example, and I think that's correct — **their fix is to delete the offending code, so there is no equivalent good example to show**:

- The metadata cops (`long_description`, `grouping`, `suggests`, `replaces`, `conflicts`, `provides`, `recipe`, `attribute`) — the fix is removing the line
- The `Chef/Effortless` department — those flag features unavailable in Effortless; the fix is architectural, not a code substitution
- `use_inline_resources`, `whyrun_supported_true`, `empty_resource_initialize`, `dsl_include_in_resource`, `unnecessary_mixlib_shellout_require`, `foodcritic_comments`, `defines_chefspec_matchers` — all pure deletions
- `easy_install`, `erl_call` — removed resources with no core replacement

Happy to add "just remove it" placeholders to these too if you'd prefer the docs be uniform, but an empty good block seemed worse than none.

## Testing

- Full suite green: **967 examples, 0 failures**
- All 36 changed cop files clean under `cookstyle` self-lint
- Regenerated the docs.chef.io yml via `rake generate_cops_yml_documentation`; 36 doc files updated, 1:1 with the changed cops

The generator also produces trailing-whitespace-only churn on ~12 unrelated cop docs (`examples: ` → `examples:`, `version_added: ` → `version_added:`). I reverted those to keep this diff reviewable — worth a separate cleanup commit if you want the checked-in docs to match the generator exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)