### PR TITLE
Pin GitHub Actions to commit SHAs and slow Dependabot to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,8 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
     open-pull-requests-limit: 10
     # don't automatically rebase on every single time we're out of date with
     # base (whith is always) because it kills CI capacity

--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -12,7 +12,7 @@ jobs:
       checks: read
       contents: read
     steps:
-      - uses: wechuli/allcheckspassed@v2
+      - uses: wechuli/allcheckspassed@e4240aa9cc76fd6828ce27a71ad16c406c25adb3 # v2.5.0
         with:
           # This seems to be working lately even for external
           # contributors, so maybe we don't need to exclude it?

--- a/.github/workflows/ci-main-pull-request-stub-1.0.8.yml
+++ b/.github/workflows/ci-main-pull-request-stub-1.0.8.yml
@@ -38,7 +38,7 @@ jobs:
       versionFromFile: ${{ steps.set-version-from-file.outputs.versionFromFile }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 'Detect version from file'
         id: set-version-from-file

--- a/.github/workflows/habitat-build-darwin.yml
+++ b/.github/workflows/habitat-build-darwin.yml
@@ -38,7 +38,7 @@ jobs:
       HAB_LICENSE: accept-no-persist
       HAB_NONINTERACTIVE: "true"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           clean: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,13 @@ jobs:
   cookstyle:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: 3.4
         bundler-cache: true
-    - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
+    # this shows the failures in the PR
+    - uses: r7kamura/rubocop-problem-matchers-action@59f1a0759f50cc2649849fd850b8487594bb5a81 # v1.2.2
     - run: bundle exec cookstyle
 
   linelint:
@@ -24,7 +25,7 @@ jobs:
     name: Check if all files end in newline
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Linelint
-        uses: fernandrone/linelint@master
+        uses: fernandrone/linelint@7907a5dca0c28ea7dd05c6d8d8cacded713aca11 # 0.0.6
         id: linelint

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -19,8 +19,8 @@ jobs:
       BUNDLE_WITHOUT: profiling debug docs
     name: Unit test on ${{ matrix.os }} with Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/workflow-change-guard.yml
+++ b/.github/workflows/workflow-change-guard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
## Description

Pins every third-party GitHub Action to a full commit SHA, and moves Dependabot's `github-actions` updates from daily to weekly so the pins stay current without flooding CI.

Tags are mutable. Anyone who can push to an action's repository can move `v7` or `v1` to point at different code, and every workflow here picks it up on the next run — with access to the repository, and in the `pull_request_target` workflows (`habitat-build-darwin.yml`, `workflow-change-guard.yml`), to secrets. A commit SHA is immutable, so an upgrade can only happen through a reviewed PR.

## Pins

| Action | Before | Pinned to | Version |
|---|---|---|---|
| `actions/checkout` | `v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
| `ruby/setup-ruby` | `v1` | `95ef2b042f9d7a56d8268cba8559e2842e2ad01b` | v1.321.0 |
| `r7kamura/rubocop-problem-matchers-action` | `v1` | `59f1a0759f50cc2649849fd850b8487594bb5a81` | v1.2.2 |
| `wechuli/allcheckspassed` | `v2` | `e4240aa9cc76fd6828ce27a71ad16c406c25adb3` | v2.5.0 |
| `fernandrone/linelint` | `master` | `7907a5dca0c28ea7dd05c6d8d8cacded713aca11` | 0.0.6 |

Each carries a trailing `# vX.Y.Z` comment so the pin stays readable, and so Dependabot has the version to bump.

**`linelint` was tracking a branch, not a tag** — it ran whatever `master` happened to be at that moment, which is the sharpest version of this problem. Its current `master` is tagged `0.0.6`, so the pin doesn't change what runs today.

## What is intentionally not pinned

`chef/common-github-actions/.github/workflows/ci-main-pull-request.yml@main` stays on `@main`. It is a first-party reusable workflow shared across the Chef organization and is designed to pick up changes centrally — pinning it is a coordination decision for that repo's owners, not a drive-by change here. Happy to do it in a follow-up if that's wanted.

## Dependabot

```diff
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
```

Dependabot already watched `github-actions`; it understands SHA pins and bumps the SHA and the version comment together, so the pins don't go stale. The interval drops to weekly because SHA pinning turns every upstream patch release into a PR, and the comment already in this file notes that rebasing "kills CI capacity." `open-pull-requests-limit: 10`, `rebase-strategy: disabled`, and the `Type: Chore` label are unchanged.

## Verification

- Every SHA was checked against the GitHub tags API to confirm it is the commit its version comment names, **dereferencing annotated tag objects** — an annotated tag's own SHA is not the commit SHA, so pinning the tag object is a silent way to break CI. All five match.
- All six workflow files plus `dependabot.yml` parse as valid YAML.
- No behaviour change: every pin resolves to the same code the mutable ref pointed at when this was written, so CI on this PR exercises the pinned refs directly.

One note on review order: this touches `.github/workflows/unit.yml`, as does #1111 (Ruby 4.0). They edit different lines and should merge cleanly in either order.