### PR TITLE
Add the missing negative cases to cop specs and enforce them

### DIFF
--- a/lib/rubocop/cop/chef/deprecation/use_yaml_dump.rb
+++ b/lib/rubocop/cop/chef/deprecation/use_yaml_dump.rb
@@ -36,6 +36,11 @@ module RuboCop
           RESTRICT_ON_SEND = [:to_yaml].freeze
 
           def on_send(node)
+            # A receiverless to_yaml is a call to a locally defined method rather than
+            # the Ruby stdlib conversion this cop is about, and there's nothing to pass
+            # to YAML.dump. Bail out rather than dereferencing a nil receiver.
+            return unless node.receiver
+
             add_offense(node, severity: :warning) do |corrector|
               corrector.replace(node, "YAML.dump(#{node.receiver.source})")
             end

--- a/spec/negative_case_coverage_spec.rb
+++ b/spec/negative_case_coverage_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+#
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+# Every cop spec must prove that the cop stays quiet on code it shouldn't flag, not
+# just that it fires on code it should. For a linter this is the more important half:
+# most of our cops autocorrect, so a false positive silently rewrites a working
+# cookbook. Only an `expect_no_offenses` example catches that.
+describe 'cop specs' do
+  # The Chef/Effortless department is slated for removal, so its specs are not held to
+  # this rule. Derived from a glob rather than a hardcoded list so that this exclusion
+  # becomes a no-op the moment the directory goes away.
+  pending_removal = Dir.glob('spec/rubocop/cop/chef/effortless/*_spec.rb')
+
+  spec_files = Dir.glob('spec/rubocop/cop/**/*_spec.rb') - pending_removal
+
+  it 'finds cop specs to check' do
+    expect(spec_files).not_to be_empty
+  end
+
+  it 'all assert that clean code registers no offense' do
+    missing = spec_files.reject { |f| File.read(f).include?('expect_no_offenses') }.sort
+
+    expect(missing).to eq([]), <<~MSG
+      #{missing.count} cop spec(s) have no `expect_no_offenses` example:
+
+      #{missing.map { |f| "  #{f}" }.join("\n")}
+
+      A cop spec needs both halves: `expect_offense` proves the cop fires on the code
+      it targets, and `expect_no_offenses` proves it leaves everything else alone.
+      Write the negative case against a near miss — the method with a similar name, the
+      resource with a similar property, the string that starts the same way — rather
+      than against unrelated code, which proves nothing.
+
+      spec/rubocop/cop/chef/correctness/node_save_spec.rb is a short example of both.
+    MSG
+  end
+end

--- a/spec/rubocop/cop/chef/correctness/openssl_password_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/correctness/openssl_password_helpers_spec.rb
@@ -32,4 +32,16 @@ describe RuboCop::Cop::Chef::Correctness::OpenSSLPasswordHelpers, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `secure_password` helper from the openssl cookbooks `Opscode::OpenSSL::Password` class should not be used to generate passwords.
     RUBY
   end
+
+  it "doesn't register an offense when using OpenSSL::Password without the Opscode namespace" do
+    expect_no_offenses(<<~RUBY)
+      ::Chef::Recipe.send(:include, OpenSSL::Password)
+    RUBY
+  end
+
+  it "doesn't register an offense when using another class in the Opscode::OpenSSL namespace" do
+    expect_no_offenses(<<~RUBY)
+      Opscode::OpenSSL::Certificate.new
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/chef_rest_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_rest_spec.rb
@@ -38,4 +38,16 @@ describe RuboCop::Cop::Chef::Deprecations::UsesChefRESTHelpers, :config do
       ^^^^^^^^^^^^ Don't use the helpers in Chef::REST which were removed in Chef Infra Client 13
     RUBY
   end
+
+  it "doesn't register an offense when requiring 'chef/http'" do
+    expect_no_offenses(<<~RUBY)
+      require 'chef/http'
+    RUBY
+  end
+
+  it "doesn't register an offense when using Chef::HTTP" do
+    expect_no_offenses(<<~RUBY)
+      Chef::HTTP::Simple.new(url).get('/')
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/chef_sugar_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chef_sugar_helpers_spec.rb
@@ -130,4 +130,16 @@ describe RuboCop::Cop::Chef::Deprecations::ChefSugarHelpers, :config do
       ^^^^^^^^^^^^^^^ Do not use legacy chef-sugar helper methods, which will not be moved into Chef Infra Client itself. For a complete set of chef-sugar helpers now shipping in Chef Infra Client itself see https://github.com/chef/chef/tree/main/chef-utils#getting-started
     RUBY
   end
