### PR TITLE
Test against Ruby 4.0 in CI

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2025, ubuntu-latest]
-        ruby: ['3.1', '3.4']
+        ruby: ['3.1', '3.4', '4.0']
     runs-on: ${{ matrix.os }}
     env:
       BUNDLE_WITHOUT: profiling debug docs


### PR DESCRIPTION
## Description

Adds Ruby `4.0` to the unit test matrix in `.github/workflows/unit.yml`.

Ruby 4.0 was released on **2025-12-25** and is the version users will increasingly run Cookstyle on, but the matrix stops at 3.4 — so nothing catches a 4.0 regression before a release goes out.

## Changes

```diff
     matrix:
       os: [windows-2025, ubuntu-latest]
-      ruby: ['3.1', '3.4']
+      ruby: ['3.1', '3.4', '4.0']
```

That's the whole change. The matrix already fans out over both runners, so this adds two jobs: Ruby 4.0 on `ubuntu-latest` and on `windows-2025`.

## Why no other changes are needed

- **Runner support** — `ruby/setup-ruby` publishes 4.0.6 for both platforms. Confirmed against the action's own manifests: `ruby-builder-versions.json` lists `4.0.0` through `4.0.6` for Ubuntu/macOS, and `windows-versions.json` lists the same range for the RubyInstaller builds Windows uses. Windows is the one that could have blocked this, since it only gets release versions published by RubyInstaller.
- **`required_ruby_version`** — the gemspec declares `>= 2.7`, which 4.0 already satisfies.
- **`TargetRubyVersion`** — untouched. That setting describes the cookbooks Cookstyle *lints*, not the Ruby it *runs on*, so it is unrelated to this change.

## Verification

Run locally on Ruby 4.0.6 against the RuboCop version currently pinned on `main` (**1.86.1**, not the 1.89.0 proposed in #1081), so the result reflects what this matrix entry will actually execute:

- `rake spec` — **1170 examples, 0 failures**
- `cookstyle` against itself — **exit 0**

This records compatibility that already exists rather than changing any behaviour, so the new jobs should be green on the first run.

## Separate note: the 3.1 floor

Not changed here, but worth flagging while this file is open — **Ruby 3.1 reached end of life on 2025-03-26** ([endoflife.date/ruby](https://endoflife.date/ruby)) and is no longer receiving security patches. It stays in the matrix in this PR since the gemspec still declares `>= 2.7`, but dropping it (and raising `required_ruby_version`) is worth its own discussion rather than being folded into a CI addition.