### PR TITLE
Restore the ExecuteArchiveExtract config entry and gate validate_config in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,19 @@ jobs:
     - uses: r7kamura/rubocop-problem-matchers-action@59f1a0759f50cc2649849fd850b8487594bb5a81 # v1.2.2
     - run: bundle exec cookstyle
 
+  validate-config:
+    runs-on: ubuntu-latest
+    name: Check every cop is defined in the configs
+    env:
+      BUNDLE_WITHOUT: profiling debug docs
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: 3.4
+          bundler-cache: true
+      - run: bundle exec rake validate_config
+
   linelint:
     runs-on: ubuntu-latest
     name: Check if all files end in newline

--- a/config/cookstyle.yml
+++ b/config/cookstyle.yml
@@ -1883,6 +1883,16 @@ Chef/Modernize/ExecuteUpdateAlternatives:
     - '**/attributes/*.rb'
     - '**/Berksfile'
 
+Chef/Modernize/ExecuteArchiveExtract:
+  Description: "Use the `archive_file` resource built into Chef Infra Client 15+ instead of shelling out to `tar` or `unzip` to extract an archive."
+  StyleGuide: 'chef_modernize_executearchiveextract'
+  Enabled: true
+  VersionAdded: '9.0'
+  Exclude:
+    - '**/metadata.rb'
+    - '**/attributes/*.rb'
+    - '**/Berksfile'
+
 Chef/Modernize/ExecuteSysctl:
   Description: Chef Infra Client 14.0 and later includes a sysctl resource that should be used to idempotently load sysctl values instead of templating files and using execute to load them.
   StyleGuide: 'chef_modernize_executesysctl'

--- a/docs-chef-io/assets/cookstyle/cops_chef_modernize_executearchiveextract.yml
+++ b/docs-chef-io/assets/cookstyle/cops_chef_modernize_executearchiveextract.yml
@@ -23,5 +23,9 @@ examples: |2-
     path "#{Chef::Config[:file_cache_path]}/nginx.tar.gz"
     destination '/opt/nginx'
   end
-version_added: 
-enabled: false
+version_added: '9.0'
+enabled: true
+excluded_file_paths:
+- "**/metadata.rb"
+- "**/attributes/*.rb"
+- "**/Berksfile"


### PR DESCRIPTION
`bundle exec rake validate_config` has been failing on `main`:

```
Checking that all cops are defined in the cookstyle.yml and chefstyle.yml configs:
Error: Chef/Modernize/ExecuteArchiveExtract not found in config/cookstyle.yml
```

### How it happened

The cop, its spec, its docs asset, and its config entry all landed together in fbdb6d51. #1106 was branched before that, and carried the config entry without the cop file. RuboCop validates every configured cop name when it loads the config, so an entry naming a cop that doesn't exist doesn't fail in one place — it takes down the whole suite:

```
Error: unrecognized cop or department Chef/Modernize/ExecuteArchiveExtract found in config/cookstyle.yml
257 errors occurred outside of examples
```

The entry was removed as stray, on the entirely reasonable reading that it belonged to a cop living on another branch. But by the time #1106 merged, `main` had the cop file too — so the removal left the cop orphaned rather than cleaning up a leftover.

### Why it matters

`config/cookstyle.yml` sets `DisabledByDefault: true`, so **a cop with no config entry never runs.** This one has been shipped but inert ever since. Against a cookbook that shells out to tar:

```ruby
execute 'extract nginx' do
  command "tar xzf /tmp/nginx.tar.gz -C /opt/nginx"
end
```

```
before:  2 files inspected, 1 offense detected
after:   2 files inspected, 2 offenses detected
```

(Worth noting for anyone reproducing: `cookstyle --only Chef/Modernize/ExecuteArchiveExtract` fires either way, because `--only` explicitly enables the cop and overrides `DisabledByDefault`. The difference only shows on a default run.)

### Changes

- **Restore the config entry** at its original position before `Chef/Modernize/ExecuteSysctl`, with `VersionAdded: '9.0'` — the cop has never fired for a user, so the release where it first works is the one that added it. Two-part versions match existing precedent in the file.
- **Regenerate the docs asset**, which recorded `enabled: false` and an empty `version_added` because the generator reads the config. Only this cop's file is included; regeneration also touches 12 other assets that are independently stale on `main`, and those are left alone rather than buried in this diff.
- **Add `rake validate_config` to the lint workflow.** The task existed and was failing — nothing ran it. CI runs `rake spec` and `cookstyle`, not `rake default`.

The asymmetry that CI job closes is the whole story here: a config entry with no cop fails loudly, immediately, and unmissably, which is exactly what happened in #1106. A cop with no config entry fails silently, and only `validate_config` catches it — a task no pipeline invoked.

### One thing to decide separately

Nine other cops in `config/cookstyle.yml` still carry `VersionAdded: '8.8.0'`. If 9.0 is the next release, those are likely wrong too, but that's a release-planning call rather than part of this fix, so I've left them alone.

### Verification

- `bundle exec rake validate_config` — "All Cops found in the config. Good work."
- `bundle exec rake spec` — 1180 examples, 0 failures
- `bundle exec cookstyle` — 11 offenses, unchanged from `main` (all pre-existing `Chef/Style/CommentFormat`)
- Confirmed the cop fires on a default run after the change and produced no offense before it

### Note for reviewers

This touches `.github/workflows/lint.yml`, so `workflow-change-guard` will flag it and the `workflow_guard` environment approval will be needed. The change adds no untrusted input — pinned action SHAs and a fixed `run:` command, matching the existing `cookstyle` job.