+
+  it "doesn't register an offense when using a helper that ships in chef-utils" do
+    expect_no_offenses(<<~RUBY)
+      windows?
+    RUBY
+  end
+
+  it "doesn't register an offense when using the platform_family? helper" do
+    expect_no_offenses(<<~RUBY)
+      platform_family?('rhel')
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/cheffile_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/cheffile_spec.rb
@@ -27,4 +27,14 @@ describe RuboCop::Cop::Chef::Deprecations::Cheffile, :config do
       cookbook 'application'
     RUBY
   end
+
+  context 'with the default Include of **/Cheffile' do
+    let(:cop_config) { { 'Include' => ['**/Cheffile'] } }
+
+    it "doesn't register an offense on a file that isn't a Cheffile" do
+      expect_no_offenses(<<~RUBY, 'metadata.rb')
+        name 'foo'
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/chefspec_coverage_report_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chefspec_coverage_report_spec.rb
@@ -26,4 +26,16 @@ describe RuboCop::Cop::Chef::Deprecations::ChefSpecCoverageReport, :config do
 
     expect_correction("\n")
   end
+
+  it "doesn't register an offense when at_exit does something else" do
+    expect_no_offenses(<<~RUBY)
+      at_exit { puts 'done' }
+    RUBY
+  end
+
+  it "doesn't register an offense when another coverage tool is used at_exit" do
+    expect_no_offenses(<<~RUBY)
+      at_exit { SimpleCov.result.format! }
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/chefspec_legacy_runner_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/chefspec_legacy_runner_spec.rb
@@ -32,4 +32,20 @@ describe RuboCop::Cop::Chef::Deprecations::ChefSpecLegacyRunner, :config do
       end
     RUBY
   end
+
+  it "doesn't register an offense when using ChefSpec::SoloRunner" do
+    expect_no_offenses(<<~RUBY)
+      describe 'foo::default' do
+        subject { ChefSpec::SoloRunner.new.converge(described_recipe) }
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when using ChefSpec::ServerRunner" do
+    expect_no_offenses(<<~RUBY)
+      describe 'foo::default' do
+        subject { ChefSpec::ServerRunner.new.converge(described_recipe) }
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/delivery_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/delivery_spec.rb
@@ -36,4 +36,16 @@ describe RuboCop::Cop::Chef::Deprecations::Delivery, :config do
       TOML
     end
   end
+
+  it "doesn't register an offense on another file in the .delivery directory" do
+    expect_no_offenses(<<~RUBY, 'cookbook/.delivery/build_cookbook/metadata.rb')
+      name 'build_cookbook'
+    RUBY
+  end
+
+  it "doesn't register an offense on a regular cookbook file" do
+    expect_no_offenses(<<~RUBY, 'cookbook/metadata.rb')
+      name 'foo'
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/deprecated_windows_version_check_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/deprecated_windows_version_check_spec.rb
@@ -26,4 +26,18 @@ describe RuboCop::Cop::Chef::Deprecations::DeprecatedWindowsVersionCheck, :confi
       end
     RUBY
   end
+
+  it "doesn't register an offense when checking the platform version directly" do
+    expect_no_offenses(<<~RUBY)
+      if node['platform_version'].to_f >= 6.2
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when using a different windows helper" do
+    expect_no_offenses(<<~RUBY)
+      if windows_server_2012?
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/eol_audit_mode_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/eol_audit_mode_spec.rb
@@ -30,4 +30,20 @@ describe RuboCop::Cop::Chef::Deprecations::EOLAuditModeUsage, :config do
       end
     RUBY
   end
+
+  it "doesn't register an offense when using an InSpec control block" do
+    expect_no_offenses(<<~RUBY)
+      control 'SSH' do
+        it 'should be listening on port 22' do
+          expect(port(22)).to be_listening
+        end
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when control_group is called on a receiver" do
+    expect_no_offenses(<<~RUBY)
+      profile.control_group 'Baseline'
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/foodcritic_file_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/foodcritic_file_spec.rb
@@ -36,4 +36,16 @@ describe RuboCop::Cop::Chef::Deprecations::FoodcriticFile, :config do
     TEXT
     end
   end
