### PR TITLE
Validate Chefstyle cops against chefstyle.yml

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,21 +20,30 @@ task :coverage do
   Rake::Task['spec'].execute
 end
 
-desc 'Ensure that all cops are defined in the cookstyle.yml config'
+desc 'Ensure that all cops are defined in the cookstyle.yml and chefstyle.yml configs'
 task :validate_config do
   require 'cookstyle'
   require 'yaml' unless defined?(YAML)
   status = 0
-  config = YAML.load_file('config/cookstyle.yml')
+  configs = {
+    'config/cookstyle.yml' => YAML.load_file('config/cookstyle.yml'),
+    'config/chefstyle.yml' => YAML.load_file('config/chefstyle.yml'),
+  }
 
-  puts 'Checking that all cops are defined in config/cookstyle.yml:'
+  puts 'Checking that all cops are defined in the cookstyle.yml and chefstyle.yml configs:'
 
   RuboCop::Cop::Chef.constants.each do |dep|
-    RuboCop::Cop::Chef.const_get(dep).constants.each do |cop|
-      unless config["Chef/#{dep}/#{cop}"]
-        puts "Error: Chef/#{dep}/#{cop} not found in config/cookstyle.yml"
-        status = 1
-      end
+    department = RuboCop::Cop::Chef.const_get(dep)
+    department.constants.each do |cop|
+      # Cookstyle and Chefstyle cops share the RuboCop::Cop::Chef namespace but ship separate
+      # configs, so check each cop against the config that matches where it's defined.
+      source = department.const_source_location(cop)&.first.to_s
+      config_file = source.include?('/cop/chefstyle/') ? 'config/chefstyle.yml' : 'config/cookstyle.yml'
+
+      next if configs[config_file]["Chef/#{dep}/#{cop}"]
+
+      puts "Error: Chef/#{dep}/#{cop} not found in #{config_file}"
+      status = 1
     end
   end
 


### PR DESCRIPTION
### Description

`rake validate_config` walks `RuboCop::Cop::Chef` and asserts that every cop it finds is present in `config/cookstyle.yml`. Cookstyle and Chefstyle ship in the same gem and share that namespace, but they have separate configs, so the five Chefstyle cops under `RuboCop::Cop::Chef::Ruby` have been reported as missing on every run:

```
Error: Chef/Ruby/GemspecLicense not found in config/cookstyle.yml
Error: Chef/Ruby/GemspecRequireRubygems not found in config/cookstyle.yml
Error: Chef/Ruby/LegacyPowershellOutMethods not found in config/cookstyle.yml
Error: Chef/Ruby/RequireNetHttps not found in config/cookstyle.yml
Error: Chef/Ruby/UnlessDefinedRequire not found in config/cookstyle.yml
```

All five are correctly registered in `config/chefstyle.yml`, and they have no business being in `cookstyle.yml` — gemspec and `require` cops don't apply to cookbooks. The cops were fine; the check was looking in the wrong file.

The task now picks which config to check based on where each cop is defined: cops under `lib/rubocop/cop/chefstyle/` are validated against `chefstyle.yml`, everything else against `cookstyle.yml`, and the error message names whichever file was actually consulted. Every department resolves to exactly one of the two directories, so the routing is unambiguous.

This makes `rake validate_config` exit `0` for the first time in a while, which means a genuinely unregistered cop will now fail the default rake task instead of being lost in the pre-existing noise.

### Verification

Passes clean on this branch:

```
$ bundle exec rake validate_config
Checking that all cops are defined in the cookstyle.yml and chefstyle.yml configs:
All Cops found in the config. Good work.
```

And it still catches real omissions — temporarily deleting one cop from each config reports both, each against the right file:

```
Error: Chef/Security/SshPrivateKey not found in config/cookstyle.yml
Error: Chef/Ruby/GemspecLicense not found in config/chefstyle.yml
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] I have read the CONTRIBUTING document.
- [x] I have run the tests and they pass.
- [x] All commits are signed off (DCO).

Note: `rake style` still reports 11 pre-existing `Chef/Style/CommentFormat` offenses on `main`; those are untouched here and left for a separate change.