### PR TITLE
Add DCO check workflow

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,23 @@
+name: DCO Check
+on: [pull_request]
+
+permissions: {}
+
+jobs:
+  dco_check_job:
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    name: DCO Check
+    steps:
+    - name: Get PR Commits
+      uses: actionshub/get-pr-commits@main
+      id: 'get-pr-commits'
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: DCO Check
+      uses: actionshub/dco@main
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+        allow-obvious-fix-label: "obvious-fix"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     name: DCO Check
     steps:
-    - name: Get PR Commits
-      uses: actionshub/get-pr-commits@main
-      id: 'get-pr-commits'
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - name: DCO Check
-      uses: actionshub/dco@main
-      with:
-        commits: ${{ steps.get-pr-commits.outputs.commits }}
-        allow-obvious-fix-label: "obvious-fix"
+      - name: Get PR Commits
+        uses: actionshub/get-pr-commits@0f1d778e95718cdf9a80f57d36c0a8754e874fa1 # v2.0.0
+        id: 'get-pr-commits'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: DCO Check
+        uses: actionshub/dco@624651527997baebfe5fd772d216f9c77bfd40f3 # v2.0.0
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          allow-obvious-fix-label: "obvious-fix"


### PR DESCRIPTION
Adds `dco.yml` matching chef/win32-service to enforce DCO sign-off on PRs.

`allchecks.yml` already exists in this repo (with cookstyle-specific tweaks: exclude SonarCloud check, 30 retries), so it was left as-is rather than overwritten.

Skipped: modifying existing allchecks.yml — it already covers this need.