+
+  it "doesn't register an offense on a regular cookbook file" do
+    expect_no_offenses(<<~RUBY, 'cookbook/metadata.rb')
+      name 'foo'
+    RUBY
+  end
+
+  it "doesn't register an offense on a file that merely mentions foodcritic" do
+    expect_no_offenses(<<~RUBY, 'cookbook/recipes/default.rb')
+      # we no longer run foodcritic here
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/librarian_chefspec_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/librarian_chefspec_spec.rb
@@ -26,4 +26,16 @@ describe RuboCop::Cop::Chef::Deprecations::LibrarianChefSpec, :config do
       name 'foo'
     RUBY
   end
+
+  it "doesn't register an offense when requiring chefspec itself" do
+    expect_no_offenses(<<~RUBY)
+      require 'chefspec'
+    RUBY
+  end
+
+  it "doesn't register an offense when requiring chefspec/berkshelf" do
+    expect_no_offenses(<<~RUBY)
+      require 'chefspec/berkshelf'
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/node_methods_not_attributes_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/node_methods_not_attributes_spec.rb
@@ -72,4 +72,16 @@ describe RuboCop::Cop::Chef::Deprecations::NodeMethodsInsteadofAttributes, :conf
       node['hostname']
     RUBY
   end
+
+  it "doesn't register an offense when the Ohai data is accessed as an attribute" do
+    expect_no_offenses(<<~RUBY)
+      node['platform']
+    RUBY
+  end
+
+  it "doesn't register an offense when calling a node method that isn't Ohai data" do
+    expect_no_offenses(<<~RUBY)
+      node.run_state
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/powershell_cookbook_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/powershell_cookbook_helpers_spec.rb
@@ -27,4 +27,16 @@ describe RuboCop::Cop::Chef::Deprecations::PowershellCookbookHelpers, :config do
 
     expect_correction("node['powershell']['version'].to_f == '4.0'\n")
   end
+
+  it "doesn't register an offense when using the built-in powershell_version helper" do
+    expect_no_offenses(<<~RUBY)
+      powershell_version?('4.0')
+    RUBY
+  end
+
+  it "doesn't register an offense when checking the powershell version attribute" do
+    expect_no_offenses(<<~RUBY)
+      node['powershell']['version'].to_f == 4.0
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/resource_uses_provider_base_method_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/resource_uses_provider_base_method_spec.rb
@@ -24,4 +24,16 @@ describe RuboCop::Cop::Chef::Deprecations::ResourceUsesProviderBaseMethod, :conf
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use the deprecated provider_base method in a resource to specify the provider module to use. Instead, the provider should call provides to register itself, or the resource should call provider to specify the provider to use. This will cause failures in Chef Infra Client 13 and later.
     RUBY
   end
+
+  it "doesn't register an offense when a provider registers itself with provides" do
+    expect_no_offenses(<<~RUBY)
+      provides :something_something
+    RUBY
+  end
+
+  it "doesn't register an offense when a resource specifies its provider" do
+    expect_no_offenses(<<~RUBY)
+      provider ::Chef::Provider::SomethingSomething
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/use_automatic_resource_name_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/use_automatic_resource_name_spec.rb
@@ -27,4 +27,16 @@ describe RuboCop::Cop::Chef::Deprecations::UseAutomaticResourceName, :config do
 
     expect_correction("\n")
   end
+
+  it "doesn't register an offense when the resource name is set explicitly" do
+    expect_no_offenses(<<~RUBY)
+      resource_name :my_resource
+    RUBY
+  end
+
+  it "doesn't register an offense when the resource uses provides" do
+    expect_no_offenses(<<~RUBY)
+      provides :my_resource
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/use_yaml_dump_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/use_yaml_dump_spec.rb
@@ -27,4 +27,18 @@ describe RuboCop::Cop::Chef::Deprecations::UseYamlDump, :config do
 
     expect_correction("YAML.dump(Foo.bar)\n")
   end
