### PR TITLE
Fix binstub_patch.rb/NOTICE path resolution on aarch64-linux builds

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,5 +1,17 @@
 export HAB_BLDR_CHANNEL="base-2025"
 export HAB_REFRESH_CHANNEL="base-2025"
+
+# Resolve the repo root and habitat dir from this file's own location
+# (BASH_SOURCE) rather than PLAN_CONTEXT. PLAN_CONTEXT is set by Habitat to
+# the directory it started the build from, which is NOT necessarily the
+# directory this file lives in -- e.g. when habitat/aarch64-linux/plan.sh
+# sources this file, PLAN_CONTEXT is "habitat/aarch64-linux", not "habitat",
+# which breaks any "${PLAN_CONTEXT}/.." or "${PLAN_CONTEXT}/binstub_patch.rb"
+# reference used here. BASH_SOURCE[0] always points at this file, so it
+# resolves correctly regardless of which plan sourced it.
+COOKSTYLE_HABITAT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COOKSTYLE_REPO_ROOT="$(cd "${COOKSTYLE_HABITAT_DIR}/.." && pwd)"
+
 ruby_pkg="core/ruby3_4"
 pkg_name="cookstyle"
 pkg_origin="chef"
@@ -36,7 +48,7 @@ do_before() {
 
 do_unpack() {
   mkdir -pv "$HAB_CACHE_SRC_PATH/$pkg_dirname"
-  cp -RT "$PLAN_CONTEXT"/.. "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
+  cp -RT "$COOKSTYLE_REPO_ROOT" "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
 }
 
 do_build() {
@@ -58,11 +70,11 @@ do_build() {
 do_install() {
 
   # Copy NOTICE.TXT to the package directory
-  if [[ -f "$PLAN_CONTEXT/../NOTICE" ]]; then
+  if [[ -f "${COOKSTYLE_REPO_ROOT}/NOTICE" ]]; then
     build_line "Copying NOTICE to package directory"
-    cp "$PLAN_CONTEXT/../NOTICE" "$pkg_prefix/"
+    cp "${COOKSTYLE_REPO_ROOT}/NOTICE" "$pkg_prefix/"
   else
-    build_line "Warning: NOTICE not found at $PLAN_CONTEXT/../NOTICE"
+    build_line "Warning: NOTICE not found at ${COOKSTYLE_REPO_ROOT}/NOTICE"
   fi
 
   export GEM_HOME="$pkg_prefix/vendor"
@@ -75,8 +87,8 @@ do_install() {
   "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" cookstyle
 
   build_line "** patching binstubs to allow running directly"
-  for binstub in ${pkg_prefix}/bin/*; do
-    sed -i -e "/require ['\"']rubygems['\"']/r ${PLAN_CONTEXT}/binstub_patch.rb" "$binstub"
+  for binstub in "${pkg_prefix}"/bin/*; do
+    sed -i -e "/require ['\"']rubygems['\"']/r ${COOKSTYLE_HABITAT_DIR}/binstub_patch.rb" "$binstub"
   done
 
   if ! grep -q 'APPBUNDLER_ALLOW_RVM' "${pkg_prefix}/bin/cookstyle"; then


### PR DESCRIPTION
## Problem

`cookstyle` builds for **aarch64-linux** fail (or, prior to a build-side safety check being added, could silently ship without the required patch) because the appbundler binstub patching step can't find `binstub_patch.rb` at the path it expects.

## Root cause

`habitat/aarch64-linux/plan.sh` is a thin file that reuses the shared plan via:

```bash
source "$(dirname "${BASH_SOURCE[0]}")/../plan.sh"
```

So the exact same `do_install`/`do_unpack` code in `habitat/plan.sh` runs for both `x86_64-linux` and `aarch64-linux` builds. That shared code referenced paths relative to `$PLAN_CONTEXT`, e.g.:

```bash
sed -i -e "/require ['\"']rubygems['\"']/r ${PLAN_CONTEXT}/binstub_patch.rb" "$binstub"
```

`PLAN_CONTEXT` is **not** "the directory of the file currently executing" — Habitat sets it to the directory it started the build from. When building `x86_64-linux`, that's `habitat/`, so `${PLAN_CONTEXT}/binstub_patch.rb` correctly resolves to `habitat/binstub_patch.rb`. When building `aarch64-linux`, Habitat starts from `habitat/aarch64-linux/`, so `PLAN_CONTEXT` is `habitat/aarch64-linux/` — even though the code being executed is `source`'d from `habitat/plan.sh` one directory up. `${PLAN_CONTEXT}/binstub_patch.rb` then resolves to `habitat/aarch64-linux/binstub_patch.rb`, which doesn't exist.

The same issue affects the `NOTICE` copy (`${PLAN_CONTEXT}/../NOTICE`) and the `do_unpack` source copy (`${PLAN_CONTEXT}/..`).

`sed -i "...r <missing-file>" "$binstub"` does **not** error when the referenced file doesn't exist — it silently does nothing and still exits `0`. Unlike `ohai`/`fauxhai`, `cookstyle`'s plan already has a post-patch self-check:

```bash
if ! grep -q 'APPBUNDLER_ALLOW_RVM' "${pkg_prefix}/bin/cookstyle"; then
  build_line "ERROR: binstub patch injection failed for ${pkg_prefix}/bin/cookstyle"
  return 1
fi
```

This correctly detects the missing patch and fails the aarch64-linux build outright (`return 1`), rather than silently shipping a broken binstub — so the practical symptom here is more likely an aarch64-linux **build failure**, rather than a runtime `Gem::MissingSpecError` on an already-shipped package (as seen with `ohai`/`fauxhai`, which lacked this safety check).

## Fix

In `habitat/plan.sh` (the shared plan, used directly for x86_64-linux and sourced by aarch64-linux):

- Resolve the repo root and the `habitat/` directory from **this file's own location** via `BASH_SOURCE[0]` instead of `$PLAN_CONTEXT`. `BASH_SOURCE[0]` always points at `habitat/plan.sh` itself, regardless of which plan sourced it.
- Use the resolved `habitat/` directory path for `binstub_patch.rb`, and the resolved repo root for `NOTICE` and the `do_unpack` source copy.
- No changes needed to `habitat/aarch64-linux/plan.sh` — it stays the thin `source ../plan.sh` shim.

Additional small hardening (no behavior change on working targets):
- Quoted the `${pkg_prefix}/bin/*` glob in the binstub-patching loop.

## Testing

- `bash -n habitat/plan.sh` and `bash -n habitat/aarch64-linux/plan.sh` — both syntactically valid.
- Manually sourced `habitat/plan.sh` with `PLAN_CONTEXT` deliberately set to an `aarch64-linux`-style path (reproducing the exact build-time condition) — confirmed the resolved repo-root/habitat-dir paths are correct, and both `binstub_patch.rb` and `NOTICE` are found.
- This is the same root-cause fix already applied to `ohai` and `fauxhai` for the identical bug pattern.

---

