### PR TITLE
Make the README cop count task work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Cookstyle is a [code linting](https://en.wikipedia.org/wiki/Lint_%28software%29) tool that helps you to write better Chef Infra cookbooks and InSpec profiles by detecting and automatically correcting style, syntax, logic, and security mistakes in your code.
 
-Cookstyle is powered by the [RuboCop](https://www.rubocop.org) linting engine. RuboCop ships with over three-hundred rules, or cops, designed to detect common Ruby coding mistakes and enforce a common coding style. We've customized Cookstyle with a subset of those cops that we believe are perfectly tailored for cookbook development. We also ship **250+ Chef Infra specific cops** that catch common cookbook coding mistakes, clean up portions of code that are no longer necessary, and detect deprecations that prevent cookbooks from running on the latest releases of Chef Infra Client.
+Cookstyle is powered by the [RuboCop](https://www.rubocop.org) linting engine. RuboCop ships with over three-hundred rules, or cops, designed to detect common Ruby coding mistakes and enforce a common coding style. We've customized Cookstyle with a subset of those cops that we believe are perfectly tailored for cookbook development. We also ship **263 Chef Infra specific cops** that catch common cookbook coding mistakes, clean up portions of code that are no longer necessary, and detect deprecations that prevent cookbooks from running on the latest releases of Chef Infra Client.
 
 For complete usage documentation along with documentation for all the included cops see https://docs.chef.io/workstation/cookstyle/
 

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -10,12 +10,19 @@ begin
 
   desc 'Update cop count in the readme'
   task :update_readme_cop_count do
-    def cop_count
-      Dir.glob('lib/rubocop/cop/**/*.rb').count
+    # The README sentence claims "Chef Infra specific cops", so only count the Chef
+    # department. The InSpec and Chefstyle cops under lib/rubocop/cop fall outside
+    # that claim, as does target_chef_version.rb, which isn't a cop at all.
+    cop_count = Dir.glob('lib/rubocop/cop/chef/**/*.rb').count
+    pattern = /ship \*\*\d+\+? Chef Infra specific cops\*\*/
+    readme = File.read('README.md')
+
+    unless readme.match?(pattern)
+      raise 'Could not find the cop count sentence in README.md. If the wording changed, update the pattern in this task.'
     end
 
-    contents = File.read('README.md').gsub(/ship \*\*\d* Chef/, "ship **#{cop_count} Chef")
-    File.write('README.md', contents)
+    File.write('README.md', readme.sub(pattern, "ship **#{cop_count} Chef Infra specific cops**"))
+    puts "README cop count set to #{cop_count}"
   end
 
   desc 'Generate yaml format docs of all Chef/InSpec cops for docs.chef.io'


### PR DESCRIPTION
`rake update_readme_cop_count` substitutes on `/ship \*\*\d* Chef/`, but the README reads:

> We also ship **250+ Chef Infra specific cops** that catch common cookbook coding mistakes...

The `+` breaks the match, so `gsub` returns the string unchanged and the task has been a silent no-op. Expeditor runs it on every docs build via `.expeditor/build_docs.sh` and gets a success either way, so the README count has been frozen at a value that was last accurate several releases ago.

### Changes

**Widen the pattern** to tolerate the trailing `+`, and anchor it on the full phrase rather than a two-word prefix.

**Raise when the pattern doesn't match.** This is the actual fix. `String#gsub` returns the receiver unchanged when nothing matches, so a substitution task built on it can never distinguish "already correct" from "pattern is dead" — which is exactly how this went unnoticed. Checking `match?` first turns a future README reword into a build failure instead of more silent drift.

**Count only the Chef department.** The old glob counted all 271 files under `lib/rubocop/cop`, which includes 2 InSpec cops, 5 Chefstyle cops, and `target_chef_version.rb`, which isn't a cop at all. The sentence claims "Chef Infra specific cops", so it should count those: `lib/rubocop/cop/chef/**/*.rb` = 263.

### Verification

```
$ bundle exec rake update_readme_cop_count
README cop count set to 263
```

Idempotent on re-run. With the sentence deliberately reworded, the guard fires:

```
rake aborted!
Could not find the cop count sentence in README.md. If the wording changed, update the pattern in this task.
```

`bundle exec cookstyle tasks/cops_documentation.rake` — no offenses.

Note: if #1113 (removing the Effortless department) merges, this count becomes 254. The docs build recalculates it on merge, so no manual follow-up is needed — that is the point of the task working again.