+
+  it "doesn't register an offense when using YAML.dump" do
+    expect_no_offenses(<<~RUBY)
+      YAML.dump(Foo.bar)
+    RUBY
+  end
+
+  it "doesn't register an offense when to_yaml is called without a receiver" do
+    expect_no_offenses(<<~RUBY)
+      def to_s
+        to_yaml
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/deprecation/windows_version_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/deprecation/windows_version_helpers_spec.rb
@@ -78,4 +78,18 @@ describe RuboCop::Cop::Chef::Deprecations::WindowsVersionHelpers, :config do
       end
     RUBY
   end
+
+  it "doesn't register an offense when using the platform_version attribute" do
+    expect_no_offenses(<<~RUBY)
+      if node['platform_version'].to_f == 10.0
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense for a VersionHelper in another namespace" do
+    expect_no_offenses(<<~RUBY)
+      if MyCookbook::VersionHelper.nt_version == 10
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/databag_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/databag_helpers_spec.rb
@@ -62,4 +62,16 @@ describe RuboCop::Cop::Chef::Modernize::DatabagHelpers, :config do
       data_bag_item('Chef::DataBagItem.load', 'item')
     RUBY
   end
+
+  it "doesn't register an offense when using the data_bag_item helper" do
+    expect_no_offenses(<<~RUBY)
+      data_bag_item('foo', 'bar')
+    RUBY
+  end
+
+  it "doesn't register an offense when loading another Chef class" do
+    expect_no_offenses(<<~RUBY)
+      Chef::Node.load('foo')
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/definitions_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/definitions_spec.rb
@@ -26,4 +26,20 @@ describe RuboCop::Cop::Chef::Modernize::Definitions, :config do
       end
     RUBY
   end
+
+  it "doesn't register an offense on a resource block" do
+    expect_no_offenses(<<~RUBY)
+      template '/etc/foo.conf' do
+        source 'foo.conf.erb'
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense on define_method" do
+    expect_no_offenses(<<~RUBY)
+      define_method(:foo) do
+        'bar'
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/node_roles_include_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/node_roles_include_spec.rb
@@ -40,4 +40,16 @@ describe RuboCop::Cop::Chef::Modernize::NodeRolesInclude, :config do
       node.role?(foo+bar)
     RUBY
   end
+
+  it "doesn't register an offense when using the node.role? helper" do
+    expect_no_offenses(<<~RUBY)
+      node.role?('foo')
+    RUBY
+  end
+
+  it "doesn't register an offense when checking a different node attribute" do
+    expect_no_offenses(<<~RUBY)
+      node['recipes'].include?('foo')
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/unnecessary_mixlib_shellout_require_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/unnecessary_mixlib_shellout_require_spec.rb
@@ -27,4 +27,16 @@ describe RuboCop::Cop::Chef::Modernize::UnnecessaryMixlibShelloutRequire, :confi
 
     expect_correction("\n")
   end
+
+  it "doesn't register an offense when requiring another mixlib library" do
+    expect_no_offenses(<<~RUBY)
+      require 'mixlib/cli'
+    RUBY
+  end
+
+  it "doesn't register an offense when requiring a similarly named library" do
+    expect_no_offenses(<<~RUBY)
+      require 'shellout'
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/modernize/use_require_relative_spec.rb
+++ b/spec/rubocop/cop/chef/modernize/use_require_relative_spec.rb
@@ -40,4 +40,16 @@ describe RuboCop::Cop::Chef::Modernize::UseRequireRelative, :config do
       require_relative '../libraries/helpers'
     RUBY
   end
+
+  it "doesn't register an offense when already using require_relative" do
+    expect_no_offenses(<<~RUBY)
+      require_relative '../libraries/helpers'
+    RUBY
+  end
+
+  it "doesn't register an offense when expanding against __dir__ instead of __FILE__" do
+    expect_no_offenses(<<~RUBY)
+      require File.expand_path('../libraries/helpers', __dir__)
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/ruby/gemspec_require_rubygems_spec.rb
+++ b/spec/rubocop/cop/chef/ruby/gemspec_require_rubygems_spec.rb
@@ -38,4 +38,16 @@ describe RuboCop::Cop::Chef::Ruby::GemspecRequireRubygems, :config do
 
     expect_correction("\n")
   end
