### PR TITLE
Remove the dead coverage pipeline

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,12 +14,6 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/cop/**/*.rb']
 end
 
-desc 'Run RSpec with code coverage'
-task :coverage do
-  ENV['COVERAGE'] = 'true'
-  Rake::Task['spec'].execute
-end
-
 desc 'Ensure that all cops are defined in the cookstyle.yml and chefstyle.yml configs'
 task :validate_config do
   require 'cookstyle'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,9 +25,8 @@ sonar.tests=spec
 # was spec/**/*.rb 
 # sonar.test.inclusions=**/*_test.go **/*Test.java
 # Coverage report
-sonar.ruby.coverage.framework=RSpec
-sonar.ruby.coverage.reportPaths=coverage/coverage.json 
-# ^^^ comma-delimited paths to Rubocop reports, SimpleCov, or RSpec plugin reports (coverage/coverage.json <-- default output for simpleCov)
+# Not configured: this project has no coverage tooling. If SimpleCov is ever added,
+# point sonar.ruby.coverage.reportPaths at the JSON report it produces.
 
 # sonar.ruby.rubocop.reportPaths=./rubocop-report.json -- import Ruby Rubocop
 # sonar.dependencyCheck.htmlReportPath=./dependency-check-report.html -- import OWASP dependency check report


### PR DESCRIPTION
`rake coverage` sets `ENV['COVERAGE'] = 'true'` and runs the specs — but nothing reads that variable. SimpleCov is not in the Gemfile and never has been, so the task has only ever run the plain spec suite under a misleading name.

```
$ grep -rn "ENV\['COVERAGE'\]" .
Rakefile:19:  ENV['COVERAGE'] = 'true'
```

That is the only occurrence in the repository: the line that sets it.

`sonar-project.properties` then points `sonar.ruby.coverage.reportPaths` at `coverage/coverage.json`, a file nothing writes. SonarQube has been analyzing this project with no coverage data at all, while appearing configured for it — which is worse than being visibly unconfigured, because the dashboard looks intentional.

### Changes

- Remove the `:coverage` task from the `Rakefile`
- Remove the two `sonar.ruby.coverage.*` properties, leaving a comment so the next person knows the omission is deliberate rather than an oversight

`.gitignore` keeps its `/coverage/` entry — it costs nothing and still does its job if anyone runs coverage tooling locally.

### Why remove rather than wire up SimpleCov

Removing is the smaller change and leaves an honest baseline. Real coverage reporting is worth doing, but it should be a deliberate change — SimpleCov plus the JSON formatter in a `:test` group, started from `spec_helper.rb`, with the report uploaded from the unit workflow — not a repair of scaffolding that never worked. Happy to follow up with that if you'd prefer it in one step.

### Verification

- `bundle exec rspec` — 1180 examples, 0 failures
- `bundle exec rake -T` — no `coverage` task listed, all other tasks intact
- `bundle exec cookstyle Rakefile` — no offenses
- Nothing in `.github/workflows`, `.expeditor`, `.buildkite`, or `habitat` invoked the task

Note: `.github/copilot-instructions.md` tells contributors to run `bundle exec rake coverage` and verify ">80% coverage" in eight places, which has never been possible. That is handled in the companion PR that fixes the contributor docs, to keep both changes off the same file.