+
+  it "doesn't register an offense when requiring a file under rubygems" do
+    expect_no_offenses(<<~RUBY)
+      require 'rubygems/package'
+    RUBY
+  end
+
+  it "doesn't register an offense when requiring another library" do
+    expect_no_offenses(<<~RUBY)
+      require 'bundler'
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/chef/style/use_platform_helpers_spec.rb
+++ b/spec/rubocop/cop/chef/style/use_platform_helpers_spec.rb
@@ -95,4 +95,18 @@ describe RuboCop::Cop::Chef::Style::UsePlatformHelpers, :config do
       end
     RUBY
   end
+
+  it "doesn't register an offense when already using the platform? helper" do
+    expect_no_offenses(<<~RUBY)
+      if platform?('redhat')
+      end
+    RUBY
+  end
+
+  it "doesn't register an offense when comparing a different node attribute" do
+    expect_no_offenses(<<~RUBY)
+      if node['platform_version'] == '7'
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
A number of cop specs asserted only that the cop *fires*, never that it stays quiet on code it shouldn't touch. For a linter that's the more important half — most Cookstyle cops autocorrect, so a false positive doesn't just print a wrong message, it silently rewrites a working cookbook.

**Correction to the number I first reported:** I said 21 specs. The real figure is **30** — my first measurement piped `tee` into `head -20`, which truncated the file on SIGPIPE before the count was taken. Excluding the 6 `Chef/Effortless` specs that #1113 removes, this PR fixes **24**.

### What's here

**47 `expect_no_offenses` examples across 24 specs.** Each is a near miss rather than unrelated code, because unrelated code proves nothing:

| Cop | Negative case asserts |
| --- | --- |
| `OpenSSLPasswordHelpers` | `OpenSSL::Password` without the `Opscode` namespace is fine |
| `UsesChefRESTHelpers` | `Chef::HTTP` and `require 'chef/http'` are fine |
| `ChefSugarHelpers` | helpers that shipped into chef-utils are fine |
| `UseRequireRelative` | expanding against `__dir__` instead of `__FILE__` is fine |
| `NodeRolesInclude` | `node['recipes'].include?` is fine |
| `UsePlatformHelpers` | `node['platform_version'] == '7'` is fine |
| …and 18 more | |

For the file-presence cops (`Cheffile`, `Delivery`, `FoodcriticFile`) the negative case asserts the path check or config `Include` actually holds — the only thing stopping those cops from firing on line 1 of every file in a cookbook.

**A crash fix the new cases surfaced.** `Chef/Deprecations/UseYamlDump` sets `RESTRICT_ON_SEND = [:to_yaml]`, guaranteeing `on_send` runs for every `to_yaml` call, then dereferences `node.receiver` in its corrector:

```ruby
corrector.replace(node, "YAML.dump(#{node.receiver.source})")
```

A receiverless `to_yaml` — `def to_s; to_yaml; end` in a cookbook library — raised `NoMethodError: undefined method 'source' for nil` and took the run down. That form isn't the stdlib conversion the cop targets and there's nothing to hand `YAML.dump`, so it now returns early. This is the payoff of the finding: 23 of 24 negative cases passed on the first run and the 24th crashed the cop.

**Enforcement so it can't regress.** `spec/negative_case_coverage_spec.rb` fails with the list of offending files if any cop spec loses its negative case:

```
1 cop spec(s) have no `expect_no_offenses` example:

  spec/rubocop/cop/chef/modernize/definitions_spec.rb
```

It's a spec rather than a rake task deliberately — CI runs `bundle exec rake spec`, not `rake default`, so a new rake task wouldn't gate anything. I also verified it actually fails when tampered with, rather than trusting that it would.

The `Chef/Effortless` directory is excluded via a glob rather than a hardcoded list, so the exclusion becomes a no-op the moment that department is removed and there's no stale allowlist to clean up. That also means this PR and #1113 don't touch the same files.

### Verification

- `bundle exec rake spec` — **1229 examples, 0 failures** (up from 1180)
- `bundle exec cookstyle` — 11 offenses, unchanged from `main` (all pre-existing `Chef/Style/CommentFormat`)
- Enforcement spec confirmed to fail, and to name the file, when a negative case is removed
- Confirmed the new spec is picked up by `rake spec`, the command